### PR TITLE
Align ROI rotation pivots with center

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2005,8 +2005,7 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             CurrentRoi.EnforceMinSize(10, 10);
 
-            var (cornerX, cornerY) = GetCurrentRoiCornerImage(RoiCorner.TopRight);
-            var pivot = new Point2f((float)cornerX, (float)cornerY);
+            var pivot = new Point2f((float)CurrentRoi.X, (float)CurrentRoi.Y);
 
             using var rotMat = Cv2.GetRotationMatrix2D(pivot, CurrentRoi.AngleDeg, 1.0);
 
@@ -2167,22 +2166,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
-            double pivotLocalX;
-            double pivotLocalY;
-
-            switch (roiModel.Shape)
-            {
-                case RoiShape.Rectangle:
-                case RoiShape.Circle:
-                case RoiShape.Annulus:
-                    pivotLocalX = width;
-                    pivotLocalY = 0;
-                    break;
-                default:
-                    pivotLocalX = width / 2.0;
-                    pivotLocalY = height / 2.0;
-                    break;
-            }
+            double pivotLocalX = width / 2.0;
+            double pivotLocalY = height / 2.0;
 
             double left = Canvas.GetLeft(shape); if (double.IsNaN(left)) left = 0;
             double top = Canvas.GetTop(shape); if (double.IsNaN(top)) top = 0;


### PR DESCRIPTION
## Summary
- rotate backend crops around the ROI center to match UI behavior
- center inspection shape transforms around their width and height midpoint so UI pivots align
- ensure inspection rotation helper continues to use the centered pivot when syncing angles

## Testing
- not run (UI project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cedc9cd3488330bea4672c60392f50