### PR TITLE
Ensure ROI overlay refreshes during drag

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1736,6 +1736,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 UpdateLayoutFromPixel(roiPixel);
             }
 
+            UpdateOverlayFromPixelModel(roiPixel);
+
             AppendLog($"[model] sync {roiPixel.Role} => {DescribeRoi(roiPixel)}");
 
             UpdatePersistentLabelForShape(shape);


### PR DESCRIPTION
## Summary
- update ROI shape syncing to refresh the overlay so drag interactions immediately reflect the current geometry

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66c43279c83308dd110c08381dc58