### PR TITLE
docs: refresh markdown for patchcore backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,23 +1,23 @@
 
 # ARCHITECTURE — BrakeDiscInspector
 
-Este documento describe la arquitectura funcional del sistema, sus componentes, el flujo de datos extremo a extremo, el mapeo de coordenadas GUI↔imagen, y los puntos de extensión.
+Este documento describe la arquitectura actual (GUI + backend), el flujo de datos extremo a extremo y las zonas donde se pueden extender las funcionalidades sin romper contratos existentes.
 
 ---
 
 ## 1) Visión general
 
-El sistema está compuesto por dos procesos principales:
+El sistema consta de dos procesos cooperando en tiempo real:
 
-- **GUI (WPF / .NET)**: captura la imagen, permite dibujar/rotar el ROI, envía el **crop ya rotado** al backend, y muestra `label/score/threshold` + **heatmap**.
-- **Backend (Flask / Python)**: recibe el crop, aplica *letterbox* y normalización, infiere con el modelo (TensorFlow), genera **Grad‑CAM** y devuelve resultados.
+- **GUI (WPF / .NET 8)**: captura imágenes, permite dibujar/rotar la ROI, gestiona datasets de muestras, llama al backend para entrenar/calibrar/inferir y superpone heatmaps sobre el ROI canónico.
+- **Backend (FastAPI / Python 3.10+)**: recibe el ROI ya canónico, extrae embeddings con DINOv2, aplica memoria PatchCore y genera score + heatmap + regiones.
 
 ```mermaid
 flowchart LR
-    A[Usuario] -->|Carga imagen / Dibuja ROI| G[WPF GUI<br/>OpenCvSharp]
-    G -->|/analyze<br/>PNG rotado + (mask/annulus)| B[(Flask + TF + OpenCV)]
-    B -->|label / score / threshold / heatmap| G
-    G -->|Visualiza resultado| A
+    U[Usuario] -->|Carga imagen / Gestiona dataset| G[GUI WPF<br/>OpenCvSharp]
+    G -->|/fit_ok, /calibrate_ng, /infer| B[(FastAPI<br/>PatchCore + DINOv2)]
+    B -->|n_embeddings / threshold / heatmap / regiones| G
+    G -->|Overlay + reporting| U
 ```
 
 ---
@@ -25,64 +25,67 @@ flowchart LR
 ## 2) Componentes
 
 ### 2.1 GUI (WPF)
