### PR TITLE
Fix rotated ROI crop angle

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
@@ -92,7 +92,7 @@ namespace BrakeDiscInspector_GUI_ROI
             double height = Math.Max(1.0, info.Height);
 
             var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
-            using var rotMat = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
+            using var rotMat = Cv2.GetRotationMatrix2D(pivot, angleDeg, 1.0);
             using var rotated = new Mat();
             Scalar border = source.Channels() == 4 ? new Scalar(0, 0, 0, 0) : Scalar.All(0);
             Cv2.WarpAffine(source, rotated, rotMat, new Size(source.Width, source.Height),


### PR DESCRIPTION
## Summary
- update the ROI crop rotation matrix to use the provided angle so the warp removes the ROI rotation instead of doubling it

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1891d06408330a49df58880b63b3a