### PR TITLE
Refactor GUI backend integration to use /infer

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using BrakeDiscInspector_GUI_ROI.Workflow;
 
 
 namespace BrakeDiscInspector_GUI_ROI
@@ -16,38 +17,59 @@ namespace BrakeDiscInspector_GUI_ROI
             if (string.IsNullOrWhiteSpace(_currentImagePathWin) || !File.Exists(_currentImagePathWin))
             { Snack("No hay imagen cargada"); return; }
 
-            var r1 = await BackendAPI.MatchOneViaFilesAsync(
-            _currentImagePathWin, _layout.Master1Pattern,
-            _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
-            string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-            0.8, false, "M1", _layout.Master1Search, AppendLog);
+            if (!TryGetBackendDataset(out var roleId, out var baseRoiId, out var mmPerPx))
+            { Snack("Configura Role/ROI en Dataset & AI antes de analizar"); return; }
 
+            var inferM1 = await BackendAPI.InferAsync(
+                _currentImagePathWin,
+                _layout.Master1Pattern,
+                roleId,
+                ResolveBackendRoiId(_layout.Master1Pattern, baseRoiId, "Master1Pattern"),
+                mmPerPx,
+                AppendLog);
 
-            var r2 = await BackendAPI.MatchOneViaFilesAsync(
-            _currentImagePathWin, _layout.Master2Pattern,
-            _preset.MatchThr, _preset.RotRange, _preset.ScaleMin, _preset.ScaleMax,
-            string.IsNullOrWhiteSpace(_preset.Feature) ? "auto" : _preset.Feature,
-            0.8, false, "M2", _layout.Master2Search, AppendLog);
+            if (!inferM1.ok || inferM1.result == null)
+            {
+                Snack("No se obtuvo inferencia para Master 1" + (inferM1.error != null ? $" ({inferM1.error})" : ""));
+                return;
+            }
 
+            var inferM2 = await BackendAPI.InferAsync(
+                _currentImagePathWin,
+                _layout.Master2Pattern,
+                roleId,
+                ResolveBackendRoiId(_layout.Master2Pattern, baseRoiId, "Master2Pattern"),
+                mmPerPx,
+                AppendLog);
 
-            if (!r1.ok || r1.center == null) { Snack("No se encontró Master 1" + (r1.error != null ? $" ({r1.error})" : "")); return; }
-            if (!r2.ok || r2.center == null) { Snack("No se encontró Master 2" + (r2.error != null ? $" ({r2.error})" : "")); return; }
+            if (!inferM2.ok || inferM2.result == null)
+            {
+                Snack("No se obtuvo inferencia para Master 2" + (inferM2.error != null ? $" ({inferM2.error})" : ""));
+                return;
+            }
 
+            var resp1 = inferM1.result.Response;
+            var resp2 = inferM2.result.Response;
+            AppendLog($"[infer] M1 score={resp1.score:0.###} thr={resp1.threshold:0.###}");
+            AppendLog($"[infer] M2 score={resp2.score:0.###} thr={resp2.threshold:0.###}");
 
-            var c1 = r1.center.Value; var c2 = r2.center.Value;
+            var center1 = _layout.Master1Pattern.GetCenter();
+            var center2 = _layout.Master2Pattern.GetCenter();
+            var c1 = new System.Windows.Point(center1.cx, center1.cy);
+            var c2 = new System.Windows.Point(center2.cx, center2.cy);
             var mid = new System.Windows.Point((c1.X + c2.X) / 2.0, (c1.Y + c2.Y) / 2.0);
             var (c1Canvas, c2Canvas, midCanvas) = ConvertMasterPointsToCanvas(c1, c2, mid);
-
 
             if (_layout.Inspection == null) { Snack("Falta ROI de Inspección"); return; }
             MoveInspectionTo(_layout.Inspection, c1, c2);
             ClipInspectionROI(_layout.Inspection, _imgW, _imgH);
 
-
             RedrawOverlay();
             DrawCross(c1Canvas.X, c1Canvas.Y, 20, Brushes.LimeGreen, 2);
             DrawCross(c2Canvas.X, c2Canvas.Y, 20, Brushes.Orange, 2);
             DrawCross(midCanvas.X, midCanvas.Y, 24, Brushes.Red, 2);
+
+            Snack($"Masters OK. Scores: M1={resp1.score:0.000}{FormatThreshold(resp1.threshold)}, M2={resp2.score:0.000}{FormatThreshold(resp2.threshold)}");
         }
 
 
@@ -70,9 +92,45 @@ namespace BrakeDiscInspector_GUI_ROI
             if (string.IsNullOrWhiteSpace(_currentImagePathWin) || !File.Exists(_currentImagePathWin))
             { Snack("No hay imagen cargada"); return; }
 
-            var resp = await BackendAPI.AnalyzeAsync(_currentImagePathWin, _layout.Inspection, _preset, AppendLog);
-            if (!resp.ok) { Snack("Analyze backend: " + (resp.error ?? "error desconocido")); return; }
-            Snack($"Resultado: {resp.label} (score={resp.score:0.000})");
+            if (!TryGetBackendDataset(out var roleId, out var roiId, out var mmPerPx))
+            { Snack("Configura Role/ROI en Dataset & AI antes de analizar"); return; }
+
+            var result = await BackendAPI.InferAsync(
+                _currentImagePathWin,
+                _layout.Inspection,
+                roleId,
+                roiId,
+                mmPerPx,
+                AppendLog);
+
+            if (!result.ok || result.result == null)
+            {
+                Snack(result.error ?? "Error en /infer");
+                return;
+            }
+
+            var resp = result.result.Response;
+            var label = resp.threshold > 0 && resp.score <= resp.threshold ? "OK" : "NG";
+            Snack($"Resultado backend: {label} (score={resp.score:0.###}, thr={resp.threshold:0.###})");
+            UpdateResultLabel(label, resp);
+
+            if (!string.IsNullOrWhiteSpace(resp.heatmap_png_base64))
+            {
+                try
+                {
+                    var heatBytes = Convert.FromBase64String(resp.heatmap_png_base64);
+                    var export = new Workflow.RoiExportResult(result.result.PngBytes, result.result.ShapeJson, result.result.RoiImage);
+                    await ShowHeatmapOverlayAsync(export, heatBytes, _heatmapOverlayOpacity);
+                }
+                catch (FormatException ex)
+                {
+                    AppendLog("[infer] heatmap decode error: " + ex.Message);
+                }
+            }
+            else
+            {
+                ClearHeatmapOverlay();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the legacy backend helpers with /infer-aware models, serialization, and canonical ROI cropping utilities
- refactor AnalyzeMastersAsync and the Analyze ROI button to send canonical PNGs through /infer, logging thresholds and regions while reusing dataset context
- update the partial MainWindow helpers to rely on inference-based fallbacks and heatmap display

## Testing
- dotnet build *(fails: Windows Desktop SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac17e1f5483309da796a812b3f84c