### PR TITLE
Clear canvas after saving ROI

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -931,7 +931,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 AppendLog($"[wizard] layout save FAILED => {layoutPath} :: {ex}");
             }
 
-            RedrawOverlay();
+            ClearPersistedRoisFromCanvas();
 
             // IMPORTANTE: recalcula habilitaciones (esto ya deja el botón "Analizar Master" activo si M1+M2 están listos)
             UpdateWizardState();
@@ -2400,6 +2400,22 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 if (CanvasROI.Children[i] is FrameworkElement fe && Equals(fe.Tag, "analysis-mark"))
                     CanvasROI.Children.RemoveAt(i);
+            }
+        }
+
+        private void ClearPersistedRoisFromCanvas()
+        {
+            if (CanvasROI == null) return;
+
+            var persistedShapes = CanvasROI.Children
+                .OfType<Shape>()
+                .Where(shape => shape.Tag is RoiModel)
+                .ToList();
+
+            foreach (var shape in persistedShapes)
+            {
+                RemoveRoiAdorners(shape);
+                CanvasROI.Children.Remove(shape);
             }
         }
 


### PR DESCRIPTION
## Summary
- add a helper to strip persisted ROI shapes from the canvas
- update the master ROI save handler to clear persisted shapes after saving so the canvas is ready for the next drawing

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d02b2eb9b88330a7bdf73fb7311fd1