### PR TITLE
Fix annulus ROI frame drift during resize

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -548,12 +548,12 @@ namespace BrakeDiscInspector_GUI_ROI
             }
             else
             {
+                // Para Circle y Annulus: SIEMPRE cuadrado perfecto (2·R)
                 double diameter = Math.Max(canvasRoi.Width, canvasRoi.R * 2.0);
-                double height = canvasRoi.Shape == RoiShape.Annulus && canvasRoi.Height > 0 ? canvasRoi.Height : diameter;
                 Canvas.SetLeft(shape, canvasRoi.CX - diameter / 2.0);
-                Canvas.SetTop(shape, canvasRoi.CY - height / 2.0);
+                Canvas.SetTop(shape, canvasRoi.CY - diameter / 2.0);
                 shape.Width = diameter;
-                shape.Height = height;
+                shape.Height = diameter;
             }
 
             shape.Tag = canvasRoi;


### PR DESCRIPTION
## Summary
- enforce a square bounding box when drawing circle and annulus ROI overlays so the frame stays aligned after window resizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42296f9bc8330a8fea38724e3e704