### PR TITLE
Switch ROI models to center-based coordinates

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using BrakeDiscInspector_GUI_ROI;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class BackendPayloadBuilderTests
+{
+    [Fact]
+    public void SerializeRoiToJson_EmitsCenterCoordinates()
+    {
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            Width = 48,
+            Height = 32,
+            AngleDeg = 37.5
+        };
+        roi.Left = 120;
+        roi.Top = 80;
+
+        string json = InvokeSerializeRoiToJson(roi);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal(roi.X, root.GetProperty("x").GetDouble());
+        Assert.Equal(roi.Y, root.GetProperty("y").GetDouble());
+        Assert.Equal(roi.AngleDeg, root.GetProperty("angle_deg").GetDouble());
+    }
+
+    [Fact]
+    public void TryGetSearchRect_UsesLeftTopForRectangle()
+    {
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            Width = 60,
+            Height = 40
+        };
+        roi.Left = 50;
+        roi.Top = 30;
+
+        object[] args = { roi, 0, 0, 0, 0 };
+        bool ok = (bool)TryGetSearchRectMethod().Invoke(null, args)!;
+
+        Assert.True(ok);
+        Assert.Equal((int)Math.Round(roi.Left), (int)args[1]);
+        Assert.Equal((int)Math.Round(roi.Top), (int)args[2]);
+        Assert.Equal((int)Math.Round(roi.Width), (int)args[3]);
+        Assert.Equal((int)Math.Round(roi.Height), (int)args[4]);
+    }
+
+    private static string InvokeSerializeRoiToJson(RoiModel roi)
+    {
+        return (string)SerializeRoiToJsonMethod().Invoke(null, new object[] { roi })!;
+    }
+
+    private static MethodInfo SerializeRoiToJsonMethod()
+    {
+        return typeof(MainWindow).GetMethod("SerializeRoiToJson", BindingFlags.NonPublic | BindingFlags.Static)
+               ?? throw new InvalidOperationException("SerializeRoiToJson not found");
+    }
+
+    private static MethodInfo TryGetSearchRectMethod()
+    {
+        return typeof(BackendAPI).GetMethod("TryGetSearchRect", BindingFlags.NonPublic | BindingFlags.Static)
+               ?? throw new InvalidOperationException("TryGetSearchRect not found");
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
@@ -29,11 +29,11 @@ public class RoiCropUtilsTests
         var roi = new RoiModel
         {
             Shape = RoiShape.Rectangle,
-            X = left,
-            Y = top,
             Width = width,
             Height = height
         };
+        roi.Left = left;
+        roi.Top = top;
 
         Assert.True(RoiCropUtils.TryBuildRoiCropInfo(roi, out var info));
         Assert.Equal(left, info.Left);
@@ -66,11 +66,11 @@ public class RoiCropUtilsTests
         var roi = new RoiModel
         {
             Shape = RoiShape.Rectangle,
-            X = left,
-            Y = top,
             Width = width,
             Height = height
         };
+        roi.Left = left;
+        roi.Top = top;
 
         Assert.True(RoiCropUtils.TryBuildRoiCropInfo(roi, out var info));
         Assert.True(RoiCropUtils.TryGetRotatedCrop(source, info, angleDeg, out var crop, out var cropRect));

--- a/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
@@ -283,8 +283,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     break;
                 case RoiShape.Rectangle:
                 default:
-                    sx = roi.X;
-                    sy = roi.Y;
+                    sx = roi.Left;
+                    sy = roi.Top;
                     sw = roi.Width;
                     sh = roi.Height;
                     break;

--- a/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
@@ -185,10 +185,10 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             if (r.Shape == RoiShape.Rectangle)
             {
-                double left = r.X;
-                double top = r.Y;
-                double right = r.X + r.Width;
-                double bottom = r.Y + r.Height;
+                double left = r.Left;
+                double top = r.Top;
+                double right = left + r.Width;
+                double bottom = top + r.Height;
 
                 int x = (int)Math.Floor(left);
                 int y = (int)Math.Floor(top);

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/Preset.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/Preset.cs
@@ -38,11 +38,25 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
-        // Rectángulo
+        // Rectángulo (X/Y representan el centro geométrico)
         public double X { get; set; }
         public double Y { get; set; }
         public double Width { get; set; }
         public double Height { get; set; }
+
+        [JsonIgnore]
+        public double Left
+        {
+            get => X - Width / 2.0;
+            set => X = value + Width / 2.0;
+        }
+
+        [JsonIgnore]
+        public double Top
+        {
+            get => Y - Height / 2.0;
+            set => Y = value + Height / 2.0;
+        }
 
         // Círculo / Annulus
         public double CX { get; set; }
@@ -54,7 +68,7 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             return Shape switch
             {
-                RoiShape.Rectangle => (X + Width / 2.0, Y + Height / 2.0),
+                RoiShape.Rectangle => (X, Y),
                 RoiShape.Circle or RoiShape.Annulus => (CX, CY),
                 _ => (0, 0)
             };

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -711,12 +711,12 @@ namespace BrakeDiscInspector_GUI_ROI
             if (shape is Rectangle)
             {
                 roi.Shape = RoiShape.Rectangle;
-                roi.X = x;
-                roi.Y = y;
                 roi.Width = w;
                 roi.Height = h;
-                roi.CX = x + w / 2.0;
-                roi.CY = y + h / 2.0;
+                roi.Left = x;
+                roi.Top = y;
+                roi.CX = roi.X;
+                roi.CY = roi.Y;
                 roi.R = 0.0;
                 roi.RInner = 0.0;
             }
@@ -728,10 +728,10 @@ namespace BrakeDiscInspector_GUI_ROI
                 double centerY = y + radiusY;
 
                 roi.Shape = roi.Shape == RoiShape.Annulus ? RoiShape.Annulus : RoiShape.Circle;
-                roi.X = x;
-                roi.Y = y;
                 roi.Width = w;
                 roi.Height = h;
+                roi.Left = x;
+                roi.Top = y;
                 roi.CX = centerX;
                 roi.CY = centerY;
                 roi.R = Math.Max(radiusX, radiusY);

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs
@@ -47,8 +47,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     {
                         double width = Math.Max(1.0, roi.Width);
                         double height = Math.Max(1.0, roi.Height);
-                        double left = roi.X;
-                        double top = roi.Y;
+                        double left = roi.Left;
+                        double top = roi.Top;
                         var pivotLocal = RoiAdorner.GetRotationPivotLocalPoint(roi, width, height);
                         double pivotX = left + pivotLocal.X;
                         double pivotY = top + pivotLocal.Y;


### PR DESCRIPTION
## Summary
- store rectangle ROI coordinates as centers and expose helper left/top accessors
- update canvas/image conversion, clipping, and exporter logic to honor the new center-based storage
- adjust backend helpers and add regression tests covering serialization and search rect conversions

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI.sln *(fails: missing Microsoft.NET.Sdk.WindowsDesktop on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68d6822e50348330b4afd3c747bec491