### PR TITLE
Include ROI rotation angle in serialized payloads

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1680,7 +1680,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 ["cx"] = roi.CX,
                 ["cy"] = roi.CY,
                 ["r"] = roi.R,
-                ["ri"] = roi.RInner
+                ["ri"] = roi.RInner,
+                ["angle_deg"] = roi.AngleDeg
             };
             return System.Text.Json.JsonSerializer.Serialize(obj);
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/Preset.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/Preset.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace BrakeDiscInspector_GUI_ROI
 {
@@ -21,7 +22,21 @@ namespace BrakeDiscInspector_GUI_ROI
         public RoiShape Shape { get; set; } = RoiShape.Rectangle;
         public RoiRole Role { get; set; } = RoiRole.Inspection;
 
+        [JsonPropertyName("AngleDeg")]
         public double AngleDeg { get; set; } = 0.0;
+
+        // Permite deserializar tanto AngleDeg como angle_deg (snake_case) sin duplicar la escritura.
+        [JsonPropertyName("angle_deg")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public double? AngleDegSerialized
+        {
+            get => null;
+            set
+            {
+                if (value.HasValue)
+                    AngleDeg = value.Value;
+            }
+        }
 
         // Rectángulo
         public double X { get; set; }


### PR DESCRIPTION
## Summary
- add the ROI rotation angle (angle_deg) to the JSON that the GUI sends to the backend
- teach `RoiModel` to accept either `AngleDeg` or `angle_deg` when deserialising so layouts/presets preserve rotation

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cf183dece4833088f590a299df15ea