### PR TITLE
Expose ROI overlay transform and sync ROI visuals

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
@@ -33,7 +33,8 @@ public class RoiAdornerTests
         Canvas.SetLeft(annulus, 0);
         Canvas.SetTop(annulus, 0);
 
-        var adorner = new RoiAdorner(annulus, (_, _) => { }, _ => { });
+        var overlay = new RoiOverlay();
+        var adorner = new RoiAdorner(annulus, overlay, (_, _) => { }, _ => { });
 
         InvokeResizeByCorner(adorner, 20.0, -20.0, "NE");
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -146,19 +146,24 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             InitializeComponent();
 
-            if (RoiOverlay != null)
-            {
-                // Vincular overlay con la imagen para conocer su rectángulo renderizado (Stretch=Uniform)
-                RoiOverlay.BindToImage(ImgMain);
-            }
+            // (si no está ya) vincular overlay a la Image y recalcular en cambios de tamaño
+            RoiOverlay.BindToImage(ImgMain);
+            ImgMain.SizeChanged += (_, __) => RoiOverlay.InvalidateOverlay();
+            SizeChanged += (_, __) => RoiOverlay.InvalidateOverlay();
 
-            if (ImgMain != null)
+            // === NUEVO: sincronizar CanvasROI con la misma transform imagen (scale+offset) ===
+            RoiOverlay.OverlayTransformChanged += (_, __) =>
             {
-                // Recalcular transform cuando cambie el tamaño de la imagen o la ventana
-                ImgMain.SizeChanged += (_, __) => RoiOverlay?.InvalidateOverlay();
-            }
+                var tg = new TransformGroup();
+                tg.Children.Add(new ScaleTransform(RoiOverlay.Scale, RoiOverlay.Scale));
+                tg.Children.Add(new TranslateTransform(RoiOverlay.OffsetX, RoiOverlay.OffsetY));
+                CanvasROI.RenderTransform = tg;
+                CanvasROI.RenderTransformOrigin = new Point(0, 0);
+            };
 
-            SizeChanged += (_, __) => RoiOverlay?.InvalidateOverlay();
+            // Fuerza una primera actualización al iniciar
+            RoiOverlay.InvalidateOverlay();
+
             _preset = PresetManager.LoadOrDefault(_preset);
 
             InitUI();
@@ -404,7 +409,7 @@ namespace BrakeDiscInspector_GUI_ROI
             _imgSourceBI.EndInit();
 
             ImgMain.Source = _imgSourceBI;
-            RoiOverlay?.InvalidateOverlay();
+            RoiOverlay.InvalidateOverlay();
             _imgW = _imgSourceBI.PixelWidth;
             _imgH = _imgSourceBI.PixelHeight;
 

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -25,8 +25,8 @@ namespace BrakeDiscInspector_GUI_ROI
     /// callback: onChanged(changeKind, modelUpdated)
     public class RoiAdorner : Adorner
     {
-        private readonly Shape _shape;
         private readonly RoiOverlay _overlay;
+        private readonly Shape _shape;
         private readonly Action<RoiAdornerChangeKind, RoiModel> _onChanged;
         private readonly Action<string> _log;
 
@@ -146,6 +146,21 @@ namespace BrakeDiscInspector_GUI_ROI
                 return _innerRadiusThumb;
 
             throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        protected override GeneralTransform GetDesiredTransform(GeneralTransform transform)
+        {
+            var baseT = base.GetDesiredTransform(transform);
+
+            // Matriz: primero escalar, luego trasladar
+            var m = new Matrix();
+            m.ScaleAt(_overlay.Scale, _overlay.Scale, 0, 0);
+            m.Translate(_overlay.OffsetX, _overlay.OffsetY);
+
+            var gt = new GeneralTransformGroup();
+            if (baseT != null) gt.Children.Add(baseT);
+            gt.Children.Add(new MatrixTransform(m));
+            return gt;
         }
 
         protected override Size ArrangeOverride(Size finalSize)

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
@@ -9,6 +9,14 @@ namespace BrakeDiscInspector_GUI_ROI
 {
     public class RoiOverlay : FrameworkElement
     {
+        // === Exponer la transform actual del overlay ===
+        public double Scale => _scale;
+        public double OffsetX => _offX;
+        public double OffsetY => _offY;
+
+        // Evento para avisar de cambios en la transform (scale/offset)
+        public event EventHandler? OverlayTransformChanged;
+
         public ROI? Roi { get; set; }
 
         // === Transformación imagen <-> pantalla ===
@@ -57,12 +65,17 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 _scale = 1.0;
                 _offX = _offY = 0.0;
+                // Notificar identidad cuando no hay imagen/tamaño válido
+                OverlayTransformChanged?.Invoke(this, EventArgs.Empty);
                 return;
             }
 
             _scale = Math.Min(sw / _imgW, sh / _imgH);
             _offX = (sw - _imgW * _scale) * 0.5;
             _offY = (sh - _imgH * _scale) * 0.5;
+
+            // Notificar a quien se suscriba (Canvas/Adorner) que cambió la transform
+            OverlayTransformChanged?.Invoke(this, EventArgs.Empty);
         }
 
         // Conversión coordenadas


### PR DESCRIPTION
## Summary
- expose the ROI overlay scale/offset along with a change event
- update the main window to mirror the overlay transform on CanvasROI and refresh after loading images
- feed the overlay transform into RoiAdorner so adorners follow the image transform and adjust unit tests

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fcfd12488330a3725867ae3b4543