### PR TITLE
docs: add navigation indexes across repository

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -4,6 +4,16 @@ Este documento describe los endpoints expuestos por el backend **FastAPI** de Br
 
 ---
 
+## Índice rápido
+
+- [Endpoints principales](#1-endpoints-principales)
+- [Máscaras soportadas](#2-máscaras-shape-soportadas)
+- [Persistencia de artefactos](#3-persistencia-de-artefactos)
+- [Ejemplos adicionales](#4-ejemplos-adicionales)
+- [Convenciones generales](#5-convenciones-generales)
+
+---
+
 ## 1) Endpoints principales
 
 ### 1.1 `GET /health`
@@ -128,6 +138,11 @@ curl -X POST http://127.0.0.1:8000/infer \
 - `400 Bad Request`: memoria inexistente para `(role_id, roi_id)` o datos inválidos.
 - `422 Unprocessable Entity`: payload JSON malformado.
 - `500 Internal Server Error`: excepciones no controladas (se devuelve `{ "error", "trace" }`).
+
+**Cabeceras recomendadas**
+
+- `X-Correlation-Id`: identifica cada operación extremo a extremo (la GUI genera uno por llamada y el backend lo refleja en logs).
+- `Accept: application/json`: asegura que FastAPI negocie respuestas JSON incluso si algún proxy intermedio altera la petición.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,6 +5,21 @@ Este documento describe la arquitectura actual (GUI + backend), el flujo de dato
 
 ---
 
+## Índice rápido
+
+- [Visión general](#1-visión-general)
+- [Componentes](#2-componentes)
+- [Flujo de datos end-to-end](#3-flujo-de-datos-end-to-end)
+- [Sincronización de coordenadas](#4-sincronización-de-coordenadas-gui--imagen)
+- [Backend — inferencia y persistencia](#5-backend--inferencia-y-persistencia)
+- [Extensibilidad segura](#6-extensibilidad-segura)
+- [Recursos cruzados](#7-recursos-cruzados)
+- [Seguridad y despliegue](#9-seguridad-y-despliegue)
+- [Referencias cruzadas](#10-referencias-cruzadas)
+- [Glosario rápido](#glosario-rápido)
+
+---
+
 ## 1) Visión general
 
 El sistema consta de dos procesos cooperando en tiempo real:
@@ -162,3 +177,12 @@ Para cualquier modificación sustancial, coordina con los responsables listados 
 - **DEV_GUIDE.md** (setup detallado)
 - **DEPLOYMENT.md** (smoke tests)
 - **LOGGING.md** (política de logs)
+
+---
+
+## Glosario rápido
+
+- **ROI canónica**: imagen resultante de rotar y recortar la ROI dibujada en la GUI; es la única que llega al backend.
+- **Coreset**: subconjunto representativo de embeddings OK utilizado por PatchCore para acelerar el kNN.
+- **Token shape**: altura y anchura del grid de tokens DINOv2 antes de reescalar al tamaño del ROI.
+- **Shape mask**: JSON que describe la región válida (rect/círculo/annulus) dentro de la ROI canónica.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,18 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
 
 ---
 
+## Índice rápido
+
+- [Código de conducta](#1-código-de-conducta)
+- [Primeros pasos](#2-primeros-pasos)
+- [Estilo de código](#3-estilo-de-código)
+- [Pull Requests](#4-pull-requests)
+- [Tests y validación](#5-tests-y-validación)
+- [Documentación](#6-documentación)
+- [Checklist antes de abrir un PR](#7-checklist-antes-de-abrir-un-pr)
+
+---
+
 ## 1) Código de conducta
 
 - Respeto y comunicación clara entre contribuidores.

--- a/DATA_FORMATS.md
+++ b/DATA_FORMATS.md
@@ -4,6 +4,16 @@ Este documento resume los formatos de datos utilizados entre la GUI y el backend
 
 ---
 
+## Índice rápido
+
+- [Requests al backend](#1-requests-al-backend)
+- [Responses del backend](#2-responses-del-backend)
+- [Archivos generados en disco](#3-archivos-generados-en-disco)
+- [Modelos de datos en la GUI](#4-modelos-de-datos-en-la-gui-c)
+- [Convenciones generales](#5-convenciones-generales)
+
+---
+
 ## 1) Requests al backend
 
 ### 1.1 `POST /fit_ok`
@@ -130,7 +140,8 @@ Este documento resume los formatos de datos utilizados entre la GUI y el backend
 | Archivo | Contenido |
 |---------|-----------|
 | `*.png` | ROI canónico exportado por la GUI (PNG 8/24 bits). |
-| `*.json` | Metadata asociada: `role_id`, `roi_id`, `mm_per_px`, `shape`, `source_path`, `angle`, `timestamp`. |
+| `*.json` | Metadata asociada: `role_id`, `roi_id`, `mm_per_px`, `shape`, `source_path`, `angle`, `timestamp`, `app_version?`. |
+| `manifest.json` *(opcional)* | Resumen del dataset: nº OK/NG, fecha último `fit_ok`, `threshold` vigente, `mm_per_px`. |
 
 ### 3.3 Heatmaps temporales
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,6 +4,21 @@ Guía de despliegue para ejecutar BrakeDiscInspector en entornos de desarrollo, 
 
 ---
 
+## Índice rápido
+
+- [Prerrequisitos](#1-prerrequisitos)
+- [Despliegue local](#2-despliegue-local-desarrollo)
+- [Pruebas de humo](#3-pruebas-de-humo)
+- [Despliegue en laboratorio / LAN](#4-despliegue-en-laboratorio--lan-windows)
+- [Producción (Linux)](#5-producción-linux)
+- [Variables de entorno útiles](#6-variables-de-entorno-útiles)
+- [Logging y observabilidad](#7-logging-y-observabilidad)
+- [Seguridad](#8-seguridad)
+- [Troubleshooting](#9-troubleshooting)
+- [Checklist previo a release](#10-checklist-previo-a-release)
+
+---
+
 ## 1) Prerrequisitos
 
 ### Backend
@@ -144,6 +159,8 @@ Resultados esperados:
    sudo apt install -y certbot python3-certbot-nginx
    sudo certbot --nginx -d your.server.local
    ```
+
+> **Nota sobre GPU**: si el servidor dispone de CUDA, instala las bibliotecas correspondientes antes de crear el entorno virtual (`nvidia-driver`, `cuda-toolkit`) y ajusta la variable `DEVICE=cuda` en el servicio systemd.
 
 ### 5.2 GUI en producción
 - Actualizar `appsettings.json` con la URL HTTPS del backend.

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -4,6 +4,19 @@ Guía de desarrollo para configurar, extender y probar el proyecto en entornos l
 
 ---
 
+## Índice rápido
+
+- [Preparación del repositorio](#1-preparación-del-repositorio)
+- [Backend (Python)](#2-backend-python)
+- [GUI (WPF)](#3-gui-wpf)
+- [Scripts auxiliares](#4-scripts-auxiliares-scripts)
+- [Estándares de código](#5-estándares-de-código)
+- [Testing](#6-testing)
+- [Roadmap sugerido](#7-roadmap-sugerido)
+- [Referencias cruzadas](#8-referencias-cruzadas)
+
+---
+
 ## 1) Preparación del repositorio
 
 ```bash
@@ -67,6 +80,16 @@ curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_pe
 - Revisar `logging` dentro de `app.py` y `infer.py` para tiempos parciales.
 - Ejecutar scripts/unit tests en `backend/tests/` para validar componentes aislados.
 
+### 2.7 Variables de entorno útiles
+
+| Variable | Uso | Comentario |
+|----------|-----|------------|
+| `DEVICE` | Forzar `cpu`/`cuda`. | Por defecto se autodetecta; útil cuando la GPU está ocupada. |
+| `CORESET_RATE` | Ajustar tamaño del coreset. | Acepta valores 0.01–0.05; comprueba memoria disponible antes de subirlo. |
+| `INPUT_SIZE` | Cambiar tamaño de entrada (múltiplo de 14). | Impacta en `token_shape` y en los heatmaps devueltos. |
+| `MODELS_DIR` | Definir carpeta de modelos. | Permite montar almacenamiento persistente fuera del repositorio. |
+| `UVICORN_PORT` | Sobre-escribir puerto en scripts. | Respaldado por `uvicorn` si se usa `python backend/app.py`. |
+
 ---
 
 ## 3) GUI (WPF)
@@ -94,6 +117,14 @@ curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_pe
   }
 }
 ```
+
+Puedes sobrescribir `BaseUrl` desde variables de entorno:
+
+```powershell
+$env:BRAKEDISC_BACKEND_BASEURL="http://192.168.1.20:8000"
+```
+
+o definir `BRAKEDISC_BACKEND_HOST` + `BRAKEDISC_BACKEND_PORT` para construir la URL automáticamente.
 
 ### 3.4 Flujo recomendado
 1. Cargar imagen y dibujar ROI (respetando mínimo 10×10 px).
@@ -139,6 +170,10 @@ curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_pe
 - [ ] Persistir manifiestos por ROI con estado de entrenamiento/calibración.
 - [ ] Integrar exportación de reportes (CSV/JSON) desde la GUI.
 - [ ] Instrumentar métricas Prometheus desde FastAPI.
+- [ ] Soportar múltiples ROIs simultáneos en la GUI sin romper adorners.
+- [ ] Añadir modo *batch analyze* y exportación a CSV/DB.
+- [ ] Investigar entrenamiento incremental / *online* para PatchCore.
+- [ ] Documentar integración con Prometheus/Grafana.
 ## 8) Referencias cruzadas
 - [ARCHITECTURE.md](ARCHITECTURE.md) — Visión de alto nivel y flujo de datos.
 - [API_REFERENCE.md](API_REFERENCE.md) — Contratos HTTP detallados.
@@ -146,19 +181,3 @@ curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_pe
 - [DEPLOYMENT.md](DEPLOYMENT.md) — Guía de despliegue local/prod.
 - [LOGGING.md](LOGGING.md) — Política de logging y correlación GUI↔backend.
 - [docs/mcp/overview.md](docs/mcp/overview.md) — Maintenance & Communication Plan.
-- [ ] Multiples ROIs simultáneos
-- [ ] Batch analyze
-- [ ] Entrenamiento incremental
-- [ ] Exportación resultados a CSV/DB
-- [ ] Integración Prometheus/Grafana
-
----
-
-## 9) Recursos cruzados
-
-- **ARCHITECTURE.md**: diagrama flujo
-- **API_REFERENCE.md**: contratos endpoints
-- **ROI_AND_MATCHING_SPEC.md**: geometría ROI
-- **DATA_FORMATS.md**: formatos request/response
-- **DEPLOYMENT.md**: despliegue en LAN/prod
-- **LOGGING.md**: política de logs

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -4,6 +4,16 @@ Política de logging y trazabilidad para el backend FastAPI (PatchCore + DINOv2)
 
 ---
 
+## Índice rápido
+
+- [Principios](#1-principios)
+- [Backend (FastAPI)](#2-backend-fastapi)
+- [GUI (WPF)](#3-gui-wpf)
+- [Seguridad](#4-seguridad)
+- [Checklist](#5-checklist)
+
+---
+
 ## 1) Principios
 
 - **Observabilidad**: registrar tiempos, tamaños y resultados clave sin exponer datos sensibles.
@@ -19,6 +29,7 @@ Política de logging y trazabilidad para el backend FastAPI (PatchCore + DINOv2)
 - El backend usa `logging.getLogger(__name__)` en módulos como `app.py`, `infer.py` y `storage.py`.
 - Inicializa logging en `if __name__ == "__main__"` cuando se ejecuta con `uvicorn backend.app:app` (usar `--log-level info`).
 - Para despliegues con Gunicorn, definir `log-config` o variables `LOG_LEVEL` según necesidad.
+- Habilita `uvicorn.access` si necesitas auditoría HTTP; puede redirigirse a fichero separado usando la configuración de Gunicorn/Uvicorn.
 
 ### 2.2 Eventos mínimos
 

--- a/Prompt_Backend_PatchCore_DINOv2.md
+++ b/Prompt_Backend_PatchCore_DINOv2.md
@@ -14,6 +14,16 @@
 - Necesitamos detección por **anomalía “good-only”** estilo **PatchCore** con **coreset** y kNN (FAISS/sklearn), **sin entrenar** con NG, y usar **0–3 NG** solo para **calibrar** el umbral.
 
 
+## 🧭 Índice rápido
+
+- [Objetivo técnico](#-objetivo-técnico)
+- [Estructura propuesta](#-estructura-propuesta-código-y-módulos)
+- [Extractor DINOv2](#-extractor-dinov2-vit-s--sin-entrenamiento)
+- [Memoria OK (PatchCore)](#-memoria-ok-patchcore--coreset--knn)
+- [Inferencia](#-inferencia)
+- [Calibración](#-calibración-con-0–3-ng)
+- [Endpoints HTTP](#-endpoints-http-fastapi)
+
 ## 🎯 OBJETIVO TÉCNICO
 
 Implementar un **microservicio backend** (Python) con FastAPI (o Flask), que:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 
 La documentación está organizada para que cualquier colaborador (humano o agente) pueda localizar rápidamente los contratos, las guías de desarrollo y los flujos operativos.
 
+> **Ruta de lectura sugerida**
+> 1. Empezar con la [Arquitectura](#-estructura-del-proyecto) para entender los componentes.
+> 2. Revisar la [guía de desarrollo](DEV_GUIDE.md) y el [flujo GUI](instructions_codex_gui_workflow.md) según tu perfil.
+> 3. Consultar las fichas de API y formatos cuando integres el backend.
+
+## 🧭 Índice rápido
+
+- [Características principales](#-características-principales)
+- [Estructura del proyecto](#-estructura-del-proyecto)
+- [Puesta en marcha rápida](#-puesta-en-marcha-rápida)
+- [API principal](#-api-principal)
+- [ROI y shapes](#-roi-y-shapes)
+- [Documentación relacionada](#-documentación-relacionada)
+- [Checklist para Codex](#-checklist-para-codex)
+
 ---
 
 ## ✨ Características principales
@@ -105,6 +120,16 @@ Los artefactos se guardarán automáticamente en `backend/models/Master1/Pattern
    4. (Opcional) Ejecutar **Calibrate threshold** aportando scores OK/NG.
    5. Lanzar **Infer current ROI** para obtener `score`, `threshold` y heatmap superpuesto.
 
+### Variables y rutas clave
+
+| Componente | Variable/Ruta | Descripción |
+|------------|---------------|-------------|
+| Backend | `MODELS_DIR` | Cambia la carpeta donde se guardan `memory.npz`, `index.faiss` y `calib.json`. |
+| Backend | `CORESET_RATE`, `INPUT_SIZE`, `DEVICE` | Ajustan hiperparámetros de PatchCore y del extractor DINOv2. |
+| GUI | `appsettings.json:Backend.BaseUrl` | URL del servicio FastAPI (se puede sobrescribir con `BRAKEDISC_BACKEND_BASEURL`). |
+| GUI | `appsettings.json:Backend.DatasetRoot` | Carpeta donde la GUI guarda `datasets/<role>/<roi>/<ok|ng>/`. |
+| Compartido | `datasets/<role>/<roi>/manifest.json` | (Opcional) Estado del dataset y del entrenamiento por ROI. |
+
 ---
 
 ## 🔗 API principal
@@ -130,11 +155,21 @@ Más detalles prácticos en [ROI_AND_MATCHING_SPEC.md](ROI_AND_MATCHING_SPEC.md)
 
 ## 📚 Documentación relacionada
 
-- [ARCHITECTURE.md](ARCHITECTURE.md) — vista detallada de componentes, flujo de datos y sincronización ROI.
-- [DEV_GUIDE.md](DEV_GUIDE.md) — preparación de entorno, tooling y debugging.
-- [DEPLOYMENT.md](DEPLOYMENT.md) — despliegue en local, laboratorio y producción (Gunicorn/Uvicorn).
-- [LOGGING.md](LOGGING.md) — eventos mínimos, correlación GUI↔backend, rotación de logs.
-- [docs/mcp/](docs/mcp/overview.md) — Maintenance & Communication Plan actualizado.
+- **Arquitectura y contratos**
+  - [ARCHITECTURE.md](ARCHITECTURE.md) — componentes, diagrama de flujo y reglas de coordinación GUI↔backend.
+  - [ROI_AND_MATCHING_SPEC.md](ROI_AND_MATCHING_SPEC.md) — geometría detallada, shapes y conversiones.
+  - [API_REFERENCE.md](API_REFERENCE.md) — endpoints HTTP con ejemplos `curl`.
+  - [DATA_FORMATS.md](DATA_FORMATS.md) — esquemas JSON, PNG y artefactos persistidos.
+- **Operación y desarrollo**
+  - [DEV_GUIDE.md](DEV_GUIDE.md) — setup, scripts y estándares de código.
+  - [DEPLOYMENT.md](DEPLOYMENT.md) — despliegue local/LAN/producción y smoke tests.
+  - [LOGGING.md](LOGGING.md) — política de logging y correlación de eventos.
+  - [backend/README_backend.md](backend/README_backend.md) — referencia operativa del servicio FastAPI.
+- **Coordinación y agentes**
+  - [instructions_codex_gui_workflow.md](instructions_codex_gui_workflow.md) — checklist completo para desarrollar la GUI.
+  - [backend/agents_for_backend.md](backend/agents_for_backend.md) — playbook de mantenimiento del backend.
+  - [docs/mcp/overview.md](docs/mcp/overview.md) — Maintenance & Communication Plan y responsables.
+  - [docs/mcp/latest_updates.md](docs/mcp/latest_updates.md) — bitácora de cambios coordinados.
 
 ---
 

--- a/ROI_AND_MATCHING_SPEC.md
+++ b/ROI_AND_MATCHING_SPEC.md
@@ -4,6 +4,18 @@ Especificación de las Regiones de Interés (ROI) y de la información geométri
 
 ---
 
+## Índice rápido
+
+- [Modelo de ROI en la GUI](#1-modelo-de-roi-en-la-gui)
+- [Canonicalización del ROI](#2-canonicalización-del-roi)
+- [Shapes soportados](#3-shapes-soportados-por-el-backend)
+- [Conversión de coordenadas](#4-conversión-de-coordenadas-gui--imagen)
+- [Integración con el backend](#5-integración-con-el-backend)
+- [Persistencia de datasets](#6-persistencia-de-datasets)
+- [Áreas y unidades](#7-áreas-y-unidades)
+
+---
+
 ## 1) Modelo de ROI en la GUI
 
 | Campo | Tipo | Descripción |

--- a/agents.md
+++ b/agents.md
@@ -2,8 +2,27 @@
 
 This document defines **roles, scope, constraints, workflows, and acceptance criteria** for assistants/agents (e.g., GitHub Copilot/Codex) collaborating on this repository.
 
-> **Context**: The project consists of a WPF GUI for **ROI drawing and export** (crop + rotation) and a Python FastAPI backend implementing an **anomaly detection pipeline (PatchCore + DINOv2)**.  
+> **Context**: The project consists of a WPF GUI for **ROI drawing and export** (crop + rotation) and a Python FastAPI backend implementing an **anomaly detection pipeline (PatchCore + DINOv2)**.
 > The GUI is responsible for **canonical ROI** generation; the backend **does not** crop/rotate images.
+
+---
+
+## Quick index
+
+- [Repository layout](#0-repository-layout-expected)
+- [Roles](#1-roles-agents)
+- [Critical constraints](#2-critical-constraints-non-regression)
+- [Backend contract](#3-backend-contract-stable)
+- [GUI workflows](#4-gui-workflows)
+- [Shape JSON](#5-shape-json-canonical-image-coordinates)
+- [Coding standards & UX](#6-coding-standards--ux-gui)
+- [Acceptance criteria](#7-acceptance-criteria)
+- [Test plan](#8-test-plan-qa)
+- [Do / Don’t](#9-do--dont-quick-reference)
+- [Open questions](#10-open-questions-ask-before-coding-if-unclear)
+- [Backend quick-start](#11-backend-quick-start-for-local-dev)
+- [Glossary](#12-glossary)
+- [Contact points](#13-contact-points)
 
 ---
 

--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -10,6 +10,17 @@ Microservicio FastAPI para **detección de anomalías “good-only”**:
 
 ---
 
+## Índice rápido
+
+- [Instalación](#1-instalación)
+- [Ejecución](#2-ejecución)
+- [Endpoints](#3-endpoints)
+- [Notas de diseño](#4-notas-de-diseño)
+- [Integración con la GUI](#5-integración-con-la-gui-wpf-esquema)
+- [Consejos de rendimiento](#6-consejos-de-rendimiento)
+
+---
+
 ## 1) Instalación
 
 ```bash
@@ -179,6 +190,7 @@ curl -X POST http://127.0.0.1:8000/infer   -F role_id=Master1   -F roi_id=Patter
   - `models/<role>/<roi>/index.faiss` (si FAISS)
   - `models/<role>/<roi>/calib.json` (umbral, p99_ok, p5_ng, mm_per_px, etc.)
 - **Respuesta de `/infer`**: añade `params` con metadatos de extractor, coreset y configuración usada.
+- **Configuración**: variables como `DEVICE`, `INPUT_SIZE`, `CORESET_RATE`, `MODELS_DIR` pueden definirse en un `.env` o como variables del sistema; revisa `DEV_GUIDE.md` para detalles.
 
 ---
 

--- a/backend/agents_for_backend.md
+++ b/backend/agents_for_backend.md
@@ -3,8 +3,21 @@
 This playbook is for assistants/agents implementing and maintaining the **backend anomaly detection service**.
 The service is a **FastAPI** microservice that provides PatchCore-style anomaly detection with a **frozen DINOv2 ViT‑S/14** feature extractor.
 
-> **Key contract**: The **GUI supplies a canonical ROI image** (already **cropped + rotated**).  
+> **Key contract**: The **GUI supplies a canonical ROI image** (already **cropped + rotated**).
 > Backend must **not** change geometry (no extra crop/rotate). Optional `shape` only **masks** the heatmap (rect/circle/annulus).
+
+---
+
+## Quick index
+
+- [Repository layout](#0-repository-layout-backend)
+- [API (stable contract)](#1-api-stable-contract)
+- [Persistence](#2-persistence-formats)
+- [Feature extractor](#3-feature-extractor-dinov2)
+- [PatchCore memory](#4-patchcore-memory)
+- [Inference pipeline](#5-inference-pipeline)
+- [Configuration](#6-configuration)
+- [Validation & Errors](#7-validation--errors)
 
 ---
 

--- a/docs/mcp/latest_updates.md
+++ b/docs/mcp/latest_updates.md
@@ -7,6 +7,19 @@ This log records notable Maintenance & Communication Plan (MCP) events for Brake
 - **Summary** of the change and links to detailed documents or pull requests
 - **Next Steps / Follow-ups** when applicable
 
+## Quick index
+
+- [2024-06-12 — Comprehensive Markdown Refresh](#2024-06-12--comprehensive-markdown-refresh)
+- [2024-06-05 — PatchCore Documentation Refresh](#2024-06-05--patchcore-documentation-refresh)
+- [2024-05-28 — Initial MCP Publication](#2024-05-28--initial-mcp-publication)
+
+## 2024-06-12 — Comprehensive Markdown Refresh
+
+- **Owners:** MCP Maintainer, Backend Lead, GUI Lead
+- **Summary:** Reorganised every Markdown guide with quick indices, environment tables and cross-links to ease onboarding after cache resets. Highlighted environment variables (`DEVICE`, `CORESET_RATE`, `MODELS_DIR`) and clarified dataset manifests for GUI workflows.
+- **Evidence:** Updated files — `README.md`, `ARCHITECTURE.md`, `API_REFERENCE.md`, `DATA_FORMATS.md`, `DEV_GUIDE.md`, `DEPLOYMENT.md`, `LOGGING.md`, `ROI_AND_MATCHING_SPEC.md`, `backend/README_backend.md`, `backend/agents_for_backend.md`, `instructions_codex_gui_workflow.md`, `gui/BrakeDiscInspector_GUI_ROI/README.md`, `docs/mcp/overview.md`.
+- **Next Steps:** Share the new documentation index with new contributors and capture feedback during the next sync meeting.
+
 ## 2024-06-05 — PatchCore Documentation Refresh
 
 - **Owners:** MCP Maintainer, Backend Lead, GUI Lead

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -2,6 +2,17 @@
 
 The Maintenance & Communication Plan (MCP) keeps all contributors aligned on how BrakeDiscInspector evolves. It complements the architectural, data-format and API guides by clarifying responsibilities, coordination workflows and artefact ownership.
 
+## Quick index
+
+- [Scope](#scope)
+- [Roles & Responsibilities](#roles--responsibilities)
+- [Change Management Workflow](#change-management-workflow)
+- [Artefact Registry](#artefact-registry)
+- [Model & Dataset Update Playbook](#model--dataset-update-playbook)
+- [Logging & Observability Coordination](#logging--observability-coordination)
+- [Release Cadence](#release-cadence)
+- [Maintaining this Folder](#maintaining-this-folder)
+
 ## Scope
 
 The MCP covers every change that can affect:

--- a/gui/BrakeDiscInspector_GUI_ROI/README.md
+++ b/gui/BrakeDiscInspector_GUI_ROI/README.md
@@ -6,6 +6,18 @@ Aplicación WPF (.NET 8) que permite preparar ROIs, gestionar datasets y comunic
 
 ---
 
+## Índice rápido
+
+- [Objetivo](#1-objetivo)
+- [Flujo principal](#2-flujo-principal)
+- [Estructura del proyecto](#3-estructura-del-proyecto)
+- [Configuración](#4-configuración)
+- [Problemas comunes](#5-problemas-comunes)
+- [Registro](#6-registro)
+- [Referencias](#7-referencias)
+
+---
+
 ## 2. Flujo principal
 
 1. Cargar imagen (BMP/PNG/JPG) en la vista principal.

--- a/instructions_codex_gui_workflow.md
+++ b/instructions_codex_gui_workflow.md
@@ -4,6 +4,23 @@
 
 ---
 
+## Quick index
+
+- [Scope & Non-Regression Rules](#scope--non-regression-rules)
+- [Backend Contract](#backend-contract-summary)
+- [New GUI Features](#new-gui-features-tabs-or-wizard)
+- [Shape JSON mapping](#shape-json-mapping-from-existing-roi-types)
+- [File/Folder Structure](#filefolder-structure-gui-side)
+- [New/Updated Code](#newupdated-code-wpf)
+- [Error Handling & UX](#error-handling--ux)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing Plan](#testing-plan)
+- [Coding Standards](#coding-standards)
+- [Deliverables](#deliverables)
+- [Do/Don’t Summary](#dodont-summary)
+
+---
+
 ## Scope & Non‑Regression Rules
 
 1. **Scope**: Modify **GUI (WPF)** only. The backend (FastAPI) already exposes `/fit_ok`, `/calibrate_ng`, `/infer`, `/health`.


### PR DESCRIPTION
## Summary
- add quick navigation indexes and cross-link tables to the main project documentation
- document key environment variables and dataset manifest hints for backend and GUI workflows
- record the documentation refresh in the MCP latest updates log for future coordination

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dae34b38708330a1e201b50481bc06