### PR TITLE
Align ROI labels with updated role naming

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -98,7 +98,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private const double LabelOffsetX = 10;   // desplazamiento a la derecha de la cruz
         private const double LabelOffsetY = -20;  // desplazamiento hacia arriba de la cruz
 
-        private ROI CurrentRoi = new ROI { X = 200, Y = 150, Width = 100, Height = 80, AngleDeg = 0, Legend = "M1" };
+        private ROI CurrentRoi = new ROI { X = 200, Y = 150, Width = 100, Height = 80, AngleDeg = 0, Legend = string.Empty };
         private Mat? bgrFrame; // tu frame actual
         private bool UseAnnulus = false;
 
@@ -632,6 +632,8 @@ namespace BrakeDiscInspector_GUI_ROI
             if (activeRole.HasValue)
             {
                 canvasDraft.Role = activeRole.Value;
+                if (pixelDraft != null)
+                    pixelDraft.Role = activeRole.Value;
                 if (_tmpBuffer != null)
                     _tmpBuffer.Role = activeRole.Value;
             }
@@ -2920,11 +2922,11 @@ namespace BrakeDiscInspector_GUI_ROI
 
             return roiModel.Role switch
             {
-                RoiRole.Master1Pattern => "M1 Patrón",
-                RoiRole.Master1Search => "M1 Búsqueda",
-                RoiRole.Master2Pattern => "M2 Patrón",
-                RoiRole.Master2Search => "M2 Búsqueda",
-                RoiRole.Inspection => "Inspección",
+                RoiRole.Master1Pattern => "ROI Master 1",
+                RoiRole.Master1Search => "ROI Master 1 Inspección",
+                RoiRole.Master2Pattern => "ROI Master 2",
+                RoiRole.Master2Search => "ROI Master 2 Inspección",
+                RoiRole.Inspection => "ROI Inspección",
                 _ => null
             };
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
@@ -7,7 +7,7 @@
         public double Width { get; set; }
         public double Height { get; set; }
         public double AngleDeg { get; set; } = 0.0;
-        public string Legend { get; set; } = "M1";
+        public string Legend { get; set; } = string.Empty;
 
         public void EnforceMinSize(double minW = 10, double minH = 10)
         {


### PR DESCRIPTION
## Summary
- propagate the resolved ROI role onto the draft models when finishing a drawing
- update the ROI label resolver to emit the new naming scheme for each role
- clear default ROI legends so overlays rely on the resolver for role-based labels

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6509896248330a5a60f13df0e6804