### PR TITLE
Fix point alias ambiguity and update ROI adorner transform

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -14,6 +14,8 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
+using WPoint = System.Windows.Point;
+using CvPoint = OpenCvSharp.Point;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -33,7 +35,6 @@ using WColor = System.Windows.Media.Color;
 using WEllipse = System.Windows.Shapes.Ellipse;
 using WLine = System.Windows.Shapes.Line;
 // Aliases WPF
-using WPoint = System.Windows.Point;
 using WRect = System.Windows.Rect;
 using WRectShape = System.Windows.Shapes.Rectangle;
 using Path = System.IO.Path;
@@ -158,7 +159,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 tg.Children.Add(new ScaleTransform(RoiOverlay.Scale, RoiOverlay.Scale));
                 tg.Children.Add(new TranslateTransform(RoiOverlay.OffsetX, RoiOverlay.OffsetY));
                 CanvasROI.RenderTransform = tg;
-                CanvasROI.RenderTransformOrigin = new Point(0, 0);
+                CanvasROI.RenderTransformOrigin = new WPoint(0, 0);
             };
 
             // Fuerza una primera actualización al iniciar

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -148,11 +148,11 @@ namespace BrakeDiscInspector_GUI_ROI
             throw new ArgumentOutOfRangeException(nameof(index));
         }
 
-        protected override GeneralTransform GetDesiredTransform(GeneralTransform transform)
+        public override GeneralTransform GetDesiredTransform(GeneralTransform transform)
         {
             var baseT = base.GetDesiredTransform(transform);
 
-            // Matriz: primero escalar, luego trasladar
+            // Matriz: primero escalar, luego trasladar (valores del overlay)
             var m = new Matrix();
             m.ScaleAt(_overlay.Scale, _overlay.Scale, 0, 0);
             m.Translate(_overlay.OffsetX, _overlay.OffsetY);


### PR DESCRIPTION
## Summary
- add explicit point aliases in the main window to resolve the WPF/OpenCV name clash
- keep the canvas origin assignment on the WPF point alias to avoid ambiguity warnings
- expose `RoiAdorner.GetDesiredTransform` publicly so the overlay transform applies the scale and offset stored in the overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e402b2967083308179fc60dc4c7434