### PR TITLE
Fix ambiguous Size reference in MainWindow

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -35,6 +35,7 @@ using WPoint = System.Windows.Point;
 using WRect = System.Windows.Rect;
 using WRectShape = System.Windows.Shapes.Rectangle;
 using Path = System.IO.Path;
+using WSize = System.Windows.Size;
 
 namespace BrakeDiscInspector_GUI_ROI
 {
@@ -2801,7 +2802,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (CanvasROI == null)
                 return;
 
-            element.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+            element.Measure(new WSize(double.PositiveInfinity, double.PositiveInfinity));
             var desired = element.DesiredSize;
 
             double left = Canvas.GetLeft(shape);


### PR DESCRIPTION
## Summary
- add a WPF-specific Size alias to avoid clashes with OpenCvSharp.Size
- use the alias when measuring label elements for ROI annotations

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4209b1c8330a484543514ed7eb5