### PR TITLE
Enforce minimum annulus inner radius for easier interaction

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/AnnulusDefaultsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/AnnulusDefaultsTests.cs
@@ -1,0 +1,30 @@
+using BrakeDiscInspector_GUI_ROI;
+using Xunit;
+
+namespace BrakeDiscInspector_GUI_ROI.Tests;
+
+public class AnnulusDefaultsTests
+{
+    [Theory]
+    [InlineData(double.NaN, 60.0, 10.0)]
+    [InlineData(-5.0, 60.0, 10.0)]
+    [InlineData(0.0, 60.0, 10.0)]
+    [InlineData(4.0, 60.0, 10.0)]
+    [InlineData(12.0, 60.0, 12.0)]
+    [InlineData(80.0, 60.0, 60.0)]
+    public void ClampInnerRadius_HonorsMinimumWhenOuterAllows(double requested, double outer, double expected)
+    {
+        double clamped = AnnulusDefaults.ClampInnerRadius(requested, outer);
+        Assert.Equal(expected, clamped, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(0.0, 5.0, 0.0)]
+    [InlineData(3.0, 5.0, 3.0)]
+    [InlineData(7.0, 5.0, 5.0)]
+    public void ClampInnerRadius_AllowsSmallerAnnulusWhenOuterTooSmall(double requested, double outer, double expected)
+    {
+        double clamped = AnnulusDefaults.ClampInnerRadius(requested, outer);
+        Assert.Equal(expected, clamped, precision: 6);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/AnnulusDefaults.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AnnulusDefaults.cs
@@ -5,6 +5,7 @@ namespace BrakeDiscInspector_GUI_ROI
     internal static class AnnulusDefaults
     {
         public const double DefaultInnerRadiusRatio = 0.6;
+        public const double MinimumInnerRadius = 10.0; // pixels (=> 20 px diameter)
 
         public static double ResolveInnerRadius(double requestedInnerRadius, double outerRadius)
         {
@@ -32,6 +33,10 @@ namespace BrakeDiscInspector_GUI_ROI
                 inner = 0;
             if (inner > outerRadius)
                 inner = outerRadius;
+
+            double minAllowed = outerRadius >= MinimumInnerRadius ? MinimumInnerRadius : 0.0;
+            if (inner < minAllowed)
+                inner = minAllowed;
 
             return inner;
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/ROI.cs
@@ -50,8 +50,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
                 if (Shape == RoiShape.Annulus)
                 {
-                    if (RInner < 0) RInner = 0;
-                    if (RInner > R) RInner = R;
+                    RInner = AnnulusDefaults.ClampInnerRadius(RInner, R);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- enforce a minimum 10 px inner radius for annulus ROI handling so the inner diameter is at least 20 px when possible
- ensure ROI minimum size normalization clamps annulus inner radius through the shared defaults helper
- add unit coverage verifying the new clamping behavior

## Testing
- dotnet test BrakeDiscInspector/gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c2687d988330a54dd5706c91be41