### PR TITLE
Restrict ROI adorners to active editing role

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -226,6 +226,17 @@ namespace BrakeDiscInspector_GUI_ROI
             };
         }
 
+        private bool ShouldEnableRoiEditing(RoiRole role)
+        {
+            if (role == RoiRole.Inspection)
+            {
+                return _state == MasterState.DrawInspection || _state == MasterState.Ready;
+            }
+
+            var currentRole = GetCurrentStateRole();
+            return currentRole.HasValue && currentRole.Value == role;
+        }
+
         private bool TryClearCurrentStatePersistedRoi(out RoiRole? clearedRole)
         {
             clearedRole = GetCurrentStateRole();
@@ -2729,7 +2740,14 @@ namespace BrakeDiscInspector_GUI_ROI
                     _roiShapesById[canvasInfo.Id] = shape;
                     UpdatePersistentLabel(canvasInfo);
                 }
-                AttachRoiAdorner(shape);
+
+                bool enableEditing = ShouldEnableRoiEditing(roi.Role);
+                shape.IsHitTestVisible = enableEditing;
+
+                if (enableEditing)
+                {
+                    AttachRoiAdorner(shape);
+                }
             }
 
             AddPersistentRoi(_layout.Master1Search);


### PR DESCRIPTION
## Summary
- gate adorner attachment on the ROI role so only the active workflow step is editable
- disable hit testing for inactive saved ROIs to avoid stray interaction handles
- keep inspection ROIs editable during the inspection and ready stages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d651d66b2c8330950b78b7f56308a7