### PR TITLE
Update backend host configuration to localhost

### DIFF
--- a/backend/agents_for_backend.md
+++ b/backend/agents_for_backend.md
@@ -197,12 +197,12 @@ Keep **defaults** aligned with the checked-in code to avoid drift with GUI docs.
 
 ### Uvicorn (dev)
 ```
-uvicorn backend.app:app --host 0.0.0.0 --port 8000
+uvicorn backend.app:app --host 127.0.0.1 --port 8000
 ```
 
 ### Gunicorn (prod, workers>1)
 ```
-gunicorn -k uvicorn.workers.UvicornWorker backend.app:app -w 2 -b 0.0.0.0:8000
+gunicorn -k uvicorn.workers.UvicornWorker backend.app:app -w 2 -b 127.0.0.1:8000
 ```
 
 ### Minimal Dockerfile (example)
@@ -212,7 +212,7 @@ WORKDIR /app
 COPY backend/ /app/backend/
 RUN pip install --no-cache-dir -r backend/requirements.txt
 EXPOSE 8000
-CMD ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "backend.app:app", "--host", "127.0.0.1", "--port", "8000"]
 ```
 
 Mount or bake `models/` volume for persistence.

--- a/backend/app.py
+++ b/backend/app.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
     if not logging.getLogger().handlers:
         logging.basicConfig(level=logging.INFO)
 
-    host = "0.0.0.0"
+    host = "127.0.0.1"
     port = 8000
     log.info("Starting backend service on %s:%s", host, port)
 


### PR DESCRIPTION
## Summary
- update the backend's uvicorn host binding to use 127.0.0.1 by default
- refresh backend deployment documentation examples to reference the localhost binding

## Testing
- python app.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68daba911f2483309741230a58c31478