### PR TITLE
Remove Annulus option from Master ROI selection

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -54,7 +54,6 @@
                         <ComboBox x:Name="ComboMasterRoiShape" Margin="0,4,0,8">
                             <ComboBoxItem Content="Rectángulo"/>
                             <ComboBoxItem Content="Círculo"/>
-                            <ComboBoxItem Content="Annulus"/>
                         </ComboBox>
                         <WrapPanel>
                             <Button x:Name="BtnSaveMaster" Content="Save Master 1" Click="BtnSaveMaster_Click" Margin="0,0,8,0"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -150,7 +150,6 @@ namespace BrakeDiscInspector_GUI_ROI
             ComboMasterRoiShape.Items.Clear();
             ComboMasterRoiShape.Items.Add("Rectángulo");
             ComboMasterRoiShape.Items.Add("Círculo");
-            ComboMasterRoiShape.Items.Add("Annulus");
             ComboMasterRoiShape.SelectedIndex = 0;
 
 


### PR DESCRIPTION
## Summary
- remove the Annulus option from the Master 1 ROI shape combo box in the ROI GUI
- update the initialization code so only rectangle and circle are added to the Master ROI shape selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c316d5008330b15f06d7f3cc4500