### PR TITLE
Adjust ROI rectangle cropping to use centered coordinates

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
@@ -24,10 +24,22 @@ public class RoiCropUtilsTests
         Cv2.Line(source, new Point(roiRect.Right - 2, roiRect.Top), new Point(roiRect.Right - 2, roiRect.Bottom - 1),
             Scalar.All(120), 2);
 
-        double pivotX = left + width / 2.0;
-        double pivotY = top + height / 2.0;
-        var info = new RoiCropInfo(RoiShape.Rectangle, left, top, width, height, pivotX, pivotY, 0, 0);
         const double angleDeg = 37.0;
+
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = left + width / 2.0,
+            Y = top + height / 2.0,
+            Width = width,
+            Height = height
+        };
+
+        Assert.True(RoiCropUtils.TryBuildRoiCropInfo(roi, out var info));
+        Assert.Equal(left, info.Left);
+        Assert.Equal(top, info.Top);
+        Assert.Equal(width, info.Width);
+        Assert.Equal(height, info.Height);
 
         Assert.True(RoiCropUtils.TryGetRotatedCrop(source, info, angleDeg, out var actualCrop, out var actualRect));
         using var actual = actualCrop;

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
@@ -47,8 +47,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     {
                         double width = Math.Max(1.0, roi.Width);
                         double height = Math.Max(1.0, roi.Height);
-                        double left = roi.X;
-                        double top = roi.Y;
+                        double left = roi.X - width / 2.0;
+                        double top = roi.Y - height / 2.0;
                         var pivotLocal = RoiAdorner.GetRotationPivotLocalPoint(roi, width, height);
                         double pivotX = left + pivotLocal.X;
                         double pivotY = top + pivotLocal.Y;


### PR DESCRIPTION
## Summary
- treat rectangular ROI models as center-based when building crop info so left/top and pivot are derived from the center
- update the ROI crop unit test to build RoiModel instances with centered coordinates and keep validating rotated crop alignment

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests *(fails: Microsoft.NET.Sdk.WindowsDesktop not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1aadba90c8330abf2e583cba332c1