### PR TITLE
Fix ROI overlay redraw timing on adorner click and resize

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -665,7 +665,8 @@ namespace BrakeDiscInspector_GUI_ROI
             var newAdorner = new RoiAdorner(shape, RoiOverlay, (changeKind, updatedModel) =>
             {
                 var pixelModel = CanvasToImage(updatedModel);
-                UpdateLayoutFromPixel(pixelModel);
+                // Evitar salto del frame al hacer click en un adorner (sin arrastrar):
+                // no redibujamos aquí; delegamos en HandleAdornerChange con gating.
                 HandleAdornerChange(changeKind, updatedModel, pixelModel, "[adorner]");
             }, AppendLog);
 
@@ -1444,7 +1445,9 @@ namespace BrakeDiscInspector_GUI_ROI
                     break;
             }
 
-            UpdateOverlayFromPixelModel(pixelModel);
+            // Redibuja solo si hubo cambio geométrico real (no al iniciar el drag).
+            if (changeKind != RoiAdornerChangeKind.DragStarted)
+                UpdateOverlayFromPixelModel(pixelModel);
         }
 
         private void HandleDragStarted(RoiModel canvasModel, RoiModel pixelModel, string contextLabel)
@@ -3585,14 +3588,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
-            // ✅ Alineado: si había redibujo pendiente, hazlo ahora
-            if (_overlayNeedsRedraw)
-            {
-                AppendLog("[sync] overlay pendiente → redibujar ahora");
-                RedrawOverlay();
-                _overlayNeedsRedraw = false;
-            }
-
+            AppendLog("[sync] redibujar overlay tras realinear canvas");
+            RedrawOverlay();
+            _overlayNeedsRedraw = false; // defensivo
             RefreshHeatmapOverlay();
         }
 


### PR DESCRIPTION
## Summary
- stop forcing an overlay redraw from the adorner callback to avoid frame jumps on drag start
- redraw the overlay only after actual drag updates and always after canvas realignment during layout sync

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e50e1e2df483309fce9fa419347dd0