### PR TITLE
Relax torch requirement for CPU wheels

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.1.2
+torch>=2.2,<3
 timm==0.9.12
 faiss-cpu; platform_machine != "arm64"
 faiss-cpu==1.7.4.post2; platform_machine == "arm64" and sys_platform == "darwin"


### PR DESCRIPTION
## Summary
- relax the backend torch dependency to any CPU wheel in the 2.x series

## Testing
- pip install -r backend/requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68da563cdbe88330a23d5a6cefe2b982