### PR TITLE
Fix rectangle silhouette centering

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2466,8 +2466,8 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 silhouetteImage.Width = pattern.Width;
                 silhouetteImage.Height = pattern.Height;
-                silhouetteImage.X = matchImageCenter.X - silhouetteImage.Width / 2.0;
-                silhouetteImage.Y = matchImageCenter.Y - silhouetteImage.Height / 2.0;
+                silhouetteImage.X = matchImageCenter.X;
+                silhouetteImage.Y = matchImageCenter.Y;
             }
             else
             {


### PR DESCRIPTION
## Summary
- center rectangle match silhouettes on the matched point so the dashed frame surrounds the cross

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: missing Microsoft.NET.Sdk.WindowsDesktop in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d691ceecac83308591fafed1397519