### PR TITLE
Hide ROI frames and render canvas labels

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -29,6 +29,7 @@
                                 IsHitTestVisible="True"
                                 Panel.ZIndex="1"/>
                         <local:RoiOverlay x:Name="RoiOverlay"
+                                          Visibility="Collapsed"
                                           IsHitTestVisible="False"
                                           Panel.ZIndex="2"
                                           HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Summary
- collapse the ROI overlay in the main window so it no longer renders visible frames
- add canvas-based text labels for each ROI and hide the underlying shapes while keeping hit-testing
- keep ROI labels synchronized during adorner edits, dragging, and redraws while cleaning up orphaned labels

## Testing
- dotnet build *(fails: Microsoft.NET.Sdk.WindowsDesktop not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e545775bfc8330b376f8400bc46aa3