### PR TITLE
Fix rotation direction for ROI crop

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2089,7 +2089,7 @@ namespace BrakeDiscInspector_GUI_ROI
             double height = Math.Max(1.0, info.Height);
 
             var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
-            using var rotMat = Cv2.GetRotationMatrix2D(pivot, angleDeg, 1.0);
+            using var rotMat = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
             using var rotMatInverse = new Mat();
             Cv2.InvertAffineTransform(rotMat, rotMatInverse);
 


### PR DESCRIPTION
## Summary
- pass the negated ROI angle into GetRotationMatrix2D so OpenCV rotation matches WPF's clockwise convention

## Testing
- not run (WPF app cannot be launched in container)


------
https://chatgpt.com/codex/tasks/task_e_68d057c479408330ae07922a7ac18c31