### PR TITLE
Add helper to convert master match points to canvas

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -51,6 +51,19 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
 
+        private (System.Windows.Point c1Canvas, System.Windows.Point c2Canvas, System.Windows.Point midCanvas) ConvertMasterPointsToCanvas(
+            System.Windows.Point c1,
+            System.Windows.Point c2,
+            System.Windows.Point mid)
+        {
+            var c1Canvas = ImagePxToCanvasPt(c1.X, c1.Y);
+            var c2Canvas = ImagePxToCanvasPt(c2.X, c2.Y);
+            var midCanvas = ImagePxToCanvasPt(mid.X, mid.Y);
+
+            return (c1Canvas, c2Canvas, midCanvas);
+        }
+
+
         public async Task AnalyzeInspectionViaBackend()
         {
             if (_layout?.Inspection == null) { Snack("Falta ROI de Inspección"); return; }


### PR DESCRIPTION
## Summary
- add a helper that projects matched master points from image space to the overlay canvas

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d454f16b3083308b0f6997c55030ad