### PR TITLE
Use forward rotation matrix for ROI transform

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2093,15 +2093,12 @@ namespace BrakeDiscInspector_GUI_ROI
 
             var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
             using var rotMat = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
-            using var rotMatInverse = new Mat();
-            Cv2.InvertAffineTransform(rotMat, rotMatInverse);
-
-            double m00 = rotMatInverse.At<double>(0, 0);
-            double m01 = rotMatInverse.At<double>(0, 1);
-            double m02 = rotMatInverse.At<double>(0, 2);
-            double m10 = rotMatInverse.At<double>(1, 0);
-            double m11 = rotMatInverse.At<double>(1, 1);
-            double m12 = rotMatInverse.At<double>(1, 2);
+            double m00 = rotMat.At<double>(0, 0);
+            double m01 = rotMat.At<double>(0, 1);
+            double m02 = rotMat.At<double>(0, 2);
+            double m10 = rotMat.At<double>(1, 0);
+            double m11 = rotMat.At<double>(1, 1);
+            double m12 = rotMat.At<double>(1, 2);
 
             Point2f Transform(double x, double y)
             {


### PR DESCRIPTION
## Summary
- read rotation coefficients directly from the matrix returned by `GetRotationMatrix2D`
- map ROI corners with the same matrix that is passed to `WarpAffine`

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0687bc9848330aff67a9314f95a8b