### PR TITLE
Capture rotated angle when syncing ROI shapes

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1326,6 +1326,23 @@ namespace BrakeDiscInspector_GUI_ROI
             var w = shape.Width;
             var h = shape.Height;
 
+            double? renderAngle = null;
+            if (shape.RenderTransform is RotateTransform rotateTransform)
+            {
+                renderAngle = rotateTransform.Angle;
+            }
+            else if (shape.RenderTransform is TransformGroup transformGroup)
+            {
+                var rotate = transformGroup.Children.OfType<RotateTransform>().FirstOrDefault();
+                if (rotate != null)
+                    renderAngle = rotate.Angle;
+            }
+
+            if (renderAngle.HasValue)
+            {
+                roiCanvas.AngleDeg = renderAngle.Value;
+            }
+
             if (shape is System.Windows.Shapes.Rectangle)
             {
                 roiCanvas.Shape = RoiShape.Rectangle;


### PR DESCRIPTION
## Summary
- mirror the current rotation applied to ROI shapes on the canvas when syncing them back into their data models
- ensure the persisted ROI angle matches any RotateTransform applied to the WPF shape so subsequent conversions propagate the rotation

## Testing
- Not run (environment lacks dotnet runtime)


------
https://chatgpt.com/codex/tasks/task_e_68cf232896e48330abef297275355862