### PR TITLE
Integrate RoiOverlay into inspection view

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
         Title="Inspector — Masters &amp; ROI" Height="900" Width="1400"
         WindowStartupLocation="CenterScreen" Background="#0E0E10">
 
@@ -26,6 +27,9 @@
                                 Background="Transparent"
                                 IsHitTestVisible="True"
                                 Panel.ZIndex="1"/>
+                        <local:RoiOverlay x:Name="RoiOverlay"
+                                          IsHitTestVisible="False"
+                                          Panel.ZIndex="2"/>
                     </Grid>
                 </Grid>
             </AdornerDecorator>


### PR DESCRIPTION
## Summary
- add the RoiOverlay control to the main window so ROI visuals render from the overlay itself
- update ROI synchronization paths to feed the overlay and clear the old canvas-based labels/shapes
- keep the overlay aligned with the letterboxed image alongside the existing canvas positioning

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d63e24ac808330afefc8d5ccd7b240