### PR TITLE
Fix ROI rotate adorner alignment

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -188,41 +188,25 @@ namespace BrakeDiscInspector_GUI_ROI
             _imgW = _imgSourceBI.PixelWidth;
             _imgH = _imgSourceBI.PixelHeight;
 
-            SyncCanvasToImage();
+            SyncOverlayToImage();
 
             AppendLog($"Imagen cargada: {_imgW}x{_imgH}  (Canvas: {CanvasROI.ActualWidth:0}x{CanvasROI.ActualHeight:0})");
             RedrawOverlay();
         }
 
-        private void SyncCanvasToImage()
-        {
-            if (_imgSourceBI == null) return;
-
-            var w = ImgMain.ActualWidth > 0 ? ImgMain.ActualWidth : _imgSourceBI.PixelWidth;
-            var h = ImgMain.ActualHeight > 0 ? ImgMain.ActualHeight : _imgSourceBI.PixelHeight;
-
-            CanvasROI.Width = w;
-            CanvasROI.Height = h;
-
-            AppendLog($"[sync] Canvas={w:0}x{h:0}  Image(Actual)={ImgMain.ActualWidth:0}x{ImgMain.ActualHeight:0}");
-
-            EnsureRotateAdorner();
-            RepositionRotateAdorner();
-        }
-
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            SyncCanvasToImage();
+            SyncOverlayToImage();
         }
 
         private void MainWindow_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            SyncCanvasToImage();
+            SyncOverlayToImage();
         }
 
         private void ImgMain_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            SyncCanvasToImage();
+            SyncOverlayToImage();
         }
 
         private void CanvasROI_Loaded(object sender, RoutedEventArgs e)
@@ -1775,8 +1759,8 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             var layer = AdornerLayer.GetAdornerLayer(CanvasROI);
             _rotateAdorner = new RoiRotateAdorner(
-            CanvasROI,
-                () => new System.Windows.Point(CurrentRoi.X, CurrentRoi.Y),
+                CanvasROI,
+                () => ImagePxToCanvasPt(CurrentRoi.X, CurrentRoi.Y),
                 angle =>
                 {
                     CurrentRoi.AngleDeg = angle; // rotación en tiempo real
@@ -1954,53 +1938,57 @@ namespace BrakeDiscInspector_GUI_ROI
         /// Convierte un punto en píxeles de imagen -> punto en CanvasROI
         private System.Windows.Point ImgToCanvas(System.Windows.Point pImg)
         {
-            var r = GetImageDisplayRect();
-            var (pw, ph) = GetImagePixelSize();
-            if (pw <= 0 || ph <= 0) return new System.Windows.Point(0, 0);
-            double sx = r.Width / pw;
-            double sy = r.Height / ph;
-            // El CanvasROI debe cubrir el mismo rectángulo de dibujo del ImgMain.
-            // Si CanvasROI está superpuesto exactamente sobre ImgMain, podemos sumar el offset r.Left/Top:
-            return new System.Windows.Point(r.Left + pImg.X * sx, r.Top + pImg.Y * sy);
+            return ImagePxToCanvasPt(pImg.X, pImg.Y);
         }
 
         private System.Windows.Point ImagePxToCanvasPt(double px, double py)
         {
-            // Con el CanvasROI ya ajustado al área pintada, el mapping es solo escala (sin offset).
-            if (ImgMain.Source is not System.Windows.Media.Imaging.BitmapSource bmp) return new System.Windows.Point(0, 0);
-            double sx = CanvasROI.Width / bmp.PixelWidth;
-            double sy = CanvasROI.Height / bmp.PixelHeight;
-            return new System.Windows.Point(px * sx, py * sy);
+            var displayRect = GetImageDisplayRect();
+            var (pw, ph) = GetImagePixelSize();
+            if (ImgMain == null || CanvasROI == null ||
+                pw <= 0 || ph <= 0 || displayRect.Width <= 0 || displayRect.Height <= 0)
+            {
+                return new System.Windows.Point(0, 0);
+            }
+
+            double scale = displayRect.Width / pw; // escala uniforme empleada al pintar la imagen
+            var pointOnImgControl = new System.Windows.Point(
+                displayRect.Left + px * scale,
+                displayRect.Top + py * scale);
+
+            try
+            {
+                // Traduce las coordenadas del control <Image> al sistema del Canvas.
+                return ImgMain.TranslatePoint(pointOnImgControl, CanvasROI);
+            }
+            catch (InvalidOperationException)
+            {
+                // Si el árbol visual aún no está listo, vuelve al ajuste manual usando el margen.
+                return new System.Windows.Point(
+                    pointOnImgControl.X - CanvasROI.Margin.Left,
+                    pointOnImgControl.Y - CanvasROI.Margin.Top);
+            }
         }
 
         // === Sincroniza CanvasROI para que SE ACOMODE EXACTAMENTE al área visible de la imagen (letterbox) ===
         private void SyncOverlayToImage()
         {
             if (ImgMain == null || CanvasROI == null) return;
-
-            // Tamaño real del control Image
-            double cw = ImgMain.ActualWidth;
-            double ch = ImgMain.ActualHeight;
-            if (cw <= 0 || ch <= 0) return;
-
-            // Tamaño en píxeles de la imagen cargada
             if (ImgMain.Source is not System.Windows.Media.Imaging.BitmapSource bmp) return;
-            int pw = bmp.PixelWidth;
-            int ph = bmp.PixelHeight;
-            if (pw <= 0 || ph <= 0) return;
 
-            // Letterbox: rectángulo real donde se dibuja la imagen dentro del control Image
-            double scale = Math.Min(cw / pw, ch / ph);
-            double w = pw * scale;
-            double h = ph * scale;
-            double x = (cw - w) * 0.5;
-            double y = (ch - h) * 0.5;
+            var displayRect = GetImageDisplayRect();
+            if (displayRect.Width <= 0 || displayRect.Height <= 0) return;
 
-            // Posiciona y redimensiona el CanvasROI para que cubra SOLO el área pintada
-            Canvas.SetLeft(CanvasROI, x);
-            Canvas.SetTop(CanvasROI, y);
-            CanvasROI.Width = w;
-            CanvasROI.Height = h;
+            CanvasROI.HorizontalAlignment = HorizontalAlignment.Left;
+            CanvasROI.VerticalAlignment = VerticalAlignment.Top;
+            CanvasROI.Margin = new Thickness(displayRect.Left, displayRect.Top, 0, 0);
+            CanvasROI.Width = displayRect.Width;
+            CanvasROI.Height = displayRect.Height;
+
+            AppendLog($"[sync] Canvas={displayRect.Width:0}x{displayRect.Height:0}  Offset=({displayRect.Left:0},{displayRect.Top:0})  Image={bmp.PixelWidth}x{bmp.PixelHeight}");
+
+            EnsureRotateAdorner();
+            RepositionRotateAdorner();
         }
 
 


### PR DESCRIPTION
## Summary
- convert image pixel coordinates into the overlay canvas space with `TranslatePoint`, keeping the rotate adorner centered on the ROI even with letterboxing
- reuse the same conversion when creating the legacy ROI adorner helper so both paths stay aligned with the displayed image

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1e0627c08330893d9d77491eb1dd