### PR TITLE
Fix image-to-canvas transform before overlay alignment

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3540,14 +3540,29 @@ namespace BrakeDiscInspector_GUI_ROI
             if (pw <= 0 || ph <= 0)
                 return (1.0, 0.0, 0.0);
 
-            double canvasWidth = CanvasROI?.ActualWidth ?? CanvasROI?.Width ?? 0.0;
-            double canvasHeight = CanvasROI?.ActualHeight ?? CanvasROI?.Height ?? 0.0;
+            var displayRect = GetImageDisplayRect();
+            bool overlayAligned = IsOverlayAligned();
+
+            double canvasWidth = 0.0;
+            double canvasHeight = 0.0;
+
+            if (overlayAligned)
+            {
+                canvasWidth = CanvasROI?.ActualWidth ?? CanvasROI?.Width ?? 0.0;
+                canvasHeight = CanvasROI?.ActualHeight ?? CanvasROI?.Height ?? 0.0;
+            }
+
+            if (!overlayAligned || canvasWidth <= 0 || canvasHeight <= 0)
+            {
+                canvasWidth = displayRect.Width;
+                canvasHeight = displayRect.Height;
+            }
 
             if (canvasWidth <= 0 || canvasHeight <= 0)
             {
-                var displayRect = GetImageDisplayRect();
-                canvasWidth = displayRect.Width;
-                canvasHeight = displayRect.Height;
+                // Último recurso: usa las dimensiones actuales del canvas aunque no estén alineadas.
+                canvasWidth = CanvasROI?.ActualWidth ?? CanvasROI?.Width ?? 0.0;
+                canvasHeight = CanvasROI?.ActualHeight ?? CanvasROI?.Height ?? 0.0;
             }
 
             if (canvasWidth <= 0 || canvasHeight <= 0)


### PR DESCRIPTION
## Summary
- derive the image-to-canvas scale from the display rectangle whenever the overlay has not finished aligning
- fall back to display size so ROI conversions remain stable during deferred syncs

## Testing
- not run (UI alignment change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6891cf5e08330be61cf43d7c33e05