### PR TITLE
Fix ambiguous Rect reference in ROI crop helper

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2312,7 +2312,7 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         private bool TryBuildRoiCrop(RoiModel roi, string logTag, out Mat? cropWithAlpha,
-            out RoiCropInfo cropInfo, out Rect cropRect)
+            out RoiCropInfo cropInfo, out Cv.Rect cropRect)
         {
             cropWithAlpha = null;
             cropInfo = default;


### PR DESCRIPTION
## Summary
- disambiguate the Rect type in MainWindow.xaml.cs by using the OpenCvSharp alias for ROI crops

## Testing
- not run (WPF project requires Windows build tooling)


------
https://chatgpt.com/codex/tasks/task_e_68db8dc9a7a48330802efee11c29ef10