### PR TITLE
Add editable annulus ROI support

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/MasterLayoutTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/MasterLayoutTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using BrakeDiscInspector_GUI_ROI;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class MasterLayoutTests
+{
+    [Fact]
+    public void AnnulusRoiSerialization_RoundTripsInnerRadius()
+    {
+        var layout = new MasterLayout
+        {
+            Inspection = new RoiModel
+            {
+                Shape = RoiShape.Annulus,
+                CX = 150,
+                CY = 120,
+                R = 60,
+                RInner = 25,
+                AngleDeg = 12.5
+            }
+        };
+
+        if (layout.Inspection is not null)
+        {
+            layout.Inspection.Width = layout.Inspection.R * 2.0;
+            layout.Inspection.Height = layout.Inspection.Width;
+        }
+
+        string json = JsonSerializer.Serialize(layout);
+        var roundTrip = JsonSerializer.Deserialize<MasterLayout>(json);
+
+        Assert.NotNull(roundTrip);
+        Assert.NotNull(roundTrip!.Inspection);
+        Assert.Equal(RoiShape.Annulus, roundTrip.Inspection!.Shape);
+        Assert.Equal(25, roundTrip.Inspection.RInner);
+        Assert.Equal(60, roundTrip.Inspection.R);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/AnnulusShape.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AnnulusShape.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace BrakeDiscInspector_GUI_ROI
+{
+    public class AnnulusShape : Shape
+    {
+        public static readonly DependencyProperty InnerRadiusProperty = DependencyProperty.Register(
+            nameof(InnerRadius),
+            typeof(double),
+            typeof(AnnulusShape),
+            new FrameworkPropertyMetadata(0.0, FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public double InnerRadius
+        {
+            get => (double)GetValue(InnerRadiusProperty);
+            set => SetValue(InnerRadiusProperty, value);
+        }
+
+        protected override Geometry DefiningGeometry
+        {
+            get
+            {
+                double width = RenderSize.Width;
+                double height = RenderSize.Height;
+
+                if (double.IsNaN(width) || double.IsNaN(height) || width <= 0 || height <= 0)
+                {
+                    return Geometry.Empty;
+                }
+
+                double outerRadius = Math.Min(width, height) / 2.0;
+                if (outerRadius <= 0)
+                    return Geometry.Empty;
+
+                double inner = Math.Max(0.0, Math.Min(InnerRadius, outerRadius));
+                var center = new Point(width / 2.0, height / 2.0);
+
+                var geometry = new StreamGeometry { FillRule = FillRule.EvenOdd };
+                using (var ctx = geometry.Open())
+                {
+                    // Outer circumference (clockwise)
+                    ctx.BeginFigure(new Point(center.X + outerRadius, center.Y), true, true);
+                    ctx.ArcTo(new Point(center.X - outerRadius, center.Y), new Size(outerRadius, outerRadius), 0, false,
+                        SweepDirection.Clockwise, true, false);
+                    ctx.ArcTo(new Point(center.X + outerRadius, center.Y), new Size(outerRadius, outerRadius), 0, false,
+                        SweepDirection.Clockwise, true, false);
+
+                    if (inner > 0)
+                    {
+                        // Inner circumference (counterclockwise to carve the hole)
+                        ctx.BeginFigure(new Point(center.X + inner, center.Y), true, true);
+                        ctx.ArcTo(new Point(center.X - inner, center.Y), new Size(inner, inner), 0, false,
+                            SweepDirection.Counterclockwise, true, false);
+                        ctx.ArcTo(new Point(center.X + inner, center.Y), new Size(inner, inner), 0, false,
+                            SweepDirection.Counterclockwise, true, false);
+                    }
+                }
+
+                geometry.Freeze();
+                return geometry;
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
@@ -1,4 +1,6 @@
-﻿namespace BrakeDiscInspector_GUI_ROI
+using System;
+
+namespace BrakeDiscInspector_GUI_ROI
 {
     public class ROI
     {
@@ -9,10 +11,46 @@
         public double AngleDeg { get; set; } = 0.0;
         public string Legend { get; set; } = string.Empty;
 
+        public RoiShape Shape { get; set; } = RoiShape.Rectangle;
+        public double R { get; set; }
+        public double RInner { get; set; }
+
         public void EnforceMinSize(double minW = 10, double minH = 10)
         {
             if (Width < minW) Width = minW;
             if (Height < minH) Height = minH;
+
+            if (Shape == RoiShape.Circle || Shape == RoiShape.Annulus)
+            {
+                double diameter = Math.Max(Width, Height);
+                if (R > 0)
+                {
+                    diameter = Math.Max(diameter, R * 2.0);
+                }
+                if (diameter <= 0)
+                {
+                    diameter = Math.Max(minW, minH);
+                }
+
+                R = diameter / 2.0;
+                Width = diameter;
+                Height = diameter;
+
+                if (Shape == RoiShape.Annulus)
+                {
+                    if (RInner < 0) RInner = 0;
+                    if (RInner > R) RInner = R;
+                }
+                else
+                {
+                    RInner = 0;
+                }
+            }
+            else
+            {
+                R = 0;
+                RInner = 0;
+            }
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System;
+using System.Windows;
 using System.Windows.Media;
 
 namespace BrakeDiscInspector_GUI_ROI
@@ -40,9 +41,39 @@ namespace BrakeDiscInspector_GUI_ROI
 
             var rect = new System.Windows.Rect(cx - w / 2, cy - h / 2, w, h);
             var rotate = new RotateTransform(Roi.AngleDeg, cx, cy);
+            var pen = new Pen(Brushes.Lime, 2);
 
             dc.PushTransform(rotate);
-            dc.DrawRectangle(null, new Pen(Brushes.Lime, 2), rect);
+
+            switch (Roi.Shape)
+            {
+                case RoiShape.Rectangle:
+                    dc.DrawRectangle(null, pen, rect);
+                    break;
+                case RoiShape.Circle:
+                    dc.DrawEllipse(null, pen, new System.Windows.Point(cx, cy), w / 2.0, h / 2.0);
+                    break;
+                case RoiShape.Annulus:
+                    {
+                        double outerRadiusX = w / 2.0;
+                        double outerRadiusY = h / 2.0;
+                        double innerRadiusX = Roi.RInner > 0 ? Roi.RInner * sx : outerRadiusX * 0.6;
+                        double innerRadiusY = Roi.RInner > 0 ? Roi.RInner * sy : outerRadiusY * 0.6;
+
+                        innerRadiusX = Math.Max(0, Math.Min(innerRadiusX, outerRadiusX));
+                        innerRadiusY = Math.Max(0, Math.Min(innerRadiusY, outerRadiusY));
+
+                        dc.DrawEllipse(null, pen, new System.Windows.Point(cx, cy), outerRadiusX, outerRadiusY);
+                        if (innerRadiusX > 0 && innerRadiusY > 0)
+                        {
+                            dc.DrawEllipse(null, pen, new System.Windows.Point(cx, cy), innerRadiusX, innerRadiusY);
+                        }
+                        break;
+                    }
+                default:
+                    dc.DrawRectangle(null, pen, rect);
+                    break;
+            }
 
             var dpi = VisualTreeHelper.GetDpi(this);
 


### PR DESCRIPTION
## Summary
- introduce an AnnulusShape and update the layout/overlay rendering so annuli draw both the inner and outer rings
- propagate annulus shape metadata and inner radius through ROI syncing, allowing the adorner to edit the inner radius via a dedicated thumb
- add a regression test that confirms annulus ROIs preserve their inner radius when layouts are serialized

## Testing
- dotnet test ../BrakeDiscInspector_GUI_ROI.sln *(fails: WindowsDesktop SDK is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f8338a8083308f9a3e4ac965452f