### PR TITLE
Fix annulus overlay misalignment after window resize

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3541,6 +3541,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 RoiOverlay.Height = h;
                 RoiOverlay.SnapsToDevicePixels = true;
                 RenderOptions.SetEdgeMode(RoiOverlay, EdgeMode.Aliased);
+                RoiOverlay.InvalidateVisual();
             }
 
             // Estabilidad visual


### PR DESCRIPTION
## Summary
- trigger a redraw of the ROI overlay after synchronizing it to the image letterbox
- ensure the annulus label snaps back into place immediately after window resizes

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c8c1340c8330a26a3d0b9f137bd4