### PR TITLE
Prevent inspection ROI drift when reanalyzing masters

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Windows;
+using BrakeDiscInspector_GUI_ROI;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class InspectionAlignmentHelperTests
+{
+    [Theory]
+    [InlineData(RoiShape.Rectangle)]
+    [InlineData(RoiShape.Circle)]
+    [InlineData(RoiShape.Annulus)]
+    public void MoveInspectionTo_DoesNotDriftAcrossRepeatedApplications(RoiShape shape)
+    {
+        var baselineMaster1 = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 120,
+            Y = 110,
+            Width = 60,
+            Height = 40
+        };
+
+        var baselineMaster2 = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 250,
+            Y = 180,
+            Width = 55,
+            Height = 35
+        };
+
+        var baselineInspection = CreateBaselineInspection(shape);
+        var target = baselineInspection.Clone();
+
+        var master1 = new Point(150, 140);
+        var master2 = new Point(320, 210);
+
+        InspectionAlignmentHelper.MoveInspectionTo(
+            target,
+            baselineInspection.Clone(),
+            baselineMaster1,
+            baselineMaster2,
+            master1,
+            master2);
+
+        Assert.False(AreApproximatelyEqual(baselineInspection, target, shape));
+
+        var firstResult = target.Clone();
+
+        InspectionAlignmentHelper.MoveInspectionTo(
+            target,
+            baselineInspection.Clone(),
+            baselineMaster1,
+            baselineMaster2,
+            master1,
+            master2);
+
+        AssertClose(firstResult, target, shape);
+    }
+
+    private static RoiModel CreateBaselineInspection(RoiShape shape)
+    {
+        return shape switch
+        {
+            RoiShape.Rectangle => new RoiModel
+            {
+                Shape = RoiShape.Rectangle,
+                X = 200,
+                Y = 160,
+                Width = 90,
+                Height = 60,
+                AngleDeg = 28
+            },
+            RoiShape.Circle => new RoiModel
+            {
+                Shape = RoiShape.Circle,
+                CX = 210,
+                CY = 150,
+                R = 45,
+                AngleDeg = -5
+            },
+            RoiShape.Annulus => new RoiModel
+            {
+                Shape = RoiShape.Annulus,
+                CX = 205,
+                CY = 155,
+                R = 60,
+                RInner = 25,
+                AngleDeg = 12
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null)
+        };
+    }
+
+    private static bool AreApproximatelyEqual(RoiModel expected, RoiModel actual, RoiShape shape)
+    {
+        const double tolerance = 1e-6;
+
+        return shape switch
+        {
+            RoiShape.Rectangle =>
+                AreClose(expected.X, actual.X, tolerance) &&
+                AreClose(expected.Y, actual.Y, tolerance) &&
+                AreClose(expected.Width, actual.Width, tolerance) &&
+                AreClose(expected.Height, actual.Height, tolerance) &&
+                AreClose(expected.AngleDeg, actual.AngleDeg, tolerance),
+            RoiShape.Circle =>
+                AreClose(expected.CX, actual.CX, tolerance) &&
+                AreClose(expected.CY, actual.CY, tolerance) &&
+                AreClose(expected.R, actual.R, tolerance),
+            RoiShape.Annulus =>
+                AreClose(expected.CX, actual.CX, tolerance) &&
+                AreClose(expected.CY, actual.CY, tolerance) &&
+                AreClose(expected.R, actual.R, tolerance) &&
+                AreClose(expected.RInner, actual.RInner, tolerance),
+            _ => false
+        };
+    }
+
+    private static void AssertClose(RoiModel expected, RoiModel actual, RoiShape shape)
+    {
+        const int precision = 6;
+
+        Assert.Equal(expected.Shape, actual.Shape);
+
+        switch (shape)
+        {
+            case RoiShape.Rectangle:
+                Assert.Equal(expected.X, actual.X, precision);
+                Assert.Equal(expected.Y, actual.Y, precision);
+                Assert.Equal(expected.Width, actual.Width, precision);
+                Assert.Equal(expected.Height, actual.Height, precision);
+                Assert.Equal(expected.AngleDeg, actual.AngleDeg, precision);
+                break;
+            case RoiShape.Circle:
+                Assert.Equal(expected.CX, actual.CX, precision);
+                Assert.Equal(expected.CY, actual.CY, precision);
+                Assert.Equal(expected.R, actual.R, precision);
+                Assert.Equal(expected.AngleDeg, actual.AngleDeg, precision);
+                break;
+            case RoiShape.Annulus:
+                Assert.Equal(expected.CX, actual.CX, precision);
+                Assert.Equal(expected.CY, actual.CY, precision);
+                Assert.Equal(expected.R, actual.R, precision);
+                Assert.Equal(expected.RInner, actual.RInner, precision);
+                Assert.Equal(expected.AngleDeg, actual.AngleDeg, precision);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(shape), shape, null);
+        }
+    }
+
+    private static bool AreClose(double expected, double actual, double tolerance)
+    {
+        return Math.Abs(expected - actual) <= tolerance;
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/AssemblyInfo.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AssemblyInfo.cs
@@ -1,4 +1,7 @@
+using System.Runtime.CompilerServices;
 using System.Windows;
+
+[assembly: InternalsVisibleTo("BrakeDiscInspector_GUI_ROI.Tests")]
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located

--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Windows;
+
+namespace BrakeDiscInspector_GUI_ROI;
+
+internal static class InspectionAlignmentHelper
+{
+    internal static void MoveInspectionTo(
+        RoiModel inspectionTarget,
+        RoiModel baselineInspection,
+        RoiModel? baselineMaster1,
+        RoiModel? baselineMaster2,
+        Point master1,
+        Point master2)
+    {
+        if (inspectionTarget == null)
+        {
+            return;
+        }
+
+        if (baselineInspection == null)
+        {
+            baselineInspection = inspectionTarget.Clone();
+        }
+
+        bool transformed = false;
+
+        if (baselineMaster1 != null && baselineMaster2 != null)
+        {
+            var savedM1Center = GetRoiCenter(baselineMaster1);
+            var savedM2Center = GetRoiCenter(baselineMaster2);
+            var originalCenter = GetRoiCenter(baselineInspection);
+
+            double dxOld = savedM2Center.X - savedM1Center.X;
+            double dyOld = savedM2Center.Y - savedM1Center.Y;
+            double dxNew = master2.X - master1.X;
+            double dyNew = master2.Y - master1.Y;
+
+            double lenOld = Math.Sqrt(dxOld * dxOld + dyOld * dyOld);
+            double lenNew = Math.Sqrt(dxNew * dxNew + dyNew * dyNew);
+
+            if (lenOld > 1e-6 && lenNew > 0)
+            {
+                double scale = lenNew / lenOld;
+                double angleOld = Math.Atan2(dyOld, dxOld);
+                double angleNew = Math.Atan2(dyNew, dxNew);
+                double angleDelta = angleNew - angleOld;
+                double cos = Math.Cos(angleDelta);
+                double sin = Math.Sin(angleDelta);
+
+                double relX = originalCenter.X - savedM1Center.X;
+                double relY = originalCenter.Y - savedM1Center.Y;
+
+                double rotatedX = scale * (cos * relX - sin * relY);
+                double rotatedY = scale * (sin * relX + cos * relY);
+
+                double newCx = master1.X + rotatedX;
+                double newCy = master1.Y + rotatedY;
+
+                ApplyShapeTransform(inspectionTarget, baselineInspection, newCx, newCy, scale, angleDelta, false);
+                transformed = true;
+            }
+        }
+
+        if (!transformed)
+        {
+            var mid = new Point((master1.X + master2.X) / 2.0, (master1.Y + master2.Y) / 2.0);
+            ApplyShapeTransform(inspectionTarget, baselineInspection, mid.X, mid.Y, 1.0, 0.0, true);
+        }
+    }
+
+    private static void ApplyShapeTransform(
+        RoiModel target,
+        RoiModel baseline,
+        double centerX,
+        double centerY,
+        double scale,
+        double angleDelta,
+        bool fallback)
+    {
+        switch (baseline.Shape)
+        {
+            case RoiShape.Rectangle:
+                target.Shape = RoiShape.Rectangle;
+                target.X = centerX;
+                target.Y = centerY;
+                target.Width = Math.Max(1, baseline.Width * scale);
+                target.Height = Math.Max(1, baseline.Height * scale);
+                double baseAngle = baseline.AngleDeg;
+                target.AngleDeg = fallback ? baseAngle : baseAngle + angleDelta * 180.0 / Math.PI;
+                break;
+            case RoiShape.Circle:
+                target.Shape = RoiShape.Circle;
+                target.CX = centerX;
+                target.CY = centerY;
+                target.R = Math.Max(1, baseline.R * scale);
+                target.AngleDeg = baseline.AngleDeg;
+                break;
+            case RoiShape.Annulus:
+                target.Shape = RoiShape.Annulus;
+                target.CX = centerX;
+                target.CY = centerY;
+                target.R = Math.Max(1, baseline.R * scale);
+                target.RInner = Math.Max(0, baseline.RInner * scale);
+                if (target.RInner >= target.R)
+                {
+                    target.RInner = Math.Max(0, target.R - 1);
+                }
+                target.AngleDeg = baseline.AngleDeg;
+                break;
+        }
+    }
+
+    private static Point GetRoiCenter(RoiModel roi)
+    {
+        var (cx, cy) = roi.GetCenter();
+        return new Point(cx, cy);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -10,6 +10,7 @@ namespace BrakeDiscInspector_GUI_ROI
         public RoiModel? Master2Pattern { get; set; }
         public RoiModel? Master2Search { get; set; }
         public RoiModel? Inspection { get; set; }
+        public RoiModel? InspectionBaseline { get; set; }
     }
 
     public static class MasterLayoutManager


### PR DESCRIPTION
## Summary
- store and maintain a baseline copy of the inspection ROI in the master layout so it survives reloads and edits
- refactor inspection relocation to reuse the baseline geometry via a helper, avoiding cumulative scale/rotation drift
- add unit coverage that verifies repeated relocation leaves the ROI unchanged

## Testing
- `dotnet test gui/BrakeDiscInspector_GUI_ROI.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f0ba043c8330a137362a139c4ff4