### PR TITLE
Maintain annulus uniform sizing during corner drags

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Reflection;
+using System.Windows.Controls;
+using BrakeDiscInspector_GUI_ROI;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class RoiAdornerTests
+{
+    [StaFact]
+    public void ResizeByCorner_KeepsAnnulusUniformAndClampsInnerRadius()
+    {
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Annulus,
+            CX = 60,
+            CY = 60,
+            Width = 120,
+            Height = 120,
+            R = 60,
+            RInner = 30
+        };
+
+        var annulus = new AnnulusShape
+        {
+            Width = 120,
+            Height = 120,
+            InnerRadius = 30,
+            Tag = roi
+        };
+
+        Canvas.SetLeft(annulus, 0);
+        Canvas.SetTop(annulus, 0);
+
+        var adorner = new RoiAdorner(annulus, (_, _) => { }, _ => { });
+
+        InvokeResizeByCorner(adorner, 20.0, -20.0, "NE");
+
+        Assert.True(Math.Abs(annulus.Width - annulus.Height) < 1e-6);
+        Assert.True(Math.Abs(roi.Width - roi.Height) < 1e-6);
+
+        annulus.InnerRadius = annulus.Width / 2.0 + 5.0;
+
+        InvokeResizeByCorner(adorner, -40.0, 40.0, "NE");
+
+        Assert.True(Math.Abs(annulus.Width - annulus.Height) < 1e-6);
+        Assert.True(Math.Abs(roi.Width - roi.Height) < 1e-6);
+        Assert.True(annulus.InnerRadius <= annulus.Width / 2.0 + 1e-6);
+    }
+
+    private static void InvokeResizeByCorner(RoiAdorner adorner, double dx, double dy, string cornerName)
+    {
+        var method = typeof(RoiAdorner).GetMethod("ResizeByCorner", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ResizeByCorner not found");
+
+        var cornerType = typeof(RoiAdorner).GetNestedType("Corner", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Corner enum not found");
+
+        object corner = Enum.Parse(cornerType, cornerName);
+
+        method.Invoke(adorner, new[] { (object)dx, (object)dy, corner });
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -335,6 +335,21 @@ namespace BrakeDiscInspector_GUI_ROI
                     break;
             }
 
+            if (roi.Shape == RoiShape.Annulus)
+            {
+                double widthCandidate = newWidth;
+                double heightCandidate = newHeight;
+                double widthDelta = widthCandidate - w;
+                double heightDelta = heightCandidate - h;
+
+                double uniform = Math.Abs(widthDelta) >= Math.Abs(heightDelta)
+                    ? widthCandidate
+                    : heightCandidate;
+
+                newWidth = uniform;
+                newHeight = uniform;
+            }
+
             const double minSize = 10.0;
             newWidth = Math.Max(minSize, newWidth);
             newHeight = Math.Max(minSize, newHeight);
@@ -797,6 +812,13 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void ApplyResizeResult(Point center, double width, double height, double angleDeg, RoiModel roi)
         {
+            if (roi.Shape == RoiShape.Annulus)
+            {
+                double uniform = (width + height) / 2.0;
+                width = uniform;
+                height = uniform;
+            }
+
             double left = center.X - width / 2.0;
             double top = center.Y - height / 2.0;
 


### PR DESCRIPTION
## Summary
- enforce uniform width and height updates for annulus ROIs when resizing from a corner
- normalize annulus dimensions in ApplyResizeResult so the rendered shape stays square and inner radius clamps correctly
- add an STA unit test exercising annulus corner drags to confirm width/height synchronization and inner-radius clamping

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82202f46c8330a723cf28e1dd9670