### PR TITLE
Fix ROI drift after resize

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3092,11 +3092,10 @@ namespace BrakeDiscInspector_GUI_ROI
             if (CanvasROI.Parent is not FrameworkElement parent) return;
             var imgTopLeft = ImgMain.TranslatePoint(new System.Windows.Point(0, 0), parent);
 
-            // Forzar a píxel de dispositivo (evita drift al redimensionar)
-            double left = Math.Round(imgTopLeft.X + displayRect.Left);
-            double top = Math.Round(imgTopLeft.Y + displayRect.Top);
-            double w = Math.Round(displayRect.Width);
-            double h = Math.Round(displayRect.Height);
+            double left = imgTopLeft.X + displayRect.Left;
+            double top = imgTopLeft.Y + displayRect.Top;
+            double w = displayRect.Width;
+            double h = displayRect.Height;
 
             CanvasROI.HorizontalAlignment = HorizontalAlignment.Left;
             CanvasROI.VerticalAlignment = VerticalAlignment.Top;


### PR DESCRIPTION
## Summary
- keep the ROI overlay canvas aligned with the actual image letterbox without rounding so saved ROIs stay in place after resizing or reloading

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4160b3a648330a6027eed58843b7b