### PR TITLE
Fix ROI persistence to avoid double scaling

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -929,7 +929,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     if (!IsAllowedMasterShape(_tmpBuffer.Shape)) { Snack("Master: usa rectángulo o círculo"); return; }
                     _tmpBuffer.Role = savedRole.Value;
 
-                    _layout.Master1Pattern = CanvasToImage(_tmpBuffer).Clone();
+                    _layout.Master1Pattern = _tmpBuffer.Clone();
                     savedRoi = _layout.Master1Pattern;
                     // Preview (si hay imagen cargada)
                     {
@@ -953,7 +953,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     AppendLog($"[wizard] save state={_state} role={savedRole} source={bufferSource} roi={DescribeRoi(_tmpBuffer)}");
                     _tmpBuffer.Role = savedRole.Value;
 
-                    _layout.Master1Search = CanvasToImage(_tmpBuffer).Clone();
+                    _layout.Master1Search = _tmpBuffer.Clone();
                     savedRoi = _layout.Master1Search;
                     SaveRoiCropPreview(_layout.Master1Search, "M1_search");
 
@@ -967,7 +967,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     if (!IsAllowedMasterShape(_tmpBuffer.Shape)) { Snack("Master: usa rectángulo o círculo"); return; }
                     _tmpBuffer.Role = savedRole.Value;
 
-                    _layout.Master2Pattern = CanvasToImage(_tmpBuffer).Clone();
+                    _layout.Master2Pattern = _tmpBuffer.Clone();
                     savedRoi = _layout.Master2Pattern;
                     SaveRoiCropPreview(_layout.Master2Pattern, "M2_pattern");
 
@@ -983,7 +983,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     AppendLog($"[wizard] save state={_state} role={savedRole} source={bufferSource} roi={DescribeRoi(_tmpBuffer)}");
                     _tmpBuffer.Role = savedRole.Value;
 
-                    _layout.Master2Search = CanvasToImage(_tmpBuffer).Clone();
+                    _layout.Master2Search = _tmpBuffer.Clone();
                     savedRoi = _layout.Master2Search;
                     SaveRoiCropPreview(_layout.Master2Search, "M2_search");
 
@@ -998,7 +998,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     AppendLog($"[wizard] save state={_state} role={savedRole} source={bufferSource} roi={DescribeRoi(_tmpBuffer)}");
                     _tmpBuffer.Role = savedRole.Value;
 
-                    _layout.Inspection = CanvasToImage(_tmpBuffer).Clone();
+                    _layout.Inspection = _tmpBuffer.Clone();
                     savedRoi = _layout.Inspection;
                     SyncCurrentRoiFromInspection(_layout.Inspection);
 


### PR DESCRIPTION
## Summary
- persist wizard ROI selections using the buffered image-space coordinates instead of re-scaling them
- ensure saved master and inspection ROIs remain aligned after window resizes or reloads

## Testing
- ⚠️ `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4160b3a648330a6027eed58843b7b