### PR TITLE
Log ROI preview rectangles

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1928,6 +1928,9 @@ namespace BrakeDiscInspector_GUI_ROI
                     return;
                 }
 
+                var roiRect = new Rect2d(cropInfo.Left, cropInfo.Top, cropInfo.Width, cropInfo.Height);
+                var pivotPoint = new Point2d(cropInfo.PivotX, cropInfo.PivotY);
+
                 Mat? alphaMask = null;
                 try
                 {
@@ -1938,7 +1941,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     string fname = $"{tag}_{ts}.png";
                     var outPath = System.IO.Path.Combine(baseDir, fname);
                     Cv2.ImWrite(outPath, cropWithAlpha);
-                    AppendLog($"[preview] Guardado {fname} en {baseDir} (w={cropRect.Width} h={cropRect.Height} ang={roi.AngleDeg:0.##})");
+                    AppendLog($"[preview] Guardado {fname} en {baseDir} ROI=({roiRect.X:0.##},{roiRect.Y:0.##},{roiRect.Width:0.##},{roiRect.Height:0.##}) pivot=({pivotPoint.X:0.##},{pivotPoint.Y:0.##}) => crop=({cropRect.X},{cropRect.Y},{cropRect.Width},{cropRect.Height}) ang={roi.AngleDeg:0.##}");
                 }
                 finally
                 {


### PR DESCRIPTION
## Summary
- capture the ROI rectangle and pivot after building the crop preview
- extend the preview log to show the ROI rectangle, pivot, and resulting crop rectangle for easier diagnostics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d058babe1083308ef1f507cb0baa2f