### PR TITLE
Add /match_one alias to match_master endpoint

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -119,20 +119,61 @@ curl -X POST http://127.0.0.1:5000/analyze   -F "file=@crop.png"   -F "annulus={
 
 ---
 
-### 1.3 `/match_one` (POST)
+### 1.3 `/match_master` (POST) — alias `/match_one`
 
-- **Descripción**: Endpoint experimental para matching basado en plantilla o comparación directa de archivos.
-- **URL**: `http://<host>:5000/match_one`
+- **Descripción**: Matching maestro que localiza la plantilla (`template`) dentro de una imagen (`image`).
+- **URL**: `http://<host>:5000/match_master` (compatible con `/match_one`).
 - **Método**: POST
 
-#### Entrada
-- `template` o `file1` + `file2`
+#### Entrada (`multipart/form-data`)
+- `image`: captura donde buscar (obligatoria).
+- `template`: plantilla de referencia (obligatoria, se acepta PNG con canal alfa para máscara implícita).
+- Parámetros opcionales:
+  - `feature`: `auto` (por defecto) / `sift` / `orb` / `tm_rot` / `geom`.
+  - `thr`: umbral de confianza para coincidencia geométrica/SIFT-ORB (por defecto `0.6`).
+  - `tm_thr`: umbral de template matching (`0.8` por defecto).
+  - `rot_range`: rango de rotaciones ±grados para `tm_rot`.
+  - `scale_min` / `scale_max`: escalas mín./máx. para `tm_rot`.
+  - `search_x`, `search_y`, `search_w`, `search_h`: ROI para limitar la búsqueda.
+  - `debug`: `1/true` para adjuntar capturas de depuración codificadas en Base64.
 
-#### Respuesta
+#### Respuesta (ejemplo `found=true`)
 ```json
 {
-  "similarity": 0.94,
-  "matched": true
+  "found": true,
+  "stage": "TM_OK",
+  "center_x": 412.5,
+  "center_y": 298.0,
+  "confidence": 0.91,
+  "tm_best": 0.91,
+  "tm_thr": 0.8,
+  "bbox": [380.0, 260.0, 65.0, 76.0],
+  "sift_orb": {
+    "detector": "auto->orb",
+    "kp_tpl": 523,
+    "kp_img": 497,
+    "matches": 480,
+    "good": 132,
+    "confidence": 0.86
+  }
+}
+```
+
+#### Respuesta (ejemplo `found=false`)
+```json
+{
+  "found": false,
+  "stage": "TM_FAIL",
+  "reason": "tm_below_threshold",
+  "tm_best": 0.42,
+  "tm_thr": 0.8,
+  "crop_off": [0, 0],
+  "sift_orb": {
+    "detector": "auto->orb",
+    "matches": 12,
+    "good": 1,
+    "fail_reason": "not_enough_good_matches"
+  }
 }
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,12 +31,12 @@ flowchart LR
   - `RoiAdorner.cs`: adorner de edición (mover, redimensionar y rotar mediante thumb NE).
 - **Overlays/**:
   - `RoiOverlay.cs`: dibuja el ROI en el `CanvasROI` **alineado** con el área visible del `<Image>` (letterbox).
-- **BackendAPI.cs**: cliente HTTP tipado (POST `/analyze`, GET `/train_status`, POST `/match_one`).
+- **BackendAPI.cs**: cliente HTTP tipado (POST `/analyze`, GET `/train_status`, POST `/match_master` alias `/match_one`).
 - **appsettings.json**: `Backend.BaseUrl`.
 
 ### 2.2 Backend (Flask)
 - **app.py**:
-  - Endpoints: `/analyze`, `/train_status`, `/match_one`.
+  - Endpoints: `/analyze`, `/train_status`, `/match_master` (alias `/match_one`).
   - Carga modelo `model/current_model.h5` y umbral `model/threshold.txt`.
   - Preprocesado (*letterbox*), inferencia, **Grad‑CAM**, codificación heatmap a PNG Base64.
 - **utils/**: utilidades (`letterbox`, `masks/annulus`, `heatmap Grad‑CAM`, `schemas`).

--- a/DATA_FORMATS.md
+++ b/DATA_FORMATS.md
@@ -31,13 +31,17 @@ multipart/form-data
 - **Tipo**: `application/json`  
 - **Body**: vacío
 
-### 1.3 `/match_one`
+### 1.3 `/match_master` (alias `/match_one`)
 
-- **Método**: POST  
-- **Tipo**: `multipart/form-data`  
-- **Body**:
-  - `template`: archivo de plantilla, o  
-  - `file1` + `file2`: imágenes a comparar
+- **Método**: POST
+- **Tipo**: `multipart/form-data`
+- **Campos obligatorios**:
+  - `image`: imagen donde buscar la plantilla.
+  - `template`: plantilla (PNG en BGR o BGRA para máscara implícita).
+- **Campos opcionales**:
+  - `feature`, `thr`, `tm_thr`, `rot_range`, `scale_min`, `scale_max`.
+  - `search_x`, `search_y`, `search_w`, `search_h` para limitar el área de búsqueda.
+  - `debug` (`1/true`) para incluir capturas base64 de depuración.
 
 ---
 
@@ -97,12 +101,24 @@ multipart/form-data
 }
 ```
 
