### PR TITLE
Synchronize annulus geometry with shape dimensions

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/AnnulusShape.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AnnulusShape.cs
@@ -23,8 +23,27 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             get
             {
-                double width = RenderSize.Width;
-                double height = RenderSize.Height;
+                double width = Width;
+                if (double.IsNaN(width) || width <= 0)
+                {
+                    width = ActualWidth;
+                }
+
+                if (double.IsNaN(width) || width <= 0)
+                {
+                    width = RenderSize.Width;
+                }
+
+                double height = Height;
+                if (double.IsNaN(height) || height <= 0)
+                {
+                    height = ActualHeight;
+                }
+
+                if (double.IsNaN(height) || height <= 0)
+                {
+                    height = RenderSize.Height;
+                }
 
                 if (double.IsNaN(width) || double.IsNaN(height) || width <= 0 || height <= 0)
                 {


### PR DESCRIPTION
## Summary
- derive the annulus geometry dimensions from the shape's Width/Height before falling back to ActualWidth/ActualHeight/RenderSize
- ensure the inner and outer radii calculations use the synchronized dimensions to keep the ring centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81298b6d88330b2c61863a7a0af12