### PR TITLE
Align inspection ROI with master transform

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -40,7 +40,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
 
             if (_layout.Inspection == null) { Snack("Falta ROI de Inspección"); return; }
-            MoveInspectionTo(_layout.Inspection, mid.X, mid.Y);
+            MoveInspectionTo(_layout.Inspection, c1, c2);
             ClipInspectionROI(_layout.Inspection, _imgW, _imgH);
 
 


### PR DESCRIPTION
## Summary
- update MoveInspectionTo to derive the inspection ROI position from the saved master layout using a similarity transform
- accept the individual master match centers when repositioning inspection ROIs and keep the midpoint fallback when layout data is incomplete
- adjust AnalyzeMasters call sites to pass both master centers through the new signature

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d695b51d68833097c29e6a280d67e3