### PR TITLE
Constrain backend NumPy dependency to 1.x releases

### DIFF
--- a/backend/environment.yml
+++ b/backend/environment.yml
@@ -9,4 +9,4 @@ dependencies:
       - flask-cors
       - opencv-python
       - tensorflow
-      - numpy
+      - numpy>=1.24,<2.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ faiss-cpu; platform_machine != "arm64"
 faiss-cpu==1.7.4.post2; platform_machine == "arm64" and sys_platform == "darwin"
 fastapi>=0.110
 uvicorn[standard]>=0.23
-numpy>=1.24
+numpy>=1.24,<2.0
 opencv-python>=4.8
 scikit-learn>=1.3
 scipy>=1.10


### PR DESCRIPTION
## Summary
- limit the backend's NumPy requirement to the 1.x series in requirements.txt to avoid incompatibilities with current PyTorch wheels
- apply the same NumPy constraint in the Conda environment file to keep pip and Conda setups aligned

## Testing
- backend/.venv/bin/pip install -r backend/requirements.txt
- backend/.venv/bin/python backend/app.py

------
https://chatgpt.com/codex/tasks/task_e_68da6f33f6e88330b43b475552fcdbad