### PR TITLE
Refine PatchCore DINOv2 backend

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import torch
 import numpy as np
-from typing import Tuple
+from typing import Tuple, Sequence
 
 try:
     import timm
@@ -9,12 +9,24 @@ except Exception:
     timm = None
 
 class DinoV2Features:
+    """Wrapper ligero para la extracción de embeddings con DINOv2 ViT-S/14.
+
+    - El modelo se carga congelado (`eval()` y sin gradientes).
+    - La entrada se redimensiona a un tamaño múltiplo del `patch_size`.
+    - Permite obtener tokens de varias capas internas (`out_indices`) y concatenarlos
+      para una representación multi-escala sencilla.
+    - Devuelve los embeddings L2-normalizados (N_tokens, D_concat) y la forma del
+      grid de tokens (H_tokens, W_tokens).
     """
-    DINOv2 ViT-S/14 extractor (frozen). Ajusta input al múltiplo del patch (14).
-    Devuelve (embeddings: [N,D], token_hw: (H,W)).
-    """
-    def __init__(self, model_name: str = "vit_small_patch14_dinov2.lvd142m",
-                 device: str = "auto", input_size: int = 448, patch_size: int = 14):
+
+    def __init__(
+        self,
+        model_name: str = "vit_small_patch14_dinov2.lvd142m",
+        device: str = "auto",
+        input_size: int = 448,
+        patch_size: int = 14,
+        out_indices: Sequence[int] | None = (9, 11),
+    ):
         if timm is None:
             raise RuntimeError("timm no está disponible. Añádelo a requirements.txt e instala dependencias.")
         self.device = self._pick_device(device)
@@ -23,8 +35,10 @@ class DinoV2Features:
         for p in self.model.parameters():
             p.requires_grad_(False)
         self.model.to(self.device)
+        self.model_name = model_name
         self.patch = patch_size
         self.input_size = self._snap_to_patch(input_size, patch_size)
+        self.out_indices = tuple(sorted(out_indices)) if out_indices else None
         self.mean = torch.tensor([0.485, 0.456, 0.406], device=self.device).view(1,3,1,1)
         self.std  = torch.tensor([0.229, 0.224, 0.225], device=self.device).view(1,3,1,1)
 
@@ -52,28 +66,71 @@ class DinoV2Features:
         x = (x.to(self.device) - self.mean) / self.std
         return x
 
-    def extract(self, img_bgr: np.ndarray) -> Tuple[np.ndarray, Tuple[int,int]]:
+    def extract(self, img_bgr: np.ndarray) -> Tuple[np.ndarray, Tuple[int, int]]:
         x = self._preprocess(img_bgr)
         with torch.inference_mode():
+            tokens = self._forward_tokens(x)
+
+        emb = tokens.detach().cpu().numpy()
+        emb = self._l2_normalize(emb)
+        n = emb.shape[0]
+        h = w = int(round(n ** 0.5))
+        if h * w != n:
+            raise RuntimeError(f"Forma de tokens inesperada: {n}")
+        return emb, (h, w)
+
+    def _forward_tokens(self, x: torch.Tensor) -> torch.Tensor:
+        if self.out_indices and hasattr(self.model, "get_intermediate_layers"):
+            try:
+                layers = self.model.get_intermediate_layers(
+                    x,
+                    self.out_indices,
+                    reshape=True,
+                    return_class_token=False,
+                )
+            except TypeError:
+                # Algunas implementaciones esperan un entero y devuelven las últimas `n` capas.
+                layers = self.model.get_intermediate_layers(
+                    x,
+                    len(self.out_indices),
+                    reshape=True,
+                    return_class_token=False,
+                )
+            feats = []
+            for layer in layers:
+                if layer.ndim == 4:
+                    # (B, H, W, C)
+                    b, h, w, c = layer.shape
+                    feats.append(layer.reshape(b, h * w, c))
+                elif layer.ndim == 3:
+                    feats.append(layer)
+                else:
+                    raise RuntimeError(f"Forma inesperada en capa intermedia: {layer.shape}")
+            tokens = torch.cat(feats, dim=-1)
+        else:
             feats = self.model.forward_features(x)
             if isinstance(feats, dict):
-                t = feats.get("x", None) or feats.get("tokens", None)
+                t = feats.get("x") or feats.get("tokens")
                 if t is None:
                     t = max((v for v in feats.values() if isinstance(v, torch.Tensor)), key=lambda u: u.numel())
             else:
                 t = feats
             if t.ndim == 3:
-                b,n,c = t.shape
-                h = w = int(n**0.5)
-                if h*w != n and n>1 and int((n-1)**0.5)**2 == (n-1):
-                    t = t[:,1:,:]; n -= 1; h = w = int(n**0.5)
-                tok = t[0]  # (N,C)
-                emb = tok.detach().cpu().numpy()
-                return emb, (h,w)
+                if t.shape[1] == self._expected_tokens(t.shape[1]):
+                    tokens = t
+                else:
+                    tokens = t[:, 1:, :]
             elif t.ndim == 4:
-                b,c,h,w = t.shape
-                tok = t[0].permute(1,2,0).reshape(h*w, c)
-                emb = tok.detach().cpu().numpy()
-                return emb, (h,w)
+                b, c, h, w = t.shape
+                tokens = t.permute(0, 2, 3, 1).reshape(b, h * w, c)
             else:
                 raise RuntimeError(f"Forma inesperada de features: {t.shape}")
+        return tokens[0]
+
+    def _expected_tokens(self, n: int) -> int:
+        r = int(round(n ** 0.5))
+        return r * r
+
+    def _l2_normalize(self, emb: np.ndarray, eps: float = 1e-8) -> np.ndarray:
+        norm = np.linalg.norm(emb, axis=1, keepdims=True) + eps
+        return emb / norm

--- a/backend/infer.py
+++ b/backend/infer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import numpy as np
 import cv2
-from typing import Tuple, Optional, Dict, Any
+from typing import Tuple, Optional, Dict, Any, List
 
 from .features import DinoV2Features
 from .patchcore import PatchCoreMemory
@@ -21,13 +21,15 @@ class InferenceEngine:
                  token_hw: Tuple[int, int],
                  mm_per_px: float,
                  k: int = 1,
-                 score_percentile: int = 99):
+                 score_percentile: int = 99,
+                 memory_metadata: Optional[Dict[str, Any]] = None):
         self.extractor = extractor
         self.memory = memory
         self.token_hw = token_hw  # (Ht, Wt) con el que se construyó la memoria
         self.mm_per_px = float(mm_per_px)
         self.k = int(k)
         self.score_p = int(score_percentile)
+        self.memory_metadata = memory_metadata or {}
 
     def run(self,
             img_bgr: np.ndarray,
@@ -39,7 +41,7 @@ class InferenceEngine:
         Devuelve:
           {
             "score": float,
-            "threshold": float (0 si no hay),
+            "threshold": Optional[float],
             "heatmap_u8": np.uint8[H,W]  (normalizado 0..255 y enmascarado),
             "regions": [ {"bbox":[x,y,w,h], "area_px":..., "area_mm2":...}, ... ],
             "token_shape": [Ht, Wt]
@@ -50,39 +52,44 @@ class InferenceEngine:
 
         # 2) Distancias kNN por parche (min-dist al coreset)
         d = self.memory.knn_min_dist(emb)  # (N,)
-        heat = d.reshape(Ht, Wt)
+        heat = d.reshape(Ht, Wt).astype(np.float32)
 
         # 3) Reescalar a tamaño del ROI (para overlay)
         H, W = img_bgr.shape[:2]
-        heat_up = cv2.resize(heat, (W, H), interpolation=cv2.INTER_LINEAR)
+        heat_up = cv2.resize(heat, (W, H), interpolation=cv2.INTER_LINEAR).astype(np.float32)
 
         # 4) Suavizado opcional
         if blur_sigma and blur_sigma > 0:
             ksize = int(max(3, round(blur_sigma * 3) * 2 + 1))
-            heat_up = cv2.GaussianBlur(heat_up, (ksize, ksize), blur_sigma)
+            heat_proc = cv2.GaussianBlur(heat_up, (ksize, ksize), blur_sigma)
+        else:
+            heat_proc = heat_up
 
-        # 5) Normalización robusta a 0..255 para visualización
-        h_norm = heat_up.astype(np.float32)
-        if h_norm.size > 0:
-            mn, mx = np.percentile(h_norm, 1), np.percentile(h_norm, 99)
-            if mx > mn:
-                h_norm = (h_norm - mn) / (mx - mn)
-            h_norm = np.clip(h_norm, 0.0, 1.0)
-        heat_u8 = (h_norm * 255.0 + 0.5).astype(np.uint8)
-
-        # 6) Máscara del ROI (rect/circle/annulus) si viene descrita
+        # 5) Máscara del ROI (rect/circle/annulus) si viene descrita
         mask = build_mask(H, W, shape)
-        heat_u8_masked = cv2.bitwise_and(heat_u8, heat_u8, mask=mask)
+        mask_bool = mask > 0
 
-        # 7) Score global (percentil sobre zona enmascarada)
-        valid = heat_u8_masked[mask > 0]
+        # 6) Score global sobre el heatmap suavizado y enmascarado
+        valid = heat_proc[mask_bool]
         sc = percentile(valid, self.score_p) if valid.size else 0.0
 
+        # 7) Generar heatmap 0..255 para visualización
+        heat_vis = np.zeros_like(heat_proc, dtype=np.float32)
+        if valid.size:
+            mn, mx = np.percentile(valid, [1, 99])
+            if mx > mn:
+                heat_vis[mask_bool] = np.clip((heat_proc[mask_bool] - mn) / (mx - mn), 0.0, 1.0)
+            else:
+                heat_vis[mask_bool] = 0.0
+        heat_u8 = (heat_vis * 255.0 + 0.5).astype(np.uint8)
+        heat_u8_masked = cv2.bitwise_and(heat_u8, heat_u8, mask=mask)
+
         # 8) Umbral + eliminación de islas pequeñas + contornos
-        regions = []
-        thr = threshold if threshold is not None else 0.0
-        if threshold is not None:
-            _, bin_img = cv2.threshold(heat_u8_masked, int(round(threshold)), 255, cv2.THRESH_BINARY)
+        regions: List[Dict[str, Any]] = []
+        thr_value = float(threshold) if threshold is not None else None
+        if thr_value is not None:
+            bin_img = np.zeros((H, W), dtype=np.uint8)
+            bin_img[mask_bool & (heat_proc >= thr_value)] = 255
             # Elimina regiones con área < área mínima (en mm² → px²)
             px_thr = mm2_to_px2(area_mm2_thr, self.mm_per_px)
             cnts, _ = cv2.findContours(bin_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
@@ -90,7 +97,6 @@ class InferenceEngine:
                 area_px = cv2.contourArea(c)
                 if area_px < px_thr:
                     cv2.drawContours(bin_img, [c], -1, 0, thickness=-1)
-            # Recalcular contornos tras limpieza
             cnts, _ = cv2.findContours(bin_img, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
             for c in cnts:
                 x, y, w, h = cv2.boundingRect(c)
@@ -99,12 +105,30 @@ class InferenceEngine:
                     "bbox": [int(x), int(y), int(w), int(h)],
                     "area_px": float(area_px),
                     "area_mm2": float(px2_to_mm2(area_px, self.mm_per_px)),
+                    "contour": contour_to_list(c),
                 })
+            regions.sort(key=lambda r: r["area_px"], reverse=True)
 
         return {
             "score": float(sc),
-            "threshold": float(thr),
+            "threshold": float(thr_value) if thr_value is not None else None,
             "heatmap_u8": heat_u8_masked,   # la API lo convertirá a PNG base64
             "regions": regions,
             "token_shape": [int(Ht), int(Wt)],
+            "params": {
+                "extractor": self.extractor.model_name,
+                "input_size": int(self.extractor.input_size),
+                "patch_size": int(self.extractor.patch),
+                "coreset_rate": float(self.memory.coreset_rate) if self.memory.coreset_rate is not None else None,
+                "coreset_rate_applied": self.memory_metadata.get("applied_rate"),
+                "k": int(self.k),
+                "score_percentile": int(self.score_p),
+                "blur_sigma": float(blur_sigma),
+                "mm_per_px": float(self.mm_per_px),
+            },
         }
+
+
+def contour_to_list(contour: np.ndarray) -> List[List[int]]:
+    pts = contour.reshape(-1, 2)
+    return [[int(x), int(y)] for x, y in pts]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ opencv-python>=4.8
 scikit-learn>=1.3
 scipy>=1.10
 pillow>=10.0
+python-multipart>=0.0.6


### PR DESCRIPTION
## Summary
- expose PatchCore training metadata (requested/applied coreset rate) and persist it alongside the memory artifacts
- enrich inference by using float distance maps, ROI masking, contour export, and returning configuration metadata
- update the DinoV2 feature extractor to support multi-layer embeddings and document the new API capabilities
- refresh backend documentation and add python-multipart to the dependencies list

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d96a07b10483308eb6669f4bacc73d