### PR TITLE
Fix annulus overlay scaling and adorner coordinate mapping

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -30,7 +30,9 @@
                                 Panel.ZIndex="1"/>
                         <local:RoiOverlay x:Name="RoiOverlay"
                                           IsHitTestVisible="False"
-                                          Panel.ZIndex="2"/>
+                                          Panel.ZIndex="2"
+                                          HorizontalAlignment="Stretch"
+                                          VerticalAlignment="Stretch"/>
                     </Grid>
                 </Grid>
             </AdornerDecorator>

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiOverlay.cs
@@ -1,131 +1,213 @@
 using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 
 namespace BrakeDiscInspector_GUI_ROI
 {
     public class RoiOverlay : FrameworkElement
     {
+        // === Transformación imagen <-> pantalla ===
+        private Image _boundImage;
+        private double _scale = 1.0;
+        private double _offX = 0.0, _offY = 0.0;
+        private int _imgW = 0, _imgH = 0;
+
+        // Vincula este overlay con la Image real (ImgMain)
+        public void BindToImage(Image image)
+        {
+            _boundImage = image;
+            InvalidateOverlay();
+        }
+
+        // Fuerza recálculo y repintado
+        public void InvalidateOverlay()
+        {
+            RecomputeImageTransform();
+            InvalidateVisual();
+        }
+
+        // Recalcular scale/offset asumiendo Stretch=Uniform y letterbox centrado
+        private void RecomputeImageTransform()
+        {
+            if (_boundImage?.Source is System.Windows.Media.Imaging.BitmapSource bmp)
+            {
+                _imgW = bmp.PixelWidth;
+                _imgH = bmp.PixelHeight;
+            }
+            else
+            {
+                _imgW = _imgH = 0;
+            }
+
+            if (_imgW <= 0 || _imgH <= 0)
+            {
+                _scale = 1.0;
+                _offX = _offY = 0.0;
+                return;
+            }
+
+            double sw = ActualWidth;
+            double sh = ActualHeight;
+
+            if ((sw <= 0 || sh <= 0) && _boundImage != null)
+            {
+                sw = _boundImage.ActualWidth;
+                sh = _boundImage.ActualHeight;
+            }
+
+            if (sw <= 0 || sh <= 0)
+            {
+                _scale = 1.0;
+                _offX = _offY = 0.0;
+                return;
+            }
+
+            _scale = Math.Min(sw / _imgW, sh / _imgH);
+            _offX = (sw - _imgW * _scale) * 0.5;
+            _offY = (sh - _imgH * _scale) * 0.5;
+        }
+
+        // Conversión coordenadas
+        public System.Windows.Point ToScreen(double ix, double iy)
+        {
+            return new System.Windows.Point(_offX + ix * _scale, _offY + iy * _scale);
+        }
+
+        public double ToScreenLen(double ilen) => ilen * _scale;
+
+        public System.Windows.Point ToImage(double sx, double sy)
+        {
+            if (_scale <= 0.0)
+                return new System.Windows.Point(0.0, 0.0);
+
+            return new System.Windows.Point((sx - _offX) / _scale, (sy - _offY) / _scale);
+        }
+
+        public double ToImageLen(double slen)
+        {
+            if (_scale <= 0.0)
+                return 0.0;
+            return slen / _scale;
+        }
         public ROI Roi { get; set; }
 
         protected override void OnRender(DrawingContext dc)
         {
-            if (Roi == null) return;
+            base.OnRender(dc);
+            RecomputeImageTransform();
 
-            Roi.EnforceMinSize(10, 10);
+            var roi = Roi;
+            if (roi == null)
+                return;
 
-            // Mapear píxeles de imagen → coords del CanvasROI (mismo que usa el adorner)
-            var mw = Window.GetWindow(this) as MainWindow;
-            if (mw == null) return;
-
-            if (mw.ImgMain.Source is not System.Windows.Media.Imaging.BitmapSource bmp) return;
-
-            double canvasWidth = mw.CanvasROI?.ActualWidth ?? 0;
-            double canvasHeight = mw.CanvasROI?.ActualHeight ?? 0;
-
-            if (canvasWidth <= 0 || canvasHeight <= 0)
-            {
-                canvasWidth = this.ActualWidth;
-                canvasHeight = this.ActualHeight;
-            }
-
-            if (canvasWidth <= 0 || canvasHeight <= 0) return;
-
-            double sx = canvasWidth / bmp.PixelWidth;
-            double sy = canvasHeight / bmp.PixelHeight;
-
-            double centerImageX = Roi.Shape == RoiShape.Rectangle ? Roi.X : Roi.CX;
-            double centerImageY = Roi.Shape == RoiShape.Rectangle ? Roi.Y : Roi.CY;
-
-            double widthPx = Roi.Width;
-            double heightPx = Roi.Height;
-
-            if (Roi.Shape == RoiShape.Circle || Roi.Shape == RoiShape.Annulus)
-            {
-                double radius = Roi.R > 0 ? Roi.R : Math.Max(Roi.Width, Roi.Height) / 2.0;
-                double diameter = radius * 2.0;
-                widthPx = diameter;
-                heightPx = diameter;
-            }
-
-            double cx = centerImageX * sx;
-            double cy = centerImageY * sy;
-            double w = widthPx * sx;
-            double h = heightPx * sy;
-
-            var rect = new System.Windows.Rect(cx - w / 2, cy - h / 2, w, h);
-            var rotate = new RotateTransform(Roi.AngleDeg, cx, cy);
-            var pen = new Pen(Brushes.Lime, 2);
-
-            dc.PushTransform(rotate);
-
-            switch (Roi.Shape)
-            {
-                case RoiShape.Rectangle:
-                    dc.DrawRectangle(null, pen, rect);
-                    break;
-                case RoiShape.Circle:
-                    dc.DrawEllipse(null, pen, new System.Windows.Point(cx, cy), w / 2.0, h / 2.0);
-                    break;
-                case RoiShape.Annulus:
-                    {
-                        double outerRadius = Roi.R > 0 ? Roi.R : Math.Max(Roi.Width, Roi.Height) / 2.0;
-                        if (outerRadius <= 0)
-                            outerRadius = Math.Max(Roi.Width, Roi.Height) / 2.0;
-
-                        double outerRadiusX = outerRadius * sx;
-                        double outerRadiusY = outerRadius * sy;
-
-                        double innerCandidate = Roi.RInner;
-                        double innerRadius = innerCandidate > 0
-                            ? AnnulusDefaults.ClampInnerRadius(innerCandidate, outerRadius)
-                            : AnnulusDefaults.ResolveInnerRadius(innerCandidate, outerRadius);
-
-                        double innerRadiusX = innerRadius * sx;
-                        double innerRadiusY = innerRadius * sy;
-
-                        var center = new System.Windows.Point(cx, cy);
-                        var geometry = new StreamGeometry { FillRule = FillRule.EvenOdd };
-                        using (var ctx = geometry.Open())
-                        {
-                            ctx.BeginFigure(new System.Windows.Point(center.X + outerRadiusX, center.Y), false, false);
-                            ctx.ArcTo(new System.Windows.Point(center.X - outerRadiusX, center.Y), new Size(outerRadiusX, outerRadiusY), 0,
-                                false, SweepDirection.Clockwise, true, false);
-                            ctx.ArcTo(new System.Windows.Point(center.X + outerRadiusX, center.Y), new Size(outerRadiusX, outerRadiusY), 0,
-                                false, SweepDirection.Clockwise, true, false);
-
-                            if (innerRadius > 0)
-                            {
-                                ctx.BeginFigure(new System.Windows.Point(center.X + innerRadiusX, center.Y), false, false);
-                                ctx.ArcTo(new System.Windows.Point(center.X - innerRadiusX, center.Y), new Size(innerRadiusX, innerRadiusY), 0,
-                                    false, SweepDirection.Counterclockwise, true, false);
-                                ctx.ArcTo(new System.Windows.Point(center.X + innerRadiusX, center.Y), new Size(innerRadiusX, innerRadiusY), 0,
-                                    false, SweepDirection.Counterclockwise, true, false);
-                            }
-                        }
-
-                        geometry.Freeze();
-                        dc.DrawGeometry(null, pen, geometry);
-                        break;
-                    }
-                default:
-                    dc.DrawRectangle(null, pen, rect);
-                    break;
-            }
+            roi.EnforceMinSize(10, 10);
 
             var dpi = VisualTreeHelper.GetDpi(this);
 
+            System.Windows.Point centerImage = roi.Shape == RoiShape.Rectangle
+                ? new System.Windows.Point(roi.X, roi.Y)
+                : new System.Windows.Point(roi.CX, roi.CY);
+
+            var centerScreen = ToScreen(centerImage.X, centerImage.Y);
+
+            switch (roi.Shape)
+            {
+                case RoiShape.Rectangle:
+                    DrawRectangle(dc, roi, centerScreen, dpi.PixelsPerDip);
+                    break;
+                case RoiShape.Circle:
+                    DrawCircle(dc, roi, centerScreen, dpi.PixelsPerDip);
+                    break;
+                case RoiShape.Annulus:
+                    DrawAnnulus(dc, roi, centerScreen, dpi.PixelsPerDip);
+                    break;
+            }
+        }
+
+        private void DrawRectangle(DrawingContext dc, ROI roi, System.Windows.Point centerScreen, double pixelsPerDip)
+        {
+            double widthScreen = ToScreenLen(roi.Width);
+            double heightScreen = ToScreenLen(roi.Height);
+
+            var rect = new Rect(centerScreen.X - widthScreen / 2.0, centerScreen.Y - heightScreen / 2.0, widthScreen, heightScreen);
+            var rotate = new RotateTransform(roi.AngleDeg, centerScreen.X, centerScreen.Y);
+            var pen = new Pen(Brushes.Lime, 2.0);
+
+            dc.PushTransform(rotate);
+            dc.DrawRectangle(null, pen, rect);
+            dc.Pop();
+
+            DrawLabel(dc, roi.Legend, rect.TopLeft, pixelsPerDip, Brushes.Lime);
+        }
+
+        private void DrawCircle(DrawingContext dc, ROI roi, System.Windows.Point centerScreen, double pixelsPerDip)
+        {
+            double radius = roi.R > 0 ? roi.R : Math.Max(roi.Width, roi.Height) / 2.0;
+            double radiusScreen = ToScreenLen(radius);
+
+            var pen = new Pen(Brushes.DeepSkyBlue, 2.0);
+            dc.DrawEllipse(null, pen, centerScreen, radiusScreen, radiusScreen);
+
+            var labelAnchor = new System.Windows.Point(centerScreen.X - radiusScreen, centerScreen.Y - radiusScreen);
+            DrawLabel(dc, roi.Legend, labelAnchor, pixelsPerDip, Brushes.DeepSkyBlue);
+        }
+
+        private void DrawAnnulus(DrawingContext dc, ROI roi, System.Windows.Point centerScreen, double pixelsPerDip)
+        {
+            double outerRadius = roi.R > 0 ? roi.R : Math.Max(roi.Width, roi.Height) / 2.0;
+            if (outerRadius <= 0)
+                outerRadius = Math.Max(roi.Width, roi.Height) / 2.0;
+
+            double ro = ToScreenLen(outerRadius);
+            double innerCandidate = roi.RInner;
+            double riImage = innerCandidate > 0
+                ? AnnulusDefaults.ClampInnerRadius(innerCandidate, outerRadius)
+                : AnnulusDefaults.ResolveInnerRadius(innerCandidate, outerRadius);
+            double ri = ToScreenLen(riImage);
+
+            var circlePen = new Pen(Brushes.DeepSkyBlue, 2.0);
+            dc.DrawEllipse(null, circlePen, centerScreen, ro, ro);
+            dc.DrawEllipse(null, circlePen, centerScreen, ri, ri);
+
+            var dashedPen = new Pen(Brushes.OrangeRed, 1.5)
+            {
+                DashStyle = new DashStyle(new double[] { 4, 4 }, 0)
+            };
+            dc.DrawEllipse(null, dashedPen, centerScreen, ro, ro);
+
+            var label = string.IsNullOrWhiteSpace(roi.Legend) ? "Annulus" : roi.Legend;
             var ft = new FormattedText(
-                Roi.Legend,
-                System.Globalization.CultureInfo.CurrentCulture,
+                label,
+                System.Globalization.CultureInfo.CurrentUICulture,
                 FlowDirection.LeftToRight,
                 new Typeface("Segoe UI"),
                 12,
-                Brushes.Lime,
-                dpi.PixelsPerDip);
+                Brushes.White,
+                pixelsPerDip);
 
-            dc.DrawText(ft, new System.Windows.Point(rect.X, rect.Y - 16));
-            dc.Pop();
+            var labelPos = new System.Windows.Point(centerScreen.X - ft.Width / 2.0, centerScreen.Y - ro - ft.Height - 6);
+            dc.DrawRectangle(new SolidColorBrush(Color.FromArgb(160, 0, 0, 0)), null,
+                new Rect(labelPos.X - 4, labelPos.Y - 2, ft.Width + 8, ft.Height + 4));
+            dc.DrawText(ft, labelPos);
+        }
+
+        private void DrawLabel(DrawingContext dc, string legend, System.Windows.Point anchor, double pixelsPerDip, Brush brush)
+        {
+            if (string.IsNullOrWhiteSpace(legend))
+                return;
+
+            var ft = new FormattedText(
+                legend,
+                System.Globalization.CultureInfo.CurrentUICulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Segoe UI"),
+                12,
+                brush,
+                pixelsPerDip);
+
+            var labelPos = new System.Windows.Point(anchor.X, anchor.Y - ft.Height - 4);
+            dc.DrawText(ft, labelPos);
         }
 
 


### PR DESCRIPTION
## Summary
- bind the ROI overlay to the main image and invalidate its transform whenever the viewport changes
- implement a robust Stretch=Uniform transform in `RoiOverlay` and redraw the annulus using the computed scale/offset
- map adorner interactions through the overlay conversion helpers so ROI models remain in image coordinates

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4266f3818833097e197c60482d01a