### PR TITLE
Fix rectangle ROI crop origin

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
@@ -29,8 +29,8 @@ public class RoiCropUtilsTests
         var roi = new RoiModel
         {
             Shape = RoiShape.Rectangle,
-            X = left + width / 2.0,
-            Y = top + height / 2.0,
+            X = left,
+            Y = top,
             Width = width,
             Height = height
         };

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
@@ -47,8 +47,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     {
                         double width = Math.Max(1.0, roi.Width);
                         double height = Math.Max(1.0, roi.Height);
-                        double left = roi.X - width / 2.0;
-                        double top = roi.Y - height / 2.0;
+                        double left = roi.X;
+                        double top = roi.Y;
                         var pivotLocal = RoiAdorner.GetRotationPivotLocalPoint(roi, width, height);
                         double pivotX = left + pivotLocal.X;
                         double pivotY = top + pivotLocal.Y;


### PR DESCRIPTION
## Summary
- use the ROI model's rectangle X/Y as the crop's top-left when building RoiCropInfo
- keep the rotation pivot aligned with the rectangle's updated origin
- update the RoiCropUtils test fixture to construct rectangles from their top-left corner

## Testing
- `dotnet test gui/BrakeDiscInspector_GUI_ROI.sln` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop workload in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b31b28688330944d0fd0d165e289