-### 2.3 `/match_one`
+### 2.3 `/match_master` (alias `/match_one`)
 
 ```json
 {
-  "similarity": 0.94,
-  "matched": true
+  "found": true,
+  "stage": "TM_OK",
+  "center_x": 412.5,
+  "center_y": 298.0,
+  "confidence": 0.91,
+  "tm_best": 0.91,
+  "tm_thr": 0.8,
+  "bbox": [380.0, 260.0, 65.0, 76.0],
+  "sift_orb": {
+    "detector": "auto->orb",
+    "matches": 480,
+    "good": 132,
+    "confidence": 0.86
+  }
 }
 ```
 
@@ -138,8 +154,25 @@ class AnalyzeResponse {
 
 ```csharp
 class MatchingResponse {
-    public double similarity { get; set; }
-    public bool matched { get; set; }
+    public bool found { get; set; }
+    public string stage { get; set; }
+    public double center_x { get; set; }
+    public double center_y { get; set; }
+    public double confidence { get; set; }
+    public double tm_best { get; set; }
+    public double tm_thr { get; set; }
+    public MatchingDebug debug { get; set; } // opcional cuando se solicita
+}
+
+class MatchingDebug {
+    public string gray_png { get; set; }
+    public string tpl_gray_png { get; set; }
+    public MatchingStats stats { get; set; }
+}
+
+class MatchingStats {
+    public double gray_mean { get; set; }
+    public double gray_std { get; set; }
 }
 ```
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -39,7 +39,7 @@ pip install -r requirements.txt
 ```
 
 ### 2.3 Archivos importantes
-- `app.py`: entrypoint Flask, define endpoints `/analyze`, `/train_status`, `/match_one`
+- `app.py`: entrypoint Flask, define endpoints `/analyze`, `/train_status`, `/match_master` (alias `/match_one`)
 - `model/current_model.h5`: modelo entrenado
 - `model/threshold.txt`: umbral NG/OK
 - `utils/`: funciones auxiliares (letterbox, annulus, heatmap, schemas)

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -43,7 +43,7 @@ Guía de **logging y trazabilidad** para el backend (Flask) y la GUI (WPF). El o
   - Parámetros opcionales (mask/annulus presentes o no).
   - Resultado: `label`, `score`, `threshold` (redondeado).
 - **/train_status**: respuesta enriquecida con `state`, `threshold`, `artifacts.*`, `model_runtime` y `log_tail`.
-- **/match_one** (si se usa): similitud/resultado.
+- **/match_master** (alias `/match_one`): estado (`stage`), `found`, `confidence`, `tm_best/tm_thr` y métricas del detector.
 - **Errores**: traza con `logger.exception(...)`.
 
 Ejemplo (pseudocódigo):

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ BrakeDiscInspector/
 ### `/train_status` (GET)
 - Retorna info del modelo cargado y metadata de artefactos (tamaño, timestamp, tail del log, threshold cargado, etc.).
 
-### `/match_one` (POST)
-- (Opcional) Matching por plantilla o ficheros.
+### `/match_master` (POST) — alias `/match_one`
+- Matching por plantilla entre `image` y `template` enviados como `multipart/form-data`.
+- Parámetros opcionales: `thr`, `tm_thr`, `feature` (`auto|sift|orb|tm_rot|geom`), `rot_range`, `scale_min`, `scale_max`, `search_x/y/w/h`, `debug`.
+- Respuesta: campos como `found`, `center_x`, `center_y`, `confidence`, `stage`, `tm_best`, `tm_thr`, `sift_orb` y bloques `debug` cuando se solicitan.
 
 > Detalles completos en [API_REFERENCE.md](API_REFERENCE.md)
 

--- a/ROI_AND_MATCHING_SPEC.md
+++ b/ROI_AND_MATCHING_SPEC.md
@@ -63,25 +63,41 @@ El **annulus** es un mecanismo opcional para delimitar un área circular de inte
 
 ---
 
-## 4) Matching (experimental)
+## 4) Matching maestro
 
-Además del análisis de defectos, se soporta un endpoint `/match_one` que compara imágenes o templates.
+Además del análisis de defectos, el backend expone `/match_master` (alias `/match_one`) para localizar un patrón maestro en una captura.
 
-### 4.1 Métodos posibles
+### 4.1 Parámetros soportados
 
-- **Template matching**: correlación de un ROI contra una plantilla de referencia.  
-- **File matching**: comparación entre dos imágenes de entrada.  
+- `image` (**obligatorio**): imagen completa donde buscar.
+- `template` (**obligatorio**): plantilla; si es PNG con canal alfa, éste se usa como máscara.
+- `feature`: `auto` (default), `sift`, `orb`, `tm_rot` o `geom`.
+- `thr`, `tm_thr`: umbrales de coincidencia.
+- `rot_range`, `scale_min`, `scale_max`: rango y escalas para el modo `tm_rot`.
+- `search_x`, `search_y`, `search_w`, `search_h`: restringen la búsqueda a un ROI previo.
+- `debug`: `1/true` para recibir capturas `debug.*` codificadas en Base64.
 
 ### 4.2 Respuesta
 
+La respuesta incluye siempre `found`/`stage` y, cuando hay éxito, coordenadas absolutas (`center_x`, `center_y`) y métricas (`confidence`, `tm_best`, `tm_thr`, `sift_orb`, etc.). Ejemplo:
+
 ```json
 {
-  "similarity": 0.94,
-  "matched": true
+  "found": true,
+  "stage": "TM_ROT_OK",
+  "center_x": 410.2,
+  "center_y": 302.7,
+  "confidence": 0.93,
+  "tm_best": 0.93,
+  "tm_thr": 0.8,
+  "tm_rot": {
+    "angle_deg": -2.0,
+    "scale": 1.01
+  }
 }
 ```
 
-Donde `similarity` es un valor normalizado ∈ [0,1].
+Si no se alcanza el umbral configurado se devuelve `found=false` junto con `reason`, `tm_best`, `crop_off` y el bloque `sift_orb` indicando el detector usado o el fallo.
 
 ---
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -690,7 +690,12 @@ def match_master():
     return jsonify(resp)
 
 
-    
+@app.post("/match_one")
+def match_one():
+    """Alias de compatibilidad que reutiliza la lógica de ``match_master``."""
+    return match_master()
+
+
 @app.post("/analyze")
 def analyze():
     ok, msg = _ensure_model()

--- a/gui/BrakeDiscInspector_GUI_ROI/README.md
+++ b/gui/BrakeDiscInspector_GUI_ROI/README.md
@@ -18,7 +18,7 @@ Sistema de inspección visual de discos de freno mediante GUI en C# WPF y backen
 ## 3. Estructura del GUI (C#)
 - **MainWindow.xaml / .cs**: control principal de la UI y flujo de análisis.
 - **MainWindow.cs**: código parcial auxiliar.
-- **BackendAPI.cs**: comunicación HTTP con Flask (MatchMasterAsync, AnalyzeAsync, TryCropToPng).
+- **BackendAPI.cs**: comunicación HTTP con Flask (MatchMasterAsync → `/match_master` alias `/match_one`, AnalyzeAsync, TryCropToPng).
 - **LocalMatcher.cs**: coincidencia local con OpenCVSharp.
 - **RoiAdorner.cs / RoiOverlay.cs**: dibujo y manipulación de ROIs.
 - **PresetManager.cs**: gestión de parámetros de coincidencia.
@@ -29,7 +29,7 @@ Sistema de inspección visual de discos de freno mediante GUI en C# WPF y backen
 
 ## 4. Backend (Python)
 - **app.py**: servidor Flask con endpoints:
-  - `/match_master`
+  - `/match_master` (alias `/match_one`)
   - `/analyze`
   - `/train_status`
 - **matcher.py**: lógica de matching ORB/SIFT.


### PR DESCRIPTION
## Summary
- expose the existing `/match_master` logic under a `/match_one` POST alias for backwards compatibility
- document the template matching parameters and responses for the `/match_master` `/match_one` endpoints across the docs and GUI guide
- refresh the data format examples to reflect the real matching response payload

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d012b38090833097a64d6dfa937048