### PR TITLE
Allow annulus ROIs to retain editable inner radius

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
@@ -32,6 +32,29 @@ public class BackendPayloadBuilderTests
     }
 
     [Fact]
+    public void SerializeRoiToJson_AnnulusIncludesInnerRadius()
+    {
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Annulus,
+            CX = 180,
+            CY = 120,
+            R = 48,
+            RInner = 20,
+            AngleDeg = 15
+        };
+
+        string json = InvokeSerializeRoiToJson(roi);
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("annulus", root.GetProperty("shape").GetString());
+        Assert.Equal(roi.R, root.GetProperty("r").GetDouble());
+        Assert.Equal(roi.RInner, root.GetProperty("ri").GetDouble());
+    }
+
+    [Fact]
     public void TryGetSearchRect_UsesLeftTopForRectangle()
     {
         var roi = new RoiModel

--- a/gui/BrakeDiscInspector_GUI_ROI/AnnulusDefaults.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AnnulusDefaults.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace BrakeDiscInspector_GUI_ROI
+{
+    internal static class AnnulusDefaults
+    {
+        public const double DefaultInnerRadiusRatio = 0.6;
+
+        public static double ResolveInnerRadius(double requestedInnerRadius, double outerRadius)
+        {
+            if (outerRadius <= 0 || double.IsNaN(outerRadius))
+                return 0;
+
+            if (double.IsNaN(requestedInnerRadius) || requestedInnerRadius <= 0)
+            {
+                return ClampInnerRadius(outerRadius * DefaultInnerRadiusRatio, outerRadius);
+            }
+
+            return ClampInnerRadius(requestedInnerRadius, outerRadius);
+        }
+
+        public static double ClampInnerRadius(double innerRadius, double outerRadius)
+        {
+            if (outerRadius <= 0 || double.IsNaN(outerRadius))
+                return 0;
+
+            double inner = innerRadius;
+            if (double.IsNaN(inner))
+                inner = 0;
+
+            if (inner < 0)
+                inner = 0;
+            if (inner > outerRadius)
+                inner = outerRadius;
+
+            return inner;
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
@@ -12,8 +12,18 @@ namespace BrakeDiscInspector_GUI_ROI
         public string Legend { get; set; } = string.Empty;
 
         public RoiShape Shape { get; set; } = RoiShape.Rectangle;
+        public double CX { get; set; }
+        public double CY { get; set; }
         public double R { get; set; }
         public double RInner { get; set; }
+
+        public void SetCenter(double cx, double cy)
+        {
+            X = cx;
+            Y = cy;
+            CX = cx;
+            CY = cy;
+        }
 
         public void EnforceMinSize(double minW = 10, double minH = 10)
         {
@@ -35,6 +45,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 R = diameter / 2.0;
                 Width = diameter;
                 Height = diameter;
+                CX = X;
+                CY = Y;
 
                 if (Shape == RoiShape.Annulus)
                 {
@@ -51,6 +63,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 R = 0;
                 RInner = 0;
             }
+
+            CX = X;
+            CY = Y;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an annulus defaults helper and extend the overlay ROI model to track centers and inner radii
- update MainWindow annulus conversions and layout rendering so concentric rings are drawn with the stored geometry
- improve the annulus adorner thumb logic and add a regression test to ensure serialized payloads keep the inner radius

## Testing
- `dotnet test gui/BrakeDiscInspector_GUI_ROI.sln` *(fails: WindowsDesktop SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bbc3bfc08330b55046fe3f4f0d9a