### PR TITLE
Handle backend app imports when run as a script

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+import sys
 import traceback
 from typing import Optional, Dict, Any, List
 from pathlib import Path
@@ -17,12 +18,26 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
         "Install backend requirements with 'python -m pip install -r backend/requirements.txt'."
     ) from exc
 
-from .features import DinoV2Features
-from .patchcore import PatchCoreMemory
-from .storage import ModelStore
-from .infer import InferenceEngine
-from .calib import choose_threshold
-from .utils import ensure_dir, base64_from_bytes
+if __package__ in (None, ""):
+    # Allow running as a script: `python app.py`
+    backend_dir = Path(__file__).resolve().parent
+    project_root = backend_dir.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    from backend.features import DinoV2Features  # type: ignore[no-redef]
+    from backend.patchcore import PatchCoreMemory  # type: ignore[no-redef]
+    from backend.storage import ModelStore  # type: ignore[no-redef]
+    from backend.infer import InferenceEngine  # type: ignore[no-redef]
+    from backend.calib import choose_threshold  # type: ignore[no-redef]
+    from backend.utils import ensure_dir, base64_from_bytes  # type: ignore[no-redef]
+else:
+    from .features import DinoV2Features
+    from .patchcore import PatchCoreMemory
+    from .storage import ModelStore
+    from .infer import InferenceEngine
+    from .calib import choose_threshold
+    from .utils import ensure_dir, base64_from_bytes
 
 app = FastAPI(title="Anomaly Backend (PatchCore + DINOv2)")
 


### PR DESCRIPTION
## Summary
- add a direct-execution guard in `backend/app.py` that augments `sys.path` with the project root when `__package__` is unset
- switch the fallback imports to absolute `backend.*` modules while preserving the existing relative imports for package execution

## Testing
- python app.py
- python -m uvicorn backend.app:app --port 8001


------
https://chatgpt.com/codex/tasks/task_e_68da643473148330bbd15dfaf4b11ee2