### PR TITLE
Improve ROI overlay resync on layout changes

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -62,6 +62,8 @@ namespace BrakeDiscInspector_GUI_ROI
         private BitmapSource? _heatmapBitmap;
         private RoiModel? _heatmapRoiImage;
         private double _heatmapOverlayOpacity = 0.6;
+        private System.Windows.Rect _lastImageDisplayRect = System.Windows.Rect.Empty;
+        private const double DisplayRectChangeTolerance = 0.5;
 
         private Shape? _previewShape;
         private bool _isDrawing;
@@ -151,6 +153,7 @@ namespace BrakeDiscInspector_GUI_ROI
             InitWorkflow();
 
             ImgMain.SizeChanged += ImgMain_SizeChanged;
+            ImgMain.LayoutUpdated += ImgMain_LayoutUpdated;
             this.SizeChanged += MainWindow_SizeChanged;
             this.Loaded += MainWindow_Loaded;
         }
@@ -389,6 +392,8 @@ namespace BrakeDiscInspector_GUI_ROI
             ImgMain.Source = _imgSourceBI;
             _imgW = _imgSourceBI.PixelWidth;
             _imgH = _imgSourceBI.PixelHeight;
+
+            _lastImageDisplayRect = System.Windows.Rect.Empty;
 
             try
             {
@@ -971,6 +976,35 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             ScheduleSyncOverlay(force: true);
             RefreshHeatmapOverlay();
+        }
+
+        private void ImgMain_LayoutUpdated(object? sender, EventArgs e)
+        {
+            var currentRect = GetImageDisplayRect();
+
+            if (currentRect.Width <= 0 || currentRect.Height <= 0)
+            {
+                _lastImageDisplayRect = currentRect;
+                return;
+            }
+
+            bool lastInvalid = _lastImageDisplayRect.Width <= 0 || _lastImageDisplayRect.Height <= 0;
+            bool changed = lastInvalid || HasMeaningfulDisplayRectDelta(currentRect, _lastImageDisplayRect);
+
+            _lastImageDisplayRect = currentRect;
+
+            if (changed)
+            {
+                ScheduleSyncOverlay(force: true);
+            }
+        }
+
+        private static bool HasMeaningfulDisplayRectDelta(System.Windows.Rect current, System.Windows.Rect previous)
+        {
+            return Math.Abs(current.X - previous.X) > DisplayRectChangeTolerance ||
+                   Math.Abs(current.Y - previous.Y) > DisplayRectChangeTolerance ||
+                   Math.Abs(current.Width - previous.Width) > DisplayRectChangeTolerance ||
+                   Math.Abs(current.Height - previous.Height) > DisplayRectChangeTolerance;
         }
 
 


### PR DESCRIPTION
## Summary
- track the rendered image display rectangle and reschedule the ROI overlay sync when layout updates move the letterboxed image
- reset the cached display rectangle when loading a new image so subsequent layout events trigger a fresh alignment

## Testing
- dotnet test gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop is unavailable in this Linux environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cab144688330a444557f851a9e46