### PR TITLE
Add match_one alias for match_master endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -266,6 +266,7 @@ def upload_roi():
     (sub / name).write_bytes(f.read())
     return jsonify({"ok": True, "saved": str(sub / name)})
 
+@app.post("/match_one")
 @app.route("/match_master", methods=["POST"])
 def match_master():
     """

--- a/gui/BrakeDiscInspector_GUI_ROI/README.md
+++ b/gui/BrakeDiscInspector_GUI_ROI/README.md
@@ -29,7 +29,7 @@ Sistema de inspección visual de discos de freno mediante GUI en C# WPF y backen
 
 ## 4. Backend (Python)
 - **app.py**: servidor Flask con endpoints:
-  - `/match_master`
+  - `/match_master` (alias `/match_one`)
   - `/analyze`
   - `/train_status`
 - **matcher.py**: lógica de matching ORB/SIFT.


### PR DESCRIPTION
## Summary
- expose a new `/match_one` POST endpoint that reuses the existing `match_master` logic
- document the alias so GUI references show both endpoint names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d012cc1b048330a0918f37c3b37a98