### PR TITLE
Ensure inspection ROIs display labels

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2761,6 +2761,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 tbExisting.Text = labelText;
             }
 
+            element.Visibility = Visibility.Visible;
             Panel.SetZIndex(element, Panel.GetZIndex(shape) + 1);
             PositionLabelElement(element, shape, canvasModel);
         }
@@ -2861,6 +2862,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 RoiRole.Master1Search => "M1 Búsqueda",
                 RoiRole.Master2Pattern => "M2 Patrón",
                 RoiRole.Master2Search => "M2 Búsqueda",
+                RoiRole.Inspection => "Inspección",
                 _ => null
             };
         }


### PR DESCRIPTION
## Summary
- provide a default caption for inspection ROIs so their label is never empty
- force persistent ROI labels to remain visible after updates

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d635e892588330b49908d05ad26b5f