### PR TITLE
Ensure backend torch install pulls from PyTorch index

### DIFF
--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -22,7 +22,9 @@ source .venv/bin/activate
 pip install -r backend/requirements.txt
 ```
 
-> Si `faiss-cpu` falla en tu plataforma, el servicio seguirá funcionando con `sklearn` (`NearestNeighbors`).  
+> **PyTorch** se descarga desde el índice oficial de PyTorch gracias a la opción `--extra-index-url` incluida en `requirements.txt`.
+> Si tu red bloquea dominios externos, instala manualmente la rueda adecuada (`torch==2.1.2` CPU) y vuelve a ejecutar `pip install -r backend/requirements.txt`.
+> Si `faiss-cpu` falla en tu plataforma, el servicio seguirá funcionando con `sklearn` (`NearestNeighbors`).
 > Asegúrate de tener **Python 3.10+** y **pip** actualizado (`python -m pip install -U pip`).
 
 ---

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
-torch>=2.1
-timm>=0.9.12
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.1.2
+timm==0.9.12
 faiss-cpu; platform_machine != "arm64"
 faiss-cpu==1.7.4.post2; platform_machine == "arm64" and sys_platform == "darwin"
 fastapi>=0.110


### PR DESCRIPTION
## Summary
- add the official PyTorch CPU index to backend requirements and pin torch/timm versions
- document the PyTorch download source and offline installation fallback in the backend README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d990a83d6c8330bdd2819f9ad19653