### PR TITLE
Replace match_one alias with url rule

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -274,7 +274,6 @@ def upload_roi():
     dest.write_bytes(f.read())
     return jsonify({"ok": True, "saved": str(dest)})
 
-@app.post("/match_one")
 @app.route("/match_master", methods=["POST"])
 def match_master():
     """
@@ -634,10 +633,7 @@ def match_master():
     return jsonify(resp)
 
 
-@app.post("/match_one")
-def match_one():
-    """Alias de compatibilidad que reutiliza la lógica de ``match_master``."""
-    return match_master()
+app.add_url_rule("/match_one", view_func=match_master, methods=["POST"])
 
 
 @app.post("/analyze")


### PR DESCRIPTION
## Summary
- remove the duplicate /match_one decorator for match_master
- register /match_one as an alias of match_master with add_url_rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9068efb388330bad81a92b7becb15