### PR TITLE
Fix ROI rotation direction and add regression test

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/GlobalUsings.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using BrakeDiscInspector_GUI_ROI;
+using OpenCvSharp;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class RoiCropUtilsTests
+{
+    [Fact]
+    public void TryGetRotatedCrop_RespectsClockwiseAngles()
+    {
+        using var source = new Mat(new Size(160, 160), MatType.CV_8UC1, Scalar.All(0));
+
+        const double left = 60;
+        const double top = 40;
+        const double width = 40;
+        const double height = 30;
+        var roiRect = new Rect((int)left, (int)top, (int)width, (int)height);
+
+        // Create an asymmetric pattern inside the ROI so the rotation direction matters.
+        Cv2.Rectangle(source, roiRect, Scalar.All(30), -1);
+        Cv2.Circle(source, new Point(roiRect.Left + 5, roiRect.Top + 8), 4, Scalar.All(200), -1);
+        Cv2.Line(source, new Point(roiRect.Right - 2, roiRect.Top), new Point(roiRect.Right - 2, roiRect.Bottom - 1),
+            Scalar.All(120), 2);
+
+        double pivotX = left + width / 2.0;
+        double pivotY = top + height / 2.0;
+        var info = new RoiCropInfo(RoiShape.Rectangle, left, top, width, height, pivotX, pivotY, 0, 0);
+        const double angleDeg = 37.0;
+
+        Assert.True(RoiCropUtils.TryGetRotatedCrop(source, info, angleDeg, out var actualCrop, out var actualRect));
+        using var actual = actualCrop;
+
+        var expectedRect = BuildCropRect(info, source.Size());
+        Assert.Equal(expectedRect.X, actualRect.X);
+        Assert.Equal(expectedRect.Y, actualRect.Y);
+        Assert.Equal(expectedRect.Width, actualRect.Width);
+        Assert.Equal(expectedRect.Height, actualRect.Height);
+
+        using var expected = BuildExpectedCrop(source, info, angleDeg, expectedRect);
+        using var diff = new Mat();
+        Cv2.Absdiff(expected, actual, diff);
+        Assert.Equal(0, Cv2.CountNonZero(diff));
+    }
+
+    private static Rect BuildCropRect(RoiCropInfo info, Size sourceSize)
+    {
+        int x = (int)Math.Floor(info.Left);
+        int y = (int)Math.Floor(info.Top);
+        int w = (int)Math.Ceiling(info.Left + Math.Max(info.Width, 1.0)) - x;
+        int h = (int)Math.Ceiling(info.Top + Math.Max(info.Height, 1.0)) - y;
+
+        w = Math.Max(w, 1);
+        h = Math.Max(h, 1);
+
+        x = Math.Clamp(x, 0, sourceSize.Width - 1);
+        y = Math.Clamp(y, 0, sourceSize.Height - 1);
+        w = Math.Clamp(w, 1, sourceSize.Width - x);
+        h = Math.Clamp(h, 1, sourceSize.Height - y);
+
+        return new Rect(x, y, w, h);
+    }
+
+    private static Mat BuildExpectedCrop(Mat source, RoiCropInfo info, double angleDeg, Rect expectedRect)
+    {
+        var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
+        using var rotation = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
+        var border = source.Channels() == 4 ? new Scalar(0, 0, 0, 0) : Scalar.All(0);
+        using var rotated = new Mat();
+        Cv2.WarpAffine(source, rotated, rotation, source.Size(), InterpolationFlags.Linear, BorderTypes.Constant, border);
+        return new Mat(rotated, expectedRect).Clone();
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI.sln
+++ b/gui/BrakeDiscInspector_GUI_ROI.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.14.36119.2 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrakeDiscInspector_GUI_ROI", "BrakeDiscInspector_GUI_ROI.csproj", "{4E4FFF5D-5FE7-4B6D-8540-554CFB651F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrakeDiscInspector_GUI_ROI", "BrakeDiscInspector_GUI_ROI\\BrakeDiscInspector_GUI_ROI.csproj", "{4E4FFF5D-5FE7-4B6D-8540-554CFB651F67}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrakeDiscInspector_GUI_ROI.Tests", "BrakeDiscInspector_GUI_ROI.Tests\BrakeDiscInspector_GUI_ROI.Tests.csproj", "{597E8D16-BAD6-4AA5-847A-E7453122B560}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{4E4FFF5D-5FE7-4B6D-8540-554CFB651F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E4FFF5D-5FE7-4B6D-8540-554CFB651F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E4FFF5D-5FE7-4B6D-8540-554CFB651F67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{597E8D16-BAD6-4AA5-847A-E7453122B560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{597E8D16-BAD6-4AA5-847A-E7453122B560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{597E8D16-BAD6-4AA5-847A-E7453122B560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{597E8D16-BAD6-4AA5-847A-E7453122B560}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
+        <PropertyGroup>
+                <OutputType>WinExe</OutputType>
+                <TargetFramework>net8.0-windows</TargetFramework>
+                <UseWPF>true</UseWPF>
+                <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
-		<!-- Arquitectura fija x64 para que cargue los nativos -->
-		<PlatformTarget>x64</PlatformTarget>
+                <!-- Arquitectura fija x64 para que cargue los nativos -->
+                <PlatformTarget>x64</PlatformTarget>
 		<Prefer32Bit>false</Prefer32Bit>
 		<PublishReadyToRun>false</PublishReadyToRun>
 		<PublishSingleFile>false</PublishSingleFile>

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
@@ -92,7 +92,9 @@ namespace BrakeDiscInspector_GUI_ROI
             double height = Math.Max(1.0, info.Height);
 
             var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
-            using var rotMat = Cv2.GetRotationMatrix2D(pivot, angleDeg, 1.0);
+            // WPF angles are clockwise, while OpenCV expects counter-clockwise angles.
+            // Invert the sign so that rotations match the ROI drawn in the UI.
+            using var rotMat = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
             using var rotated = new Mat();
             Scalar border = source.Channels() == 4 ? new Scalar(0, 0, 0, 0) : Scalar.All(0);
             Cv2.WarpAffine(source, rotated, rotMat, new Size(source.Width, source.Height),


### PR DESCRIPTION
## Summary
- invert the rotation direction passed to OpenCV so clockwise WPF ROI angles align with crops
- enable Windows targeting for the GUI project and add an xUnit test project covering the ROI crop rotation

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI.sln *(fails on Linux because Microsoft.NET.Sdk.WindowsDesktop is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d18fac043c8330b24e12dd12885b46