### PR TITLE
Reduce annulus preview stroke thickness

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -460,7 +460,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 RoiShape.Annulus => new AnnulusShape
                 {
                     Stroke = WBrushes.Lime,
-                    StrokeThickness = 6,
+                    StrokeThickness = 2,
                     Fill = new SolidColorBrush(WColor.FromArgb(30, 0, 255, 0))
                 },
                 _ => null


### PR DESCRIPTION
## Summary
- reduce the annulus preview stroke thickness from 6px to 2px to align with the desired styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81a20e2988330993009e8c5a5b5eb