### PR TITLE
Fix InferRequest reference and adorner scoping issues

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -631,14 +631,14 @@ namespace BrakeDiscInspector_GUI_ROI
             if (shape.Tag is not RoiModel roiInfo)
                 return;
 
-            var adorner = new RoiAdorner(shape, (changeKind, updatedModel) =>
+            var newAdorner = new RoiAdorner(shape, (changeKind, updatedModel) =>
             {
                 var pixelModel = CanvasToImage(updatedModel);
                 UpdateLayoutFromPixel(pixelModel);
                 HandleAdornerChange(changeKind, updatedModel, pixelModel, "[adorner]");
             }, AppendLog);
 
-            layer.Add(adorner);
+            layer.Add(newAdorner);
         }
 
         private void RemoveRoiAdorners(Shape shape)
@@ -3028,7 +3028,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 // }
                 // 5) Llamada al backend /infer con el ROI canónico
                 string? shapeJson = annulus != null ? System.Text.Json.JsonSerializer.Serialize(annulus) : null;
-                var request = new BackendAPI.InferRequest("DemoRole", "DemoROI", BackendAPI.DefaultMmPerPx, cropPng)
+                var request = new InferRequest("DemoRole", "DemoROI", BackendAPI.DefaultMmPerPx, cropPng)
                 {
                     ShapeJson = shapeJson
                 };


### PR DESCRIPTION
## Summary
- rename the ROI adorner variable to avoid clashing with the foreach iterator
- construct the InferRequest using its declared type instead of referencing it off BackendAPI

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dade78328c833097ed0709bf94889e