### PR TITLE
Persist master pattern crops and enhance local matcher

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
@@ -40,5 +40,54 @@ namespace BrakeDiscInspector_GUI_ROI.Tests
             Assert.InRange(center.Value.Y, 39.5, 40.5);
             Assert.InRange(score, 90, 100);
         }
+
+        [Fact]
+        public void MatchInSearchROI_UsesOverridePatternWhenProvided()
+        {
+            using var fullImage = new Mat(new Size(200, 200), MatType.CV_8UC3, Scalar.Black);
+
+            // Pattern positioned away from the search ROI center
+            var patternRect = new Rect(70, 90, 40, 30);
+            Cv2.Rectangle(fullImage, patternRect, new Scalar(10, 220, 30), -1);
+            Cv2.Circle(fullImage, new Point(patternRect.X + patternRect.Width / 2, patternRect.Y + patternRect.Height / 2), 10,
+                new Scalar(180, 20, 200), -1);
+
+            var patternRoi = new RoiModel
+            {
+                Shape = RoiShape.Rectangle,
+                X = patternRect.X + patternRect.Width / 2.0,
+                Y = patternRect.Y + patternRect.Height / 2.0,
+                Width = patternRect.Width,
+                Height = patternRect.Height
+            };
+
+            var searchRoi = new RoiModel
+            {
+                Shape = RoiShape.Rectangle,
+                X = 110,
+                Y = 110,
+                Width = 120,
+                Height = 120
+            };
+
+            using var patternView = new Mat(fullImage, patternRect);
+            using var patternOverride = patternView.Clone();
+
+            var (center, score) = LocalMatcher.MatchInSearchROI(
+                fullImage,
+                patternRoi,
+                searchRoi,
+                feature: "tm_rot",
+                thr: 0,
+                rotRange: 0,
+                scaleMin: 1.0,
+                scaleMax: 1.0,
+                patternOverride: patternOverride);
+
+            Assert.NotNull(center);
+            Assert.InRange(center.Value.X, patternRoi.X - 0.5, patternRoi.X + 0.5);
+            Assert.InRange(center.Value.Y, patternRoi.Y - 0.5, patternRoi.Y + 0.5);
+            Assert.InRange(score, 70, 100);
+        }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -6,8 +6,10 @@ namespace BrakeDiscInspector_GUI_ROI
     public class MasterLayout
     {
         public RoiModel? Master1Pattern { get; set; }
+        public string? Master1PatternImagePath { get; set; }
         public RoiModel? Master1Search { get; set; }
         public RoiModel? Master2Pattern { get; set; }
+        public string? Master2PatternImagePath { get; set; }
         public RoiModel? Master2Search { get; set; }
         public RoiModel? Inspection { get; set; }
         public RoiModel? InspectionBaseline { get; set; }


### PR DESCRIPTION
## Summary
- persist canonical PNG paths for master pattern ROIs in the master layout
- export stable master pattern crops when saving masters and reuse them during analysis
- allow the local matcher to accept an override template image and cover it with tests

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db8b405e788330a3a5478431cc861b