### PR TITLE
Invalidate inspection adorners after programmatic rotations

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2734,10 +2734,12 @@ namespace BrakeDiscInspector_GUI_ROI
                 rotate.Angle = angle;
                 rotate.CenterX = pivotLocalX;
                 rotate.CenterY = pivotLocalY;
+                InvalidateAdornerFor(shape);
             }
             else
             {
                 shape.RenderTransform = new RotateTransform(angle, pivotLocalX, pivotLocalY);
+                InvalidateAdornerFor(shape);
             }
 
             AppendLog($"[rotate] apply role={roiModel.Role} shape={roiModel.Shape} pivotLocal=({pivotLocalX:0.##},{pivotLocalY:0.##}) pivotCanvas=({pivotCanvasX:0.##},{pivotCanvasY:0.##}) angle={angle:0.##}");


### PR DESCRIPTION
## Summary
- ensure inspection rotation helper invalidates adorners after updating RotateTransform so thumbs reposition after programmatic changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfca4fe10883308c0abeba5c17cb02