### PR TITLE
Allow configuring backend endpoints via environment variables

### DIFF
--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -35,6 +35,9 @@ pip install -r backend/requirements.txt
 uvicorn backend.app:app --reload
 # por defecto: http://127.0.0.1:8000
 # docs interactivos: http://127.0.0.1:8000/docs
+
+# o con el script directo (respeta BRAKEDISC_BACKEND_HOST/BRAKEDISC_BACKEND_PORT o HOST/PORT)
+python backend/app.py
 ```
 
 ---

--- a/backend/app.py
+++ b/backend/app.py
@@ -237,8 +237,17 @@ if __name__ == "__main__":
     if not logging.getLogger().handlers:
         logging.basicConfig(level=logging.INFO)
 
-    host = "127.0.0.1"
-    port = 8000
+    import os
+
+    host = os.environ.get("BRAKEDISC_BACKEND_HOST") or os.environ.get("HOST") or "127.0.0.1"
+
+    raw_port = os.environ.get("BRAKEDISC_BACKEND_PORT") or os.environ.get("PORT") or "8000"
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        log.warning("Invalid port '%s' provided via environment, falling back to 8000", raw_port)
+        port = 8000
+
     log.info("Starting backend service on %s:%s", host, port)
 
     import uvicorn

--- a/gui/BrakeDiscInspector_GUI_ROI/README.md
+++ b/gui/BrakeDiscInspector_GUI_ROI/README.md
@@ -48,6 +48,13 @@ Aplicación WPF (.NET 8) que permite preparar ROIs, gestionar datasets y comunic
 }
 ```
 
+También puedes sobreescribir `BaseUrl` mediante variables de entorno:
+
+- `BRAKEDISC_BACKEND_BASEURL` / `BRAKEDISC_BACKEND_BASE_URL`
+- o `BRAKEDISC_BACKEND_HOST` + `BRAKEDISC_BACKEND_PORT` (acepta también `HOST` / `PORT`)
+
+La GUI normaliza automáticamente la URL (añade `http://` si falta) antes de usarla.
+
 ---
 
 ## 5. Problemas comunes

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs
@@ -17,7 +17,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         {
             _httpClient = httpClient ?? new HttpClient();
             _httpClient.Timeout = TimeSpan.FromSeconds(120);
-            BaseUrl = "http://127.0.0.1:8000";
+            BaseUrl = ResolveDefaultBaseUrl();
         }
 
         public string BaseUrl
@@ -39,6 +39,35 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                 _httpClient.BaseAddress = new Uri(trimmed + "/");
             }
+        }
+
+        private static string ResolveDefaultBaseUrl()
+        {
+            string defaultUrl = "http://127.0.0.1:8000";
+
+            string? envBaseUrl =
+                Environment.GetEnvironmentVariable("BRAKEDISC_BACKEND_BASEURL") ??
+                Environment.GetEnvironmentVariable("BRAKEDISC_BACKEND_BASE_URL") ??
+                Environment.GetEnvironmentVariable("BRAKEDISC_BACKEND_URL");
+
+            if (!string.IsNullOrWhiteSpace(envBaseUrl))
+            {
+                return envBaseUrl;
+            }
+
+            var host = Environment.GetEnvironmentVariable("BRAKEDISC_BACKEND_HOST") ??
+                       Environment.GetEnvironmentVariable("HOST");
+            var port = Environment.GetEnvironmentVariable("BRAKEDISC_BACKEND_PORT") ??
+                       Environment.GetEnvironmentVariable("PORT");
+
+            if (!string.IsNullOrWhiteSpace(host) || !string.IsNullOrWhiteSpace(port))
+            {
+                host = string.IsNullOrWhiteSpace(host) ? "127.0.0.1" : host.Trim();
+                port = string.IsNullOrWhiteSpace(port) ? "8000" : port.Trim();
+                return $"{host}:{port}";
+            }
+
+            return defaultUrl;
         }
 
         public async Task<FitOkResult> FitOkAsync(string roleId, string roiId, double mmPerPx, IEnumerable<string> okImagePaths)


### PR DESCRIPTION
## Summary
- allow the FastAPI launcher to honour BRAKEDISC_BACKEND_HOST/BRAKEDISC_BACKEND_PORT (and HOST/PORT) when the backend runs as a script
- let the WPF backend client resolve its base URL from the same environment variables with normalization helpers
- document the new configuration knobs for both backend and GUI readmes

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop workload is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dabc7fa69083309d53814c2404bf5d