### PR TITLE
Add search ROI bounds to backend master matching requests

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -20,14 +20,14 @@ namespace BrakeDiscInspector_GUI_ROI
             _currentImagePathWin, _layout.Master1Pattern,
             _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
             string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-            0.8, false, "M1", AppendLog);
+            0.8, false, "M1", _layout.Master1Search, AppendLog);
 
 
             var r2 = await BackendAPI.MatchOneViaFilesAsync(
             _currentImagePathWin, _layout.Master2Pattern,
             _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
             string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-            0.8, false, "M2", AppendLog);
+            0.8, false, "M2", _layout.Master2Search, AppendLog);
 
 
             if (!r1.ok || r1.center == null) { Snack("No se encontró Master 1" + (r1.error != null ? $" ({r1.error})" : "")); return; }

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1233,7 +1233,7 @@ namespace BrakeDiscInspector_GUI_ROI
                         _currentImagePathWin, tpl1Path,
                         _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
                         string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-                        0.8, "M1", AppendLog);
+                        0.8, "M1", _layout.Master1Search, AppendLog);
                 }
                 else
                 {
@@ -1243,7 +1243,7 @@ namespace BrakeDiscInspector_GUI_ROI
                         _currentImagePathWin, _layout.Master1Pattern!,
                         _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
                         string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-                        0.8, false, "M1", AppendLog);
+                        0.8, false, "M1", _layout.Master1Search, AppendLog);
                 }
 
                 if (r1.ok && r1.center.HasValue)
@@ -1268,7 +1268,7 @@ namespace BrakeDiscInspector_GUI_ROI
                         _currentImagePathWin, tpl2Path,
                         _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
                         string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-                        0.8, "M2", AppendLog);
+                        0.8, "M2", _layout.Master2Search, AppendLog);
                 }
                 else
                 {
@@ -1277,7 +1277,7 @@ namespace BrakeDiscInspector_GUI_ROI
                         _currentImagePathWin, _layout.Master2Pattern!,
                         _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
                         string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-                        0.8, false, "M2", AppendLog);
+                        0.8, false, "M2", _layout.Master2Search, AppendLog);
                 }
 
                 if (r2.ok && r2.center.HasValue)


### PR DESCRIPTION
## Summary
- add optional search ROI parameters to the backend template and ROI matching helpers and include the normalized search bounds in the POST payload when present
- pass the master search ROIs through AnalyzeMastersAsync and the backend analysis helper so all backend calls include the intended search window

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj *(fails: Microsoft.NET.Sdk.WindowsDesktop not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d67950ea0883309849cf8e7319bb30