### PR TITLE
Redraw overlay after clearing persisted ROIs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1040,6 +1040,7 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             ClearPersistedRoisFromCanvas();
+            RedrawOverlaySafe();
 
             // IMPORTANTE: recalcula habilitaciones (esto ya deja el botón "Analizar Master" activo si M1+M2 están listos)
             UpdateWizardState();
@@ -2612,6 +2613,7 @@ namespace BrakeDiscInspector_GUI_ROI
             _analysisViewActive = true;
             ClearAnalysisMarksOnly();
             ClearPersistedRoisFromCanvas();
+            RedrawOverlaySafe();
 
             if (_previewShape != null)
             {


### PR DESCRIPTION
## Summary
- trigger an overlay redraw after clearing persisted ROIs during master save
- redraw the overlay when entering the analysis view so persisted shapes and labels are reconstructed immediately

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d63d149904833086bc24309d750498