-- **MainWindow.xaml(.cs)**: orquesta UI, eventos, y acciones del usuario (cargar imagen, botón Analyze).
-- **ROI/**:
-  - `ROI.cs`: modelo de ROI (`X`, `Y`, `Width`, `Height`, `AngleDeg`, `Legend`).
-  - `RoiAdorner.cs`: adorner de edición (mover, redimensionar y rotar mediante thumb NE).
-- **Overlays/**:
-  - `RoiOverlay.cs`: dibuja el ROI en el `CanvasROI` **alineado** con el área visible del `<Image>` (letterbox).
-- **BackendAPI.cs**: cliente HTTP tipado (POST `/analyze`, GET `/train_status`, POST `/match_master` alias `/match_one`).
-- **appsettings.json**: `Backend.BaseUrl`.
 
-### 2.2 Backend (Flask)
-- **app.py**:
-  - Endpoints: `/analyze`, `/train_status`, `/match_master` (alias `/match_one`).
-  - Carga modelo `model/current_model.h5` y umbral `model/threshold.txt`.
-  - Preprocesado (*letterbox*), inferencia, **Grad‑CAM**, codificación heatmap a PNG Base64.
-- **utils/**: utilidades (`letterbox`, `masks/annulus`, `heatmap Grad‑CAM`, `schemas`).
-- **logs/**: `backend.log`.
+- **MainWindow.xaml / .cs**: orquesta la UI, pestañas de Dataset/Train/Infer y binding con ViewModels.
+- **ROI/**: clases de dominio (`ROI.cs`, `ROIShape.cs`, `AnnulusShape.cs`, etc.) y adorners (`RoiAdorner`, `RoiRotateAdorner`, `ResizeAdorner`). **No modificar** geometrías ni pipelines de canonicalización.
+- **Overlays/**: `RoiOverlay.cs` y helpers que sincronizan el canvas con la imagen (`Stretch="Uniform"`).
+- **BackendClient.cs** (o `BackendAPI.cs`): cliente HTTP async que implementa `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` usando `HttpClient` y `MultipartFormDataContent`.
+- **Datasets/**: utilidades para guardar PNG + metadata JSON por `(role_id, roi_id)` en `datasets/<role>/<roi>/<ok|ng>/`.
+
+### 2.2 Backend (FastAPI)
+
+- **app.py**: define endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` y maneja orquestación de inferencia (lectura de archivos, respuesta JSON).【F:backend/app.py†L1-L199】
+- **features.py**: wrapper sobre `timm` para cargar `vit_small_patch14_dinov2.lvd142m`, normalizar entrada y devolver embeddings + `token_shape`.【F:backend/features.py†L1-L200】
+- **patchcore.py**: implementación del coreset k-center greedy y kNN (FAISS/NearestNeighbors).【F:backend/patchcore.py†L1-L200】
+- **infer.py**: lógica de inferencia (distancias→heatmap→score→contornos) e integración con máscaras (`roi_mask.py`).【F:backend/infer.py†L1-L200】
+- **storage.py**: persistencia de `memory.npz`, `index.faiss` y `calib.json` en `models/<role>/<roi>/`.【F:backend/storage.py†L1-L200】
+- **calib.py**: cálculo del umbral a partir de scores OK/NG (percentiles configurables).【F:backend/calib.py†L1-L160】
 
 ---
 
-## 3) Flujo de datos (end‑to‑end)
+## 3) Flujo de datos (end-to-end)
 
 ```mermaid
 sequenceDiagram
     participant U as Usuario
-    participant GUI as WPF GUI
-    participant CV as OpenCvSharp
-    participant BE as Flask Backend
-    participant TF as TensorFlow Model
+    participant GUI as GUI WPF
+    participant ROI as Canonical ROI Pipeline
+    participant BE as Backend FastAPI
+    participant PC as PatchCore/DINOv2
 
-    U->>GUI: Cargar imagen
-    GUI->>CV: BitmapSource -> Mat (BGR)
-    U->>GUI: Dibuja + rota ROI
-    GUI->>CV: WarpAffine (rotación en imagen completa)
-    GUI->>CV: Recorte ROI -> crop (Mat)
-    GUI->>GUI: ImEncode(".png") -> byte[]
-    GUI->>BE: POST /analyze (PNG + mask/annulus opcional)
-    BE->>BE: Decode PNG -> BGR
-    BE->>BE: (mask o annulus) -> enmascarar
-    BE->>BE: letterbox a INPUT_SIZE
-    BE->>TF: forward(pass) -> score
-    BE->>BE: Grad‑CAM -> heatmap PNG (Base64)
-    BE-->>GUI: {label, score, threshold, heatmap_png_b64}
-    GUI->>GUI: Mostrar label/score + heatmap
+    U->>GUI: Cargar imagen / ajustar ROI
+    GUI->>ROI: Exportar ROI canónico (crop + rotación)
+    GUI->>Datasets: Guardar PNG + metadata (opcional)
+    GUI->>BE: POST /fit_ok (images[])
+    BE->>PC: Extraer embeddings + coreset + persistir memoria
+    GUI->>BE: POST /calibrate_ng (scores OK/NG)
+    BE->>storage: Guardar calib.json
+    GUI->>BE: POST /infer (image + shape)
+    BE->>PC: Calcular distancias → heatmap → score
+    PC->>BE: Contornos + regiones filtradas por área_mm²
+    BE-->>GUI: JSON (score, threshold, heatmap_png_base64, regions)
+    GUI->>GUI: Superponer heatmap + mostrar métricas
 ```
+
+Notas clave:
+- El backend **no** realiza rotaciones ni recortes; depende del ROI canónico generado en la GUI.
+- La máscara `shape` permite limitar el área evaluada (rectángulo, círculo o annulus) dentro del ROI canónico.
 
 ---
 
-## 4) Mapeo de coordenadas y *letterbox*
+## 4) Sincronización de coordenadas GUI ↔ imagen
 
-### 4.1 Alineación CanvasROI al `<Image Stretch="Uniform">`
-Para sincronizar el canvas (overlay) con el área visible de la imagen renderizada:
+### 4.1 Letterboxing y canvas
+
+La imagen principal se muestra con `Stretch="Uniform"`. El canvas que contiene adorners y overlays replica la zona visible mediante:
 
 ```
-scale = min(ImgMain.ActualWidth / PixelWidth, ImgMain.ActualHeight / PixelHeight)
+scale = min(ImageHost.ActualWidth  / PixelWidth,
+            ImageHost.ActualHeight / PixelHeight)
 drawWidth  = PixelWidth  * scale
 drawHeight = PixelHeight * scale
-offsetX = (ImgMain.ActualWidth  - drawWidth)  / 2
-offsetY = (ImgMain.ActualHeight - drawHeight) / 2
+offsetX = (ImageHost.ActualWidth  - drawWidth)  / 2
+offsetY = (ImageHost.ActualHeight - drawHeight) / 2
 
 CanvasROI.Width  = drawWidth
 CanvasROI.Height = drawHeight
@@ -90,74 +93,55 @@ Canvas.SetLeft(CanvasROI, offsetX)
 Canvas.SetTop(CanvasROI,  offsetY)
 ```
 
-### 4.2 Conversión imagen ↔ canvas
-- **Imagen → Canvas** (para pintar/adorners):
-  ```
-  sx = CanvasROI.Width  / PixelWidth
-  sy = CanvasROI.Height / PixelHeight
-  canvasX = imageX * sx
-  canvasY = imageY * sy
-  ```
-- **Canvas → Imagen** (si hiciera falta):
-  ```
-  imageX = (canvasX) / sx
-  imageY = (canvasY) / sy
-  ```
+### 4.2 Conversión de coordenadas
 
-### 4.3 Rotación del ROI (GUI)
-- Se rota la **imagen completa** alrededor del centro `(ROI.X, ROI.Y)` con `Cv2.GetRotationMatrix2D` y `Cv2.WarpAffine`.
-- Después se recorta la subimagen (`Rect(x,y,w,h)`), garantizando **mínimo 10×10**.
+- **Imagen → Canvas**: `(canvasX, canvasY) = (imageX * sx, imageY * sy)` con `sx = CanvasROI.Width / PixelWidth`.
+- **Canvas → Imagen**: `(imageX, imageY) = (canvasX / sx, canvasY / sy)`.
 
-> Esta estrategia evita inconsistencias de coordenadas cuando el usuario rota el ROI: siempre enviamos un PNG ya rotado que el backend puede consumir sin conocer el ángulo.
+### 4.3 Canonicalización del ROI
+
+La GUI reutiliza el mismo pipeline que “Save Master/Pattern” (`TryBuildRoiCropInfo(...)` → `TryGetRotatedCrop(...)`) para:
+1. Rotar la imagen completa alrededor del centro del ROI (`Cv2.GetRotationMatrix2D` + `Cv2.WarpAffine`).
+2. Recortar el subrectángulo resultante (mínimo 10×10 px).
+3. Generar PNG + metadata JSON; el tamaño resultante define el espacio para el heatmap devuelto.
 
 ---
 
-## 5) Backend — preprocesado e inferencia
+## 5) Backend — inferencia y persistencia
 
-1. **Decodificar** PNG (BGR).
-2. **Máscara/Annulus** (opcional):
-   - `mask` PNG binaria: `img[mask==0] = 0`.
-   - `annulus` JSON: rellena anillo `(cx,cy,ri,ro)` y anula el resto.
-3. **Letterbox** al tamaño de entrada del modelo (p.ej. 224×224) preservando la relación de aspecto y con bordes negros.
-4. **Inferencia (TensorFlow)**: salida `score ∈ [0,1]` (NG score).
-5. **Decisión**: `label = "NG"` si `score ≥ threshold`, si no `"OK"`.
-6. **Grad‑CAM**: localizar la última `Conv2D`, calcular mapa normalizado, reescalar a entrada, mezclar con la imagen (*overlay*) y **codificar en PNG Base64**.
-7. **Respuesta**:
-   ```json
-   {"label","score","threshold","heatmap_png_b64"}
-   ```
+1. **Lectura**: el archivo recibido (`UploadFile`) se decodifica con `cv2.imdecode` a BGR (`np.uint8`).
+2. **Carga de memoria**: `storage.ModelStore.load_memory()` obtiene embeddings (`memory.npz`) y metadatos (`token_shape`, `coreset_rate`). Se reconstruye FAISS si existe `index.faiss`.
+3. **Embeddings**: `DinoV2Features.extract()` realiza resize al tamaño soportado (múltiplo de 14, por defecto 448) y devuelve `embeddings` + `(Ht, Wt)`.
+4. **PatchCore**: `InferenceEngine.run()` calcula distancias kNN (`k=1`), interpola el mapa a tamaño ROI, aplica blur, máscara `shape`, percentile `p_score` y filtrado por `area_mm2_thr` (conversión px/mm²).
+5. **Respuesta**: se codifica el heatmap en PNG Base64 y se devuelven `score`, `threshold`, `regions` (bbox, área px/mm², contorno) y `token_shape`.
+
+Persistencia:
+- `/fit_ok` guarda `memory.npz` con `emb`, `token_h`, `token_w` y metadata del coreset.
+- `/calibrate_ng` guarda `calib.json` con `threshold`, `p99_ok`, `p5_ng`, `mm_per_px`, `area_mm2_thr`, `score_percentile`.
+- `/infer` reutiliza los artefactos anteriores sin reentrenar.
 
 ---
 
-## 6) Errores típicos y manejo
+## 6) Extensibilidad segura
 
-- **CS1674 (using con `ImEncode`)**: `ImEncode` devuelve `byte[]` → **no** se usa `using`.
-- **CS1061 (`ToWriteableBitmap`)**: usar `BitmapSourceConverter.ToBitmapSource(mat)` (paquete `OpenCvSharp4.Extensions`).
-- **Adorner desalineado**: ejecutar `SyncOverlayToImage()` **antes** de crear el adorner y cuando cambie el tamaño (`SizeChanged`).
-- **Handle de rotación no aparece**: comprobar que el adorner está anclado a `CanvasROI` y el centro devuelve coordenadas de **canvas** (no de imagen).
-
-El backend devuelve errores legibles (`400` entrada inválida, `500` excepción). En ambos procesos se registran logs (`backend/logs/backend.log`, GUI opcional).
+- **GUI**: se pueden añadir nuevas vistas, comandos o reportes siempre que se reutilice la canonicalización existente y no se modifiquen adorners u overlays base.
+- **Backend**: las extensiones deben mantener estables los endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`. Nuevas rutas deben documentarse en `API_REFERENCE.md`.
+- **Persistencia**: cualquier cambio en el formato de `memory.npz`, `index.faiss` o `calib.json` requiere versionado explícito y migraciones.
+- **Observabilidad**: revisar `LOGGING.md` para mantener la correlación GUI↔backend (`X-Correlation-Id`) y la rotación de logs.
 
 ---
 
-## 7) Configuración
+## 7) Recursos cruzados
 
-- **GUI**: `gui/BrakeDiscInspector_GUI_ROI/appsettings.json`
-  ```json
-  { "Backend": { "BaseUrl": "http://127.0.0.1:5000" } }
-  ```
-- **Backend**:
-  - Modelo: `backend/model/current_model.h5`
-  - Umbral: `backend/model/threshold.txt` (p. ej., `0.57`)
-  - Tamaño de entrada (`INPUT_SIZE`) en `app.py`.
+- [API_REFERENCE.md](API_REFERENCE.md) — contratos HTTP detallados y ejemplos `curl`.
+- [DATA_FORMATS.md](DATA_FORMATS.md) — estructuras JSON, metadatos y archivos generados.
+- [DEV_GUIDE.md](DEV_GUIDE.md) — preparación de entorno, scripts y debugging.
+- [ROI_AND_MATCHING_SPEC.md](ROI_AND_MATCHING_SPEC.md) — definición formal del ROI canónico y máscaras.
+- [backend/README_backend.md](backend/README_backend.md) — guía operativa del microservicio.
 
 ---
 
-## 8) Puntos de extensión
-
-- **Nuevos endpoints**: agregar en `app.py` y documentar en `API_REFERENCE.md`.
-- **Cambiar modelo**: sustituir `current_model.h5` y ajustar `INPUT_SIZE`/preprocesado.
-- **Máscaras avanzadas**: soportar *multipart* con múltiples `mask` o parámetros adicionales.
+Para cualquier modificación sustancial, coordina con los responsables listados en `docs/mcp/overview.md` y registra el cambio en `docs/mcp/latest_updates.md`.
 - **Mejoras GUI**: snapping, restricción angular, sectores en annulus, múltiples ROIs y *batch analyze*.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,149 +1,98 @@
-
 # CONTRIBUTING — BrakeDiscInspector
 
-Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**.  
-Este documento define las reglas y el flujo de trabajo para colaborar en el repositorio.
+Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este documento describe el flujo de colaboración y las normas de estilo para el backend FastAPI y la GUI WPF.
 
 ---
 
 ## 1) Código de conducta
 
-- Respeto mutuo entre contribuidores.
-- Feedback técnico y constructivo, no personal.
-- No incluir datos sensibles (clientes, hardware propietario, etc.).
-- Issues y PRs en inglés preferiblemente para mayor alcance.
+- Respeto y comunicación clara entre contribuidores.
+- No incluir datos sensibles ni información propietaria.
+- Issues y PRs en inglés cuando sea posible para facilitar la revisión global.
 
 ---
 
-## 2) Cómo empezar
+## 2) Primeros pasos
 
-1. **Fork** del repositorio en GitHub.  
-2. **Clonar** tu fork:
+1. Realiza un **fork** del repositorio.
+2. Clona tu fork y crea una rama descriptiva:
    ```bash
    git clone https://github.com/<tu_usuario>/BrakeDiscInspector.git
    cd BrakeDiscInspector
+   git checkout -b feat/nueva-funcionalidad
    ```
-3. Crear rama de feature/fix:
-   ```bash
-   git checkout -b feature/mi-mejora
-   ```
+3. Configura tu entorno siguiendo [DEV_GUIDE.md](DEV_GUIDE.md).
 
 ---
 
 ## 3) Estilo de código
 
-### 3.1 Backend (Python)
-- Seguir [PEP8](https://peps.python.org/pep-0008/).
-- Imports ordenados (`stdlib`, `third-party`, `local`).
-- Nombrado:
-  - Funciones: `snake_case`
-  - Clases: `PascalCase`
-- Documentar funciones públicas con docstrings.
+### Backend (Python)
+- PEP8 + tipado opcional (`typing` / `pydantic`).
+- Imports agrupados (stdlib, third-party, local).
+- Logging mediante `logging.getLogger(__name__)`.
+- Evitar duplicar lógica de inferencia/persistencia ya cubierta en `infer.py`, `storage.py`.
 
-### 3.2 GUI (C#)
-- Convenciones .NET:
-  - Clases y métodos: `PascalCase`
-  - Campos privados: `_camelCase`
-  - Propiedades públicas: `PascalCase`
-- Usar `var` para inferencia local donde sea claro.
-- Mantener separación clara entre lógica GUI y llamadas al backend.
+### GUI (C# / WPF)
+- Convenciones .NET (PascalCase, `_camelCase` para privados).
+- `async/await` para todas las llamadas HTTP (`HttpClient`).
+- Mantener adorners (`RoiAdorner`, `RoiRotateAdorner`, `ResizeAdorner`) sin cambios salvo instrucciones explícitas.
+- Utilizar `ObservableCollection` para listas visibles y respetar MVVM.
 
-### 3.3 Commits
-- Idioma: inglés
-- Formato recomendado:
+### Commits
+- Idioma: inglés.
+- Formato recomendado (`conventional commits`):
   ```
-  <type>(scope): breve descripción
-
-  [opcional cuerpo explicativo]
+  <type>(scope): resumen breve
   ```
-- Tipos comunes:
-  - `feat`: nueva funcionalidad
-  - `fix`: corrección de bug
-  - `docs`: documentación
-  - `refactor`: cambios internos sin modificar funcionalidad
-  - `test`: tests añadidos o modificados
-  - `chore`: mantenimiento/infraestructura
-
-Ejemplo:
-```
-feat(gui): add rotate handle to ROI adorner
-```
+  Ejemplo: `docs: update architecture with patchcore flow`.
 
 ---
 
-## 4) Flujo de trabajo de Pull Request (PR)
+## 4) Pull Requests
 
-1. Crear rama desde `main`.
-2. Implementar cambios y asegurarse de que compila y pasa smoke tests.
-3. Actualizar documentación asociada (ej. `API_REFERENCE.md`, `ROI_AND_MATCHING_SPEC.md`).
-4. Hacer commit y push a tu fork.
-5. Abrir un PR contra `main` del repositorio principal.
-6. Describir claramente:
-   - Propósito del cambio
-   - Archivos modificados
-   - Screenshots (si aplica)
-   - Estado de pruebas locales
-
-### 4.1 Revisiones
-- Al menos 1 revisor debe aprobar antes de merge.
-- Resolver todos los comentarios de revisión.
-
-### 4.2 CI/CD (futuro)
-- Los PRs deben pasar linters y pruebas automáticas (cuando se configuren workflows).
+1. Asegúrate de que tu rama esté actualizada con `main`.
+2. Incluye descripción clara: propósito, cambios clave, pruebas realizadas.
+3. Adjunta capturas o GIFs si hay cambios visibles en la GUI.
+4. Actualiza la documentación relevante (`README.md`, `API_REFERENCE.md`, etc.).
+5. Espera al menos una aprobación antes de hacer merge.
 
 ---
 
-## 5) Issues
+## 5) Tests y validación
 
-- Usa [GitHub Issues](https://github.com/<org>/BrakeDiscInspector/issues).
-- Plantilla recomendada:
-  - **Descripción clara**
-  - **Pasos para reproducir**
-  - **Comportamiento esperado**
-  - **Logs o capturas relevantes**
-
-Labels sugeridos:
-- `bug`
-- `enhancement`
-- `documentation`
-- `question`
-
----
-
-## 6) Tests y validación
-
-### 6.1 Backend
-- Ejecutar manualmente endpoints con `curl`:
+### Backend
+- Ejecuta smoke tests:
   ```bash
-  curl http://127.0.0.1:5000/train_status
-  curl -X POST http://127.0.0.1:5000/analyze -F "file=@samples/crop.png"
+  curl http://127.0.0.1:8000/health
+  curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Test -F roi_id=ROI -F mm_per_px=0.2 -F images=@sample_ok.png
+  curl -X POST http://127.0.0.1:8000/infer -F role_id=Test -F roi_id=ROI -F mm_per_px=0.2 -F image=@sample_ok.png
   ```
+- Si añades lógica nueva, crea tests en `backend/tests/` (ej. PyTest) y documenta cómo ejecutarlos.
 
-### 6.2 GUI
-- Compilar solución en Visual Studio.
-- Probar flujo: cargar imagen, dibujar ROI, rotar, analizar.
-
----
-
-## 7) Documentación
-
-- Documentación en Markdown (`docs/*.md`).
-- Lenguaje simple y preciso, con ejemplos prácticos.
-- Mantener README.md como entrypoint actualizado.
+### GUI
+- Compila solución (`Build > Build Solution`).
+- Verifica flujo dataset → `/fit_ok` → `/calibrate_ng` → `/infer` con muestras de prueba.
+- Comprueba que los heatmaps se muestran alineados y que la app maneja errores HTTP.
 
 ---
 
-## 8) Checklist para contribuir
+## 6) Documentación
 
-- [ ] Código sigue estilos definidos.
-- [ ] Commits limpios y descriptivos.
-- [ ] PR incluye documentación actualizada si aplica.
-- [ ] Cambios probados localmente (backend/GUI).
-- [ ] Issues relacionados referenciados en PR.
+- Mantén el README y las guías actualizadas con cualquier cambio relevante.
+- Añade diagramas o ejemplos cuando simplifiquen la comprensión.
+- Registra eventos importantes en `docs/mcp/latest_updates.md` cuando afecten contratos o despliegues.
 
 ---
 
-## 9) Reconocimientos
+## 7) Checklist antes de abrir un PR
 
-Todas las contribuciones se reconocen en el historial de commits y en los PRs.  
-Gracias por ayudar a mejorar **BrakeDiscInspector** 🚀
+- [ ] Código formateado y sin warnings críticos.
+- [ ] Tests/manual smoke realizados y descritos en el PR.
+- [ ] Documentación actualizada (si aplica).
+- [ ] Sin cambios accidentales en archivos generados (`*.png`, `*.log`, etc.).
+- [ ] Referencias a issues vinculadas (`Fixes #123`).
+
+---
+
+¡Gracias por contribuir a BrakeDiscInspector! 🚀

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,23 +1,21 @@
-
 # DEPLOYMENT — BrakeDiscInspector
 
-Guía de despliegue para entornos **local**, **LAN/laboratorio** y **producción** (on‑prem o VM). Incluye pruebas de humo, logging y resolución de problemas.
+Guía de despliegue para ejecutar BrakeDiscInspector en entornos de desarrollo, laboratorio y producción. El backend es un microservicio FastAPI (PatchCore + DINOv2) y la GUI es una aplicación WPF.
 
 ---
 
-## 1) Pre‑requisitos
+## 1) Prerrequisitos
 
-- **Backend**
-  - Python 3.10+
-  - `pip install -r backend/requirements.txt`
-  - Modelo TensorFlow en `backend/model/current_model.h5`
-  - Umbral en `backend/model/threshold.txt` (ej. `0.57`)
+### Backend
+- Python 3.10+
+- Dependencias instaladas con `pip install -r backend/requirements.txt`
+- Acceso a GPU opcional (funciona en CPU)
+- Directorio `backend/models/` persistente para artefactos
 
-- **GUI**
-  - Windows 10/11
-  - .NET SDK 8.0
-  - Visual Studio 2022
-  - NuGet: OpenCvSharp4, runtime.win, Extensions
+### GUI
+- Windows 10/11
+- .NET 8.0 + Visual Studio 2022
+- Paquetes NuGet restaurados (`OpenCvSharp4`, `CommunityToolkit.Mvvm`, etc.)
 
 ---
 
@@ -27,180 +25,180 @@ Guía de despliegue para entornos **local**, **LAN/laboratorio** y **producción
 ```bash
 cd backend
 python -m venv .venv
-.venv\Scripts\activate          # PowerShell en Windows
+source .venv/bin/activate      # PowerShell: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
-python app.py                     # inicia en http://127.0.0.1:5000
+uvicorn backend.app:app --reload --host 127.0.0.1 --port 8000
 ```
 
 ### 2.2 GUI
-- Abre `gui/BrakeDiscInspector_GUI_ROI.sln` y compila.
-- Verifica `gui/BrakeDiscInspector_GUI_ROI/appsettings.json`:
-  ```json
-  { "Backend": { "BaseUrl": "http://127.0.0.1:5000" } }
-  ```
+1. Abrir `gui/BrakeDiscInspector_GUI_ROI.sln` en Visual Studio.
+2. Configurar `appsettings.json`:
+   ```json
+   {
+     "Backend": {
+       "BaseUrl": "http://127.0.0.1:8000",
+       "DatasetRoot": "C:\\data\\brakedisc\\datasets"
+     }
+   }
+   ```
+3. Ejecutar la app, crear dataset y probar el flujo dataset → fit → calibrate → infer.
 
 ---
 
-## 3) Pruebas de humo (smoke tests)
+## 3) Pruebas de humo
 
-Con el backend corriendo:
+Con el backend en marcha:
 ```bash
-# Estado
-curl http://127.0.0.1:5000/train_status
-
-# Análisis simple
-curl -X POST http://127.0.0.1:5000/analyze -F "file=@samples/crop.png"
+curl http://127.0.0.1:8000/health
+curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Smoke -F roi_id=ROI -F mm_per_px=0.2 -F images=@sample_ok.png
+curl -X POST http://127.0.0.1:8000/infer -F role_id=Smoke -F roi_id=ROI -F mm_per_px=0.2 -F image=@sample_ok.png
 ```
 
 Resultados esperados:
-- `/train_status` devuelve JSON con `status`/`threshold`.
-- `/analyze` devuelve JSON con `label/score/threshold/heatmap_png_b64`.
+- `/health` responde `status=ok` y dispositivo (`cpu`/`cuda`).
+- `/fit_ok` devuelve `n_embeddings > 0` y `coreset_size > 0`.
+- `/infer` produce `score`, `heatmap_png_base64` y `regions` (aunque esté vacío si no hay anomalías).
 
 ---
 
-## 4) Despliegue LAN/Lab (Windows)
+## 4) Despliegue en laboratorio / LAN (Windows)
 
 ### 4.1 Backend como servicio (NSSM)
-1. Instala [NSSM](https://nssm.cc/).
-2. Crear servicio:
-   ```powershell
-   nssm install BrakeDiscInspectorBackend
-   # Path: C:\Python\python.exe
-   # Arguments: app.py
-   # Startup directory: C:\ruta\a\backend
-   ```
-3. Iniciar servicio:
-   ```powershell
-   nssm start BrakeDiscInspectorBackend
-   ```
-4. Abrir firewall para el puerto (p.ej. 5000).
+1. Instalar [NSSM](https://nssm.cc/).
+2. Crear servicio apuntando a `python.exe` y al script `-m uvicorn backend.app:app --host 0.0.0.0 --port 8000`.
+3. Configurar `Startup directory` al path de `backend/` y variables de entorno necesarias (`PYTHONUNBUFFERED=1`).
+4. Abrir firewall para el puerto 8000 (o el elegido).
 
 ### 4.2 GUI
-- Distribuye el ejecutable WPF o ejecuta desde Visual Studio.
-- Ajusta `BaseUrl` al host del backend dentro de la LAN, por ejemplo:
-  ```json
-  { "Backend": { "BaseUrl": "http://192.168.1.20:5000" } }
-  ```
+- Distribuir build de WPF o ejecutar desde Visual Studio.
+- Actualizar `BaseUrl` con la IP del backend en la LAN (ej. `http://192.168.1.20:8000`).
 
 ---
 
-## 5) Producción (Linux/VM)
+## 5) Producción (Linux)
 
-### 5.1 Backend con Gunicorn + Reverse Proxy (Nginx)
+### 5.1 Backend con Gunicorn + Uvicorn Worker
 
-**Gunicorn** (como WSGI runner) y **Nginx** como proxy/estático/SSL.
+1. Instalar dependencias del sistema:
+   ```bash
+   sudo apt update && sudo apt install -y python3.10 python3.10-venv python3-pip nginx
+   ```
+2. Configurar entorno:
+   ```bash
+   sudo mkdir -p /opt/brakedisc
+   sudo chown $USER:$USER /opt/brakedisc
+   cd /opt/brakedisc
+   git clone <repo> .
+   cd backend
+   python3.10 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Crear servicio systemd `/etc/systemd/system/brakedisc.service`:
+   ```ini
+   [Unit]
+   Description=BrakeDiscInspector Backend
+   After=network.target
 
-1) Instalar dependencias del sistema (ejemplo Ubuntu):
-```bash
-sudo apt update && sudo apt install -y python3-pip python3-venv nginx
-```
+   [Service]
+   User=brakedisc
+   Group=brakedisc
+   WorkingDirectory=/opt/brakedisc/backend
+   Environment="PYTHONUNBUFFERED=1"
+   ExecStart=/opt/brakedisc/backend/.venv/bin/gunicorn \
+     -k uvicorn.workers.UvicornWorker backend.app:app \
+     -w 2 -b 0.0.0.0:8000
+   Restart=on-failure
 
-2) Entorno virtual + deps:
-```bash
-cd /opt/brakedisc/backend
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-```
+   [Install]
+   WantedBy=multi-user.target
+   ```
+4. Habilitar y arrancar el servicio:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable brakedisc
+   sudo systemctl start brakedisc
+   ```
+5. Configurar Nginx `/etc/nginx/sites-available/brakedisc`:
+   ```nginx
+   server {
+       listen 80;
+       server_name your.server.local;
 
-3) Gunicorn unit (systemd): `/etc/systemd/system/brakedisc.service`
-```
-[Unit]
-Description=BrakeDiscInspector Backend (Gunicorn)
-After=network.target
+       location / {
+           proxy_pass http://127.0.0.1:8000;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header X-Forwarded-Proto $scheme;
+       }
+   }
+   ```
+   ```bash
+   sudo ln -s /etc/nginx/sites-available/brakedisc /etc/nginx/sites-enabled/
+   sudo nginx -t
+   sudo systemctl reload nginx
+   ```
+6. (Opcional) Configurar HTTPS con Certbot:
+   ```bash
+   sudo apt install -y certbot python3-certbot-nginx
+   sudo certbot --nginx -d your.server.local
+   ```
 
-[Service]
-User=www-data
-Group=www-data
-WorkingDirectory=/opt/brakedisc/backend
-Environment="PYTHONUNBUFFERED=1"
-ExecStart=/opt/brakedisc/backend/.venv/bin/gunicorn -w 2 -b 0.0.0.0:5000 app:app
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-```
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable brakedisc
-sudo systemctl start brakedisc
-```
-
-4) Nginx host `/etc/nginx/sites-available/brakedisc`:
-```
-server {
-    listen 80;
-    server_name your.server.local;
-
-    location / {
-        proxy_pass http://127.0.0.1:5000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-```
-```bash
-sudo ln -s /etc/nginx/sites-available/brakedisc /etc/nginx/sites-enabled/brakedisc
-sudo nginx -t
-sudo systemctl reload nginx
-```
-
-5) (Opcional) HTTPS con Certbot:
-```bash
-sudo apt install -y certbot python3-certbot-nginx
-sudo certbot --nginx -d your.server.local
-```
-
-### 5.2 GUI apuntando a producción
-Actualizar `appsettings.json` en cada estación:
-```json
-{ "Backend": { "BaseUrl": "https://your.server.local" } }
-```
+### 5.2 GUI en producción
+- Actualizar `appsettings.json` con la URL HTTPS del backend.
+- Configurar rutas de dataset locales o de red según política de planta.
 
 ---
 
-## 6) Variables de entorno (opcional)
+## 6) Variables de entorno útiles
 
-- `INPUT_SIZE` (si se parametriza en `app.py`).
-- `MODEL_PATH` para ubicar modelo alternativo.
-- `FLASK_ENV=production` (si se arranca con Flask directamente).
+| Variable | Descripción |
+|----------|-------------|
+| `INPUT_SIZE` | Sobrescribe el tamaño de entrada usado por DINOv2 (por defecto 448). |
+| `CORESET_RATE` | Ajusta el porcentaje de coreset (0.02 por defecto). |
+| `MODELS_DIR` | Directorio donde guardar artefactos (`models/`). |
+
+Se pueden definir en el entorno del servicio (`systemd`, NSSM) antes de lanzar el backend.
 
 ---
 
 ## 7) Logging y observabilidad
 
-- **Backend**: `backend/logs/backend.log` (configurado por `logging.basicConfig`).
-- **Nginx/Gunicorn**: `/var/log/nginx/*`, journal `systemd`.
-- Considerar rotación de logs (`logrotate`) y niveles por entorno.
+- Backend: revisar `LOGGING.md` para eventos mínimos y uso de `X-Correlation-Id`.
+- GUI: habilitar logs locales (`gui/logs/gui.log`) para correlacionar con el backend.
+- Nginx/Gunicorn: monitorear `journalctl -u brakedisc` y `/var/log/nginx/access.log`.
 
 ---
 
 ## 8) Seguridad
 
-- Restringir el acceso del backend a red interna (Nginx delante).
-- HTTPS en proxy inverso.
-- Firewall de host y/o grupo de seguridad (cloud).
-- Aislamiento de usuario (`www-data`) en systemd unit.
-- Validación de tamaño de archivos subidos (Flask `MAX_CONTENT_LENGTH`).
+- Exponer el backend únicamente tras un proxy inverso (Nginx) con HTTPS.
+- Limitar acceso por firewall / grupos de seguridad.
+- Validar tamaños máximos de subida (FastAPI `UploadFile` + reverse proxy `client_max_body_size`).
+- Mantener dependencias actualizadas (`pip install -U -r requirements.txt`).
 
 ---
 
-## 9) Solución de problemas
+## 9) Troubleshooting
 
-- **404/502 en Nginx**: comprobar servicio `brakedisc` (`systemctl status brakedisc`) y `proxy_pass`.
-- **OOM/alto consumo**: reducir workers (`-w 2`), activar swap moderado, revisar tamaño del modelo.
-- **Permisos de modelo**: usuario del servicio debe poder leer `/opt/brakedisc/backend/model/*`.
-- **CORS**: habilitado en Flask con `flask-cors`; revisar cabeceras si hay bloqueo en navegadores.
+| Problema | Diagnóstico | Solución |
+|----------|-------------|----------|
+| `/infer` devuelve 400 “Memoria no encontrada” | No se ha ejecutado `/fit_ok` para ese rol/ROI | Entrenar nuevamente o copiar artefactos previos a `models/<role>/<roi>/`. |
+| GPU no detectada | `torch.cuda.is_available()` retorna `False` | Instalar versión CUDA de PyTorch o forzar `DEVICE=cpu`. |
+| Timeouts en GUI | Requests largos (datasets grandes) | Aumentar timeout en `HttpClient` y monitorear ancho de banda. |
+| Nginx 502 | Backend caído o puerto incorrecto | Revisar `systemctl status brakedisc` y logs. |
 
 ---
 
-## 10) Checklist de despliegue
+## 10) Checklist previo a release
 
-- [ ] Backend instalado y servicio activo (`curl /train_status` OK).
-- [ ] Nginx proxy inverso (o firewall abierto si exposición directa).
-- [ ] HTTPS configurado (si aplica).
-- [ ] Rutas de logs verificadas.
-- [ ] GUI configurada con `BaseUrl` correcto y prueba de `Analyze` con imagen real.
+- [ ] Ejecutar smoke tests (`/health`, `/fit_ok`, `/infer`).
+- [ ] Verificar que `models/<role>/<roi>/` contiene `memory.npz` y, si aplica, `calib.json`.
+- [ ] Confirmar que la GUI apunta al backend correcto (`appsettings.json`).
+- [ ] Registrar evidencias en `docs/mcp/latest_updates.md` según el MCP.
+- [ ] Revisar logs post-despliegue (backend y proxy) durante la primera hora.
+
+---
+
+Para coordinación entre equipos (dataset, backend, GUI) consulta [docs/mcp/overview.md](docs/mcp/overview.md).

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -1,24 +1,22 @@
-
 # DEV_GUIDE — BrakeDiscInspector
 
-Guía de desarrollo para configurar, extender y probar el proyecto en entornos locales.  
-Cubre **backend (Python)** y **GUI (C# / WPF)**, así como scripts auxiliares.
+Guía de desarrollo para configurar, extender y probar el proyecto en entornos locales. Cubre el backend FastAPI (PatchCore + DINOv2) y la GUI WPF.
 
 ---
 
-## 1) Clonar y preparar entorno
+## 1) Preparación del repositorio
 
 ```bash
 git clone https://github.com/<usuario>/BrakeDiscInspector.git
 cd BrakeDiscInspector
 ```
 
-Estructura básica:
+Estructura general:
 ```
-backend/   # Flask + TensorFlow + OpenCV
-gui/       # WPF .NET + OpenCvSharp
-scripts/   # utilidades PowerShell
-docs/      # Markdown (especificaciones)
+backend/   # Microservicio FastAPI (PatchCore + DINOv2)
+gui/       # WPF (.NET 8) para gestión de ROI/datasets
+scripts/   # utilidades (PowerShell)
+docs/      # documentación (arquitectura, MCP, etc.)
 ```
 
 ---
@@ -26,123 +24,128 @@ docs/      # Markdown (especificaciones)
 ## 2) Backend (Python)
 
 ### 2.1 Requisitos
-- Python 3.10+  
-- pip + virtualenv  
-- GPU opcional: CUDA/cuDNN instalados
+- Python 3.10 o superior
+- `pip` actualizado (`python -m pip install -U pip`)
+- GPU opcional (CUDA/cuDNN) — funciona también en CPU
 
 ### 2.2 Instalación
 ```bash
 cd backend
 python -m venv .venv
-.venv\Scripts\activate   # en Windows
+source .venv/bin/activate      # PowerShell: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 ```
 
-### 2.3 Archivos importantes
-- `app.py`: entrypoint Flask, define endpoints `/analyze`, `/train_status`, `/match_master` (alias `/match_one`)
-- `model/current_model.h5`: modelo entrenado
-- `model/threshold.txt`: umbral NG/OK
-- `utils/`: funciones auxiliares (letterbox, annulus, heatmap, schemas)
+> El archivo `requirements.txt` incluye `torch`, `timm`, `opencv-python`, `faiss-cpu` (opcional) y `fastapi`.
 
-### 2.4 Ejecución
-```bash
-python app.py
-```
-Por defecto en `http://127.0.0.1:5000`.
+### 2.3 Archivos clave
+- `app.py` — endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`.
+- `features.py` — wrapper DINOv2 (`vit_small_patch14_dinov2.lvd142m`).
+- `patchcore.py` — memoria PatchCore (coreset + kNN).
+- `infer.py` — pipeline de inferencia y posprocesado (heatmap, contornos).
+- `calib.py` — selección de umbral con percentiles.
+- `storage.py` — persistencia en `models/<role>/<roi>/`.
+- `README_backend.md` — guía operativa y ejemplos `curl`.
 
-### 2.5 Tests básicos
+### 2.4 Ejecución en desarrollo
 ```bash
-curl http://127.0.0.1:5000/train_status
-curl -X POST http://127.0.0.1:5000/analyze -F "file=@samples/crop.png"
+uvicorn backend.app:app --reload --port 8000
+# Documentación interactiva: http://127.0.0.1:8000/docs
 ```
+
+### 2.5 Pruebas rápidas
+```bash
+curl http://127.0.0.1:8000/health
+curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.2 -F images=@sample_ok.png
+curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.2 -F image=@sample_ok.png
+```
+
+> Los comandos anteriores generan/usan artefactos en `backend/models/Demo/ROI1/`.
+
+### 2.6 Debugging
+- Activar logs (`uvicorn --log-level debug`).
+- Revisar `logging` dentro de `app.py` y `infer.py` para tiempos parciales.
+- Ejecutar scripts/unit tests en `backend/tests/` para validar componentes aislados.
 
 ---
 
-## 3) GUI (WPF en C#)
+## 3) GUI (WPF)
 
 ### 3.1 Requisitos
 - Windows 10/11
-- Visual Studio 2022
+- Visual Studio 2022 o superior
 - .NET SDK 8.0
-- Paquetes NuGet:
-  - `OpenCvSharp4`
-  - `OpenCvSharp4.runtime.win`
-  - `OpenCvSharp4.Extensions`
+- Paquetes NuGet principales: `OpenCvSharp4`, `OpenCvSharp4.runtime.win`, `OpenCvSharp4.Extensions`, `CommunityToolkit.Mvvm`.
 
 ### 3.2 Archivos principales
-- `MainWindow.xaml` / `MainWindow.xaml.cs`: UI principal
-- `BackendAPI.cs`: cliente HTTP tipado
-- `ROI/`: lógica de ROIs y adorners
-- `Overlays/RoiOverlay.cs`: overlay sincronizado con canvas
+- `MainWindow.xaml` / `.cs` — layout y binding principal.
+- `BackendClient.cs` — cliente HTTP async para `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`.
+- `ROI/` — modelos/adorners (no modificar geometría base).
+- `Overlays/` — sincronización canvas ↔ imagen (`RoiOverlay`).
+- `Datasets/` — helpers para guardar PNG + JSON en `datasets/<role>/<roi>/<ok|ng>/`.
 
 ### 3.3 Configuración
-`appsettings.json` (GUI):
+`appsettings.json` ejemplo:
 ```json
 {
-  "Backend": { "BaseUrl": "http://127.0.0.1:5000" }
+  "Backend": {
+    "BaseUrl": "http://127.0.0.1:8000",
+    "DatasetRoot": "C:\\data\\brakedisc\\datasets"
+  }
 }
 ```
 
-### 3.4 Flujo típico
-1. Abrir GUI y cargar imagen (`File > Open`).
-2. Dibujar ROI en canvas (mín. 10x10).
-3. Rotar ROI con adorner circular.
-4. Pulsar **Analyze** → la GUI genera crop rotado y lo envía al backend.
-5. GUI muestra label/score/threshold y heatmap.
+### 3.4 Flujo recomendado
+1. Cargar imagen y dibujar ROI (respetando mínimo 10×10 px).
+2. Exportar ROI canónico desde la pestaña **Dataset** (`Add OK/NG from current ROI`).
+3. Entrenar con **Train memory (fit_ok)**.
+4. Calibrar (opcional) con **Calibrate threshold**.
+5. Ejecutar **Infer current ROI** para obtener `score`, `threshold`, heatmap y regiones.
+
+### 3.5 Debugging GUI
+- Usar `AppendLog` o `TraceSource` para registrar acciones y respuestas del backend.
+- Validar que el heatmap se superpone correctamente (revisar tamaño del PNG vs. `Image.Source`).
+- En caso de errores HTTP, mostrar mensaje amigable + detalle técnico en panel de logs.
+## 4) Scripts auxiliares (`scripts/`)
+
+| Script | Descripción |
+|--------|-------------|
+| `setup_dev.ps1` | Crea venv y ejecuta `pip install -r backend/requirements.txt`. |
+| `run_backend.ps1` | Activa el venv y lanza `uvicorn backend.app:app`. |
+| `run_gui.ps1` | Abre la solución WPF en Visual Studio. |
+| `check_env.ps1` | Verifica dependencias básicas (Python, dotnet, git). |
+> Ejecutar los scripts desde PowerShell con permisos adecuados (`Set-ExecutionPolicy -Scope Process RemoteSigned`).
+## 5) Estándares de código
+- Python: seguir PEP8, tipado opcional (`typing`) y logging estructurado (`logging.getLogger(__name__)`).
+- C#: respetar convenciones .NET (PascalCase para métodos/clases, `_camelCase` para privados), usar `async/await` para I/O.
+- Commits: mensajes en inglés (`feat:`, `fix:`, `docs:`, etc.).
 
 ---
 
-## 4) Scripts auxiliares (PowerShell)
+## 6) Testing
 
-- `scripts/setup_dev.ps1`: crea venv, instala dependencias
-- `scripts/run_backend.ps1`: activa venv y lanza Flask
-- `scripts/run_gui.ps1`: abre solución en VS
-- `scripts/check_env.ps1`: verifica presencia de Python, .NET y dependencias
-- `scripts/export_onnx.ps1`: convierte modelo `.h5` → `.onnx`
+### 6.1 Backend
+- Tests unitarios en `backend/tests/` (FAISS opcional). Ejecutar con `pytest` si está disponible.
+- Smoke tests manuales (`curl /fit_ok`, `/infer`, `/calibrate_ng`).
 
-Ejemplo:
-```powershell
-.\scripts\setup_dev.ps1
-.\scriptsun_backend.ps1
-```
+### 6.2 GUI
+- Compilar solución (`Build > Build Solution`).
+- Validar flujo dataset → fit → calibrate → infer con muestras de prueba.
+- Verificar alineación ROI/heatmap tras redimensionar la ventana.
+## 7) Roadmap sugerido
 
----
-
-## 5) Debugging
-
-### 5.1 Backend
-- Logs en `backend/logs/backend.log`
-- Nivel DEBUG activa trazas detalladas
-- `Ctrl+C` detiene servidor
-
-### 5.2 GUI
-- `AppendLog` escribe en `gui/logs/gui.log`
-- Verificar alineación ROI ↔ Canvas (`SyncOverlayToImage()`)
-- Errores comunes:
-  - CS1674 → no usar `using` con `ImEncode`
-  - CS1061 → usar `BitmapSourceConverter` en vez de `ToWriteableBitmap`
-
----
-
-## 6) Extender funcionalidad
-
-- **Nuevos endpoints**: añadir en `backend/app.py`, documentar en `API_REFERENCE.md`
-- **Nuevos tipos de ROI**: extender `ROI.cs`, `RoiOverlay.cs`
-- **Máscaras avanzadas**: aceptar múltiples ficheros en `/analyze`
-- **UI extra**: añadir pestañas WPF y bindings en `MainWindow.xaml`
-
----
-
-## 7) Convenciones de código
-
-- Backend Python: PEP8, logging estructurado, funciones puras en `utils/`
-- GUI C#: PascalCase para clases/métodos, camelCase para campos privados
-- Commits: mensajes en inglés, claro y conciso
-
----
-
-## 8) Roadmap sugerido
-
+- [ ] Automatizar `pytest` y linters (GitHub Actions).
+- [ ] Añadir modo batch para procesar múltiples ROIs.
+- [ ] Persistir manifiestos por ROI con estado de entrenamiento/calibración.
+- [ ] Integrar exportación de reportes (CSV/JSON) desde la GUI.
+- [ ] Instrumentar métricas Prometheus desde FastAPI.
+## 8) Referencias cruzadas
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Visión de alto nivel y flujo de datos.
+- [API_REFERENCE.md](API_REFERENCE.md) — Contratos HTTP detallados.
+- [DATA_FORMATS.md](DATA_FORMATS.md) — Esquemas de requests/responses y archivos persistidos.
+- [DEPLOYMENT.md](DEPLOYMENT.md) — Guía de despliegue local/prod.
+- [LOGGING.md](LOGGING.md) — Política de logging y correlación GUI↔backend.
+- [docs/mcp/overview.md](docs/mcp/overview.md) — Maintenance & Communication Plan.
 - [ ] Multiples ROIs simultáneos
 - [ ] Batch analyze
 - [ ] Entrenamiento incremental

--- a/docs/mcp/latest_updates.md
+++ b/docs/mcp/latest_updates.md
@@ -1,17 +1,21 @@
 # MCP Latest Updates
 
-This log records notable Maintenance & Communication Plan (MCP) events for BrakeDiscInspector. Add the most recent
-entries to the top of the document and include:
+This log records notable Maintenance & Communication Plan (MCP) events for BrakeDiscInspector. Add the most recent entries to the top of the document and include:
 
 - **Date** (ISO `YYYY-MM-DD`)
 - **Owner(s)** responsible for the update
 - **Summary** of the change and links to detailed documents or pull requests
 - **Next Steps / Follow-ups** when applicable
 
+## 2024-06-05 — PatchCore Documentation Refresh
+
+- **Owners:** MCP Maintainer, Backend Lead, GUI Lead
+- **Summary:** Updated all repository markdown files to align with the FastAPI + PatchCore backend (DINOv2 extractor, `/fit_ok`/`/calibrate_ng`/`/infer` contract) and the dataset-driven GUI workflow. Simplified the MCP scope to focus on the new artefact layout (`models/<role>/<roi>/`).
+- **Evidence:** See refreshed guides (`README.md`, `ARCHITECTURE.md`, `API_REFERENCE.md`, `DATA_FORMATS.md`, `DEV_GUIDE.md`, `DEPLOYMENT.md`, `LOGGING.md`, `ROI_AND_MATCHING_SPEC.md`).
+- **Next Steps:** Monitor first production deployment under the new backend. Capture latency metrics and calibration outcomes in the next MCP entry.
+
 ## 2024-05-28 — Initial MCP Publication
 
 - **Owners:** Repository maintainers
-- **Summary:** Created the MCP documentation hub (`docs/mcp/overview.md`) and the ongoing change log (`docs/mcp/latest_updates.md`).
-  Linked the new hub from the main README so future contributors can find it quickly.
-- **Next Steps:** Populate this log whenever datasets, models, or architecture contracts change. Ensure any structural updates
-to the MCP documentation keep the `overview` + `latest_updates` pattern for discoverability.
+- **Summary:** Created the MCP documentation hub (`docs/mcp/overview.md`) and the ongoing change log (`docs/mcp/latest_updates.md`). Linked the new hub from the main README for discoverability.
+- **Next Steps:** Populate this log whenever datasets, models, or architecture contracts change.


### PR DESCRIPTION
## Summary
- align the README and architecture overview with the FastAPI PatchCore backend and the GUI dataset workflow
- update API/data/development/deployment/logging/contributing guides to reflect the current endpoints and operations
- refresh the ROI specification, MCP records, and GUI README to match the canonical ROI pipeline and documentation cadence

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da750286bc8330a257f45d9ffd193b