### PR TITLE
Ensure ROI labels follow shapes during drag

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1737,6 +1737,8 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             AppendLog($"[model] sync {roiPixel.Role} => {DescribeRoi(roiPixel)}");
+
+            UpdatePersistentLabelForShape(shape);
         }
 
         private void UpdateLayoutFromPixel(RoiModel roiPixel)


### PR DESCRIPTION
## Summary
- update ROI shape synchronization to also refresh the persistent label position, keeping labels attached while dragging

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d656da11508330bf30e97fea5bff98