### PR TITLE
Ensure rectangular ROI centers use pixel model coordinates

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -1794,8 +1794,8 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (pixelModel.Shape == RoiShape.Rectangle)
             {
-                CurrentRoi.X = pixelModel.X + pixelModel.Width / 2.0;
-                CurrentRoi.Y = pixelModel.Y + pixelModel.Height / 2.0;
+                CurrentRoi.X = pixelModel.X;
+                CurrentRoi.Y = pixelModel.Y;
                 CurrentRoi.Width = pixelModel.Width;
                 CurrentRoi.Height = pixelModel.Height;
             }


### PR DESCRIPTION
## Summary
- stop offsetting rectangular ROI centers when applying pixel models so that X/Y are used directly
- verified the existing CanvasToImage and ImageToCanvas helpers continue to treat rectangular coordinates as centers, so no further code changes were required

## Testing
- not run (GUI testing requires a desktop environment)


------
https://chatgpt.com/codex/tasks/task_e_68d68df9c5d08330aede0f5a562629bc