### PR TITLE
Ensure preview cleanup uses ClearPreview

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -415,11 +415,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private void BeginDraw(RoiShape shape, WPoint p0)
         {
             // Si había un preview anterior, elimínalo para evitar capas huérfanas
-            if (_previewShape != null)
-            {
-                CanvasROI.Children.Remove(_previewShape);
-                _previewShape = null;
-            }
+            ClearPreview();
 
             _previewShape = shape switch
             {
@@ -2664,11 +2660,7 @@ namespace BrakeDiscInspector_GUI_ROI
             ClearPersistedRoisFromCanvas();
             RedrawOverlaySafe();
 
-            if (_previewShape != null)
-            {
-                CanvasROI.Children.Remove(_previewShape);
-                _previewShape = null;
-            }
+            ClearPreview();
         }
 
         private void ExitAnalysisView()


### PR DESCRIPTION
## Summary
- route preview teardown in BeginDraw and EnterAnalysisView through ClearPreview to dispose adorners consistently
- confirmed no other call sites remove the preview shape directly so ClearPreview manages adorner cleanup globally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64ef539cc833090a63fd154f1ba73