### PR TITLE
Ensure GUI uses FastAPI backend configuration

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
@@ -20,7 +20,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
     public static class BackendAPI
     {
-        public static string BaseUrl { get; private set; } = "http://127.0.0.1:5000";
+        public static string BaseUrl { get; private set; } = "http://127.0.0.1:8000";
 
         // === Endpoints
         public const string AnalyzeEndpoint = "/analyze";
@@ -33,12 +33,16 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             try
             {
-                var json = File.ReadAllText("appsettings.json");
-                using var doc = JsonDocument.Parse(json);
-                if (doc.RootElement.TryGetProperty("Backend", out var be) &&
-                    be.TryGetProperty("BaseUrl", out var baseUrlEl))
+                var settingsPath = Path.Combine(AppContext.BaseDirectory, "appsettings.json");
+                if (File.Exists(settingsPath))
                 {
-                    BaseUrl = baseUrlEl.GetString() ?? BaseUrl;
+                    var json = File.ReadAllText(settingsPath);
+                    using var doc = JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("Backend", out var be) &&
+                        be.TryGetProperty("BaseUrl", out var baseUrlEl))
+                    {
+                        BaseUrl = baseUrlEl.GetString() ?? BaseUrl;
+                    }
                 }
             }
             catch { /* fallback */ }

--- a/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
@@ -12,12 +12,18 @@
 		<PublishSingleFile>false</PublishSingleFile>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
-		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
-		<PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.11.0.20250507" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="OpenCvSharp4" Version="4.11.0.20250507" />
+                <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
+                <PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
+                <PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.11.0.20250507" />
+        </ItemGroup>
+
+        <ItemGroup>
+                <Content Include="appsettings.json">
+                        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+                </Content>
+        </ItemGroup>
 
 </Project>
 


### PR DESCRIPTION
## Summary
- ensure the GUI project copies appsettings.json next to the executable
- default the backend API to the FastAPI port and read appsettings.json from the output directory

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da7a7bb0708330aa73610a58022c9d