### PR TITLE
docs: refresh documentation and add project overview

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,24 +1,20 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+**Cambios clave documentados en esta versión:**
+- Contratos `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` sincronizados con la implementación actual de `backend/app.py`.
+- Ejemplos `curl` actualizados para dataset `datasets/<role>/<roi>/<ok|ng>/` y respuestas reales (`score`, `threshold`, `heatmap_png_base64`, `regions`).
+- Detalles añadidos sobre máscaras (`shape`) y persistencia en `backend/models/<role>/<roi>/`.
 
 # API_REFERENCE — BrakeDiscInspector
 
-Este documento describe los endpoints expuestos por el backend **FastAPI** de BrakeDiscInspector, sus parámetros, respuestas y ejemplos prácticos.
+El backend FastAPI expone cuatro endpoints estables utilizados por la GUI WPF y por scripts externos. Este documento describe parámetros, respuestas, códigos de error y artefactos generados.
 
 ---
 
 ## Índice rápido
 
 - [Endpoints principales](#1-endpoints-principales)
-- [Máscaras soportadas](#2-máscaras-shape-soportadas)
+- [Máscaras soportadas](#2-máscaras-soportadas)
 - [Persistencia de artefactos](#3-persistencia-de-artefactos)
 - [Ejemplos adicionales](#4-ejemplos-adicionales)
 - [Convenciones generales](#5-convenciones-generales)
@@ -29,39 +25,42 @@ Este documento describe los endpoints expuestos por el backend **FastAPI** de Br
 
 ### 1.1 `GET /health`
 
-- **Descripción**: Comprueba que el servicio está disponible y muestra información de dispositivo/modelo.
-- **URL base**: `http://<host>:8000/health`
-
-**Respuesta 200 OK**
-```json
-{
-  "status": "ok",
-  "device": "cuda",
-  "model": "vit_small_patch14_dinov2.lvd142m",
-  "version": "0.1.0"
-}
-```
+- **Descripción**: comprueba que el servicio está disponible y devuelve información del modelo base.
+- **URL**: `http://<host>:<puerto>/health`
+- **Respuesta 200 OK**
+  ```json
+  {
+    "status": "ok",
+    "device": "cuda",
+    "model": "vit_small_patch14_dinov2.lvd142m",
+    "version": "0.1.0"
+  }
+  ```
 
 ### 1.2 `POST /fit_ok`
 
-- **Descripción**: Recibe lotes de ROIs OK y construye/actualiza la memoria PatchCore (coreset + índice).
-- **Método**: `multipart/form-data`
+- **Descripción**: construye la memoria PatchCore a partir de ROIs OK (PNG/JPG ya rotados y recortados por la GUI).
+- **Tipo**: `multipart/form-data`
 - **Campos obligatorios**:
-  - `role_id` *(str)* — Identificador del rol/preset (ej. `Master1`).
-  - `roi_id` *(str)* — Identificador de la ROI (ej. `Pattern`).
-  - `mm_per_px` *(float)* — Resolución de la ROI para reporting (mm por pixel).
-  - `images` *(files[])* — Uno o más PNG/JPG del ROI canónico (crop + rotación ya aplicados por la GUI).
-
-**Respuesta 200 OK**
-```json
-{
-  "n_embeddings": 34992,
-  "coreset_size": 700,
-  "token_shape": [32, 32],
-  "coreset_rate_requested": 0.02,
-  "coreset_rate_applied": 0.018
-}
-```
+  | Campo | Tipo | Descripción |
+  |-------|------|-------------|
+  | `role_id` | string | Rol actual (ej. `Master1`). |
+  | `roi_id` | string | Identificador de la ROI (ej. `Pattern`). |
+  | `mm_per_px` | float | Resolución del ROI (mm por pixel). |
+  | `images` | fichero(s) | Uno o más PNG/JPG canónicos. |
+- **Respuesta 200 OK**
+  ```json
+  {
+    "n_embeddings": 34992,
+    "coreset_size": 700,
+    "token_shape": [32, 32],
+    "coreset_rate_requested": 0.02,
+    "coreset_rate_applied": 0.018
+  }
+  ```
+- **Notas**:
+  - Si las imágenes producen `token_shape` diferentes, la petición falla con 400 (`"Token grid mismatch"`).
+  - El backend persiste `memory.npz`, `index.faiss` (si FAISS disponible) y metadata del coreset.【F:backend/app.py†L54-L118】【F:backend/storage.py†L12-L64】
 
 **Ejemplo `curl`**
 ```bash
@@ -75,9 +74,9 @@ curl -X POST http://127.0.0.1:8000/fit_ok \
 
 ### 1.3 `POST /calibrate_ng`
 
-- **Descripción**: Calcula y persiste el umbral óptimo por `(role_id, roi_id)` a partir de scores OK/NG.
-- **Método**: `application/json`
-- **Body**:
+- **Descripción**: calcula y guarda el umbral óptimo por `(role_id, roi_id)` usando scores OK (y opcionalmente NG).
+- **Tipo**: `application/json`
+- **Body**
   ```json
   {
     "role_id": "Master1",
@@ -89,51 +88,54 @@ curl -X POST http://127.0.0.1:8000/fit_ok \
     "score_percentile": 99
   }
   ```
-- `ng_scores` es opcional; si se omite, el umbral será `p99(OK)`.
-
-**Respuesta 200 OK**
-```json
-{
-  "threshold": 20.0,
-  "p99_ok": 12.0,
-  "p5_ng": 28.0,
-  "mm_per_px": 0.2,
-  "area_mm2_thr": 1.0,
-  "score_percentile": 99
-}
-```
+- **Respuesta 200 OK**
+  ```json
+  {
+    "threshold": 20.0,
+    "p99_ok": 12.0,
+    "p5_ng": 28.0,
+    "mm_per_px": 0.2,
+    "area_mm2_thr": 1.0,
+    "score_percentile": 99
+  }
+  ```
+- **Notas**:
+  - `ng_scores` es opcional; si no se envía, el umbral se fija en `p99(ok_scores)`.
+  - El resultado se guarda como `calib.json` bajo `backend/models/<role>/<roi>/`.【F:backend/app.py†L120-L166】【F:backend/storage.py†L66-L79】
 
 ### 1.4 `POST /infer`
 
-- **Descripción**: Ejecuta inferencia sobre un ROI canónico usando la memoria entrenada.
-- **Método**: `multipart/form-data`
+- **Descripción**: ejecuta inferencia sobre un ROI canónico usando la memoria entrenada.
+- **Tipo**: `multipart/form-data`
 - **Campos**:
-  - `role_id`, `roi_id`, `mm_per_px` — mismos valores utilizados durante el entrenamiento/calibración.
-  - `image` *(file)* — PNG/JPG del ROI canónico.
-  - `shape` *(string, opcional)* — JSON que describe la máscara en coordenadas del ROI (`rect`, `circle`, `annulus`).
-
-**Respuesta 200 OK (resumen)**
-```json
-{
-  "role_id": "Master1",
-  "roi_id": "Pattern",
-  "score": 18.7,
-  "threshold": 20.0,
-  "heatmap_png_base64": "iVBORw0K...",
-  "regions": [
-    {"bbox": [x, y, w, h], "area_px": 250.0, "area_mm2": 10.0, "contour": [[x1, y1], ...]}
-  ],
-  "token_shape": [32, 32],
-  "params": {
-    "extractor": "vit_small_patch14_dinov2.lvd142m",
-    "input_size": 448,
-    "patch_size": 14,
-    "coreset_rate": 0.02,
-    "score_percentile": 99,
-    "mm_per_px": 0.2
+  | Campo | Tipo | Descripción |
+  |-------|------|-------------|
+  | `role_id` | string | Debe coincidir con el usado en `/fit_ok`. |
+  | `roi_id` | string | Debe coincidir con el usado en `/fit_ok`. |
+  | `mm_per_px` | float | Resolución para convertir áreas. |
+  | `image` | fichero | ROI canónico (PNG/JPG). |
+  | `shape` | string (opcional) | JSON con máscara (`rect`, `circle`, `annulus`). |
+- **Respuesta 200 OK**
+  ```json
+  {
+    "score": 18.7,
+    "threshold": 20.0,
+    "token_shape": [32, 32],
+    "heatmap_png_base64": "iVBORw0K...",
+    "regions": [
+      {
+        "bbox": [120, 96, 80, 64],
+        "area_px": 250.0,
+        "area_mm2": 10.0,
+        "contour": [[120,96],[199,96],...]
+      }
+    ]
   }
-}
-```
+  ```
+- **Notas**:
+  - `threshold` puede ser `null` si no se ejecutó `/calibrate_ng`.
+  - La máscara `shape` se aplica antes de calcular percentiles y regiones.【F:backend/infer.py†L66-L132】【F:backend/app.py†L168-L214】
+  - Los contornos se filtran por `area_mm2_thr` convertido a píxeles mediante `mm_per_px`.【F:backend/infer.py†L133-L181】
 
 **Ejemplo `curl`**
 ```bash
@@ -145,85 +147,76 @@ curl -X POST http://127.0.0.1:8000/infer \
   -F shape='{"kind":"circle","cx":192,"cy":192,"r":180}'
 ```
 
-**Códigos de error**
-- `400 Bad Request`: memoria inexistente para `(role_id, roi_id)` o datos inválidos.
-- `422 Unprocessable Entity`: payload JSON malformado.
-- `500 Internal Server Error`: excepciones no controladas (se devuelve `{ "error", "trace" }`).
-
-**Cabeceras recomendadas**
-
-- `X-Correlation-Id`: identifica cada operación extremo a extremo (la GUI genera uno por llamada y el backend lo refleja en logs).
-- `Accept: application/json`: asegura que FastAPI negocie respuestas JSON incluso si algún proxy intermedio altera la petición.
+**Errores comunes**
+- `400` con `{ "error": "Memoria no encontrada..." }` cuando falta `memory.npz` para `(role_id, roi_id)`.
+- `400` con `{ "error": "Token grid mismatch..." }` si el ROI de inferencia no coincide con el `token_shape` entrenado.
+- `500` con `{ "error", "trace" }` cuando ocurre una excepción no controlada (revisar logs backend).
 
 ---
 
-## 2) Máscaras (`shape`) soportadas
+## 2) Máscaras soportadas
 
-Todas las coordenadas se expresan en el espacio del ROI canónico (post crop + rotación):
+Las máscaras (`shape`) se expresan en píxeles del ROI canónico (post rotación/crop):
 
-- **Rectángulo completo**:
+- **Rectángulo**
   ```json
   {"kind":"rect","x":0,"y":0,"w":W,"h":H}
   ```
-- **Círculo**:
+- **Círculo**
   ```json
   {"kind":"circle","cx":CX,"cy":CY,"r":R}
   ```
-- **Annulus**:
+- **Annulus**
   ```json
   {"kind":"annulus","cx":CX,"cy":CY,"r":R_OUTER,"r_inner":R_INNER}
   ```
 
-Si no se envía `shape`, el backend asume la imagen completa.
+Si no se envía `shape`, se considera todo el ROI. El backend construye las máscaras con `roi_mask.build_mask` antes de calcular heatmap y score.【F:backend/roi_mask.py†L1-L160】
 
 ---
 
 ## 3) Persistencia de artefactos
 
-Tras un `POST /fit_ok` exitoso, se genera la carpeta `backend/models/<role>/<roi>/` con:
+Tras un `/fit_ok` exitoso se crea `backend/models/<role>/<roi>/` con:
 
-- `memory.npz` — embeddings del coreset (`emb`), `token_h`, `token_w`, `metadata` (coreset rate aplicado).
-- `index.faiss` — índice serializado (si FAISS está disponible).
-- `calib.json` — creado por `/calibrate_ng` con `threshold`, percentiles y parámetros de área.
+| Archivo | Descripción |
+|---------|-------------|
+| `memory.npz` | Embeddings del coreset (`emb`), `token_h`, `token_w`, metadata (`coreset_rate`, `applied_rate`). |
+| `index.faiss` | Índice serializado (si FAISS está disponible). |
+| `calib.json` | Creado por `/calibrate_ng` con `threshold`, percentiles, `mm_per_px`, `area_mm2_thr`. |
 
-Los endpoints `/infer` y `/calibrate_ng` leen estos artefactos para mantener consistencia entre ejecuciones.
+`/infer` reutiliza estos artefactos para reconstruir `PatchCoreMemory` y aplicar la calibración sin reentrenar.【F:backend/app.py†L134-L214】【F:backend/storage.py†L38-L79】
 
 ---
 
 ## 4) Ejemplos adicionales
 
 ### 4.1 Obtener scores para calibración manual
-
-Para recolectar scores de muestras NG antes de llamar a `/calibrate_ng`:
 ```bash
 curl -X POST http://127.0.0.1:8000/infer \
   -F role_id=Master1 \
   -F roi_id=Pattern \
   -F mm_per_px=0.20 \
   -F image=@datasets/Master1/Pattern/ng/sample_ng.png \
-  -F shape='{"kind":"rect","x":0,"y":0,"w":384,"h":384}' \
-  | jq '.score'
+  -F shape='{"kind":"rect","x":0,"y":0,"w":384,"h":384}' | jq '.score'
 ```
 
 ### 4.2 Reentrenar con muestras adicionales
+Repite `/fit_ok` con nuevas imágenes; la memoria y el índice se sobrescriben con los embeddings actualizados.
 
-Repite `/fit_ok` tantas veces como sea necesario; el backend sobrescribe `memory.npz` e índice con los embeddings recalculados.
-
-### 4.3 Limpieza de artefactos
-
-Para reiniciar un rol/ROI:
+### 4.3 Limpiar artefactos
 ```bash
 rm -rf backend/models/Master1/Pattern
 ```
-La próxima llamada a `/infer` devolverá `400` indicando que falta memoria.
+La siguiente llamada a `/infer` devolverá `400` indicando que falta memoria.
 
 ---
 
 ## 5) Convenciones generales
 
-- Imágenes esperadas: PNG/JPG en BGR (`cv2.imdecode`).
-- Tamaño de entrada: se reescala internamente al múltiplo de 14 más cercano al `input_size` configurado (448 por defecto).
-- Percentil de score: configurable vía `score_percentile` (99 por defecto) y persistido en `calib.json`.
-- Respuestas de error: `{ "error": "mensaje", "trace": "stacktrace" }` para facilitar debugging desde la GUI.
+- Las imágenes se decodifican con OpenCV (`cv2.imdecode`) en BGR `uint8` antes de extraer embeddings.【F:backend/app.py†L46-L71】
+- El extractor reescala internamente al `input_size` configurado (448 por defecto) y devuelve `token_shape` (`Ht`, `Wt`).
+- El score global usa percentil configurable (99 por defecto) y se recalcula en `InferenceEngine.run` cada vez.【F:backend/infer.py†L80-L120】
+- Las respuestas de error siempre incluyen `{ "error": "mensaje", "trace": "stacktrace" }` en 4xx/5xx cuando el backend captura excepciones.【F:backend/app.py†L116-L214】
 
-Para más detalles sobre formatos JSON y almacenamiento en disco consulta [DATA_FORMATS.md](DATA_FORMATS.md) y [backend/README_backend.md](backend/README_backend.md).
+Para detalles adicionales sobre formatos y almacenamiento consulta [DATA_FORMATS.md](DATA_FORMATS.md) y [backend/README_backend.md](backend/README_backend.md).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,18 +1,13 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
-
+**Cambios clave documentados en esta versión:**
+- Se actualizan los componentes GUI/Backend para reflejar las clases activas (`BackendClient`, `DatasetManager`, `InferenceEngine`).
+- Diagramas y flujo end-to-end alineados con los endpoints estables (`/fit_ok`, `/calibrate_ng`, `/infer`).
+- Se documenta la sincronización ROI ↔ heatmap y la persistencia `backend/models/<role>/<roi>/` según `ModelStore`.
 
 # ARCHITECTURE — BrakeDiscInspector
 
-Este documento describe la arquitectura actual (GUI + backend), el flujo de datos extremo a extremo y las zonas donde se pueden extender las funcionalidades sin romper contratos existentes.
+Visión global del sistema BrakeDiscInspector, compuesto por una GUI WPF para gestionar ROIs y un backend FastAPI que ejecuta PatchCore + DINOv2. Incluye componentes, flujo de datos y pautas de extensibilidad.
 
 ---
 
@@ -21,29 +16,27 @@ Este documento describe la arquitectura actual (GUI + backend), el flujo de dato
 - [Visión general](#1-visión-general)
 - [Componentes](#2-componentes)
 - [Flujo de datos end-to-end](#3-flujo-de-datos-end-to-end)
-- [Sincronización de coordenadas](#4-sincronización-de-coordenadas-gui--imagen)
+- [Sincronización de coordenadas](#4-sincronización-de-coordenadas)
 - [Backend — inferencia y persistencia](#5-backend--inferencia-y-persistencia)
 - [Extensibilidad segura](#6-extensibilidad-segura)
 - [Recursos cruzados](#7-recursos-cruzados)
-- [Seguridad y despliegue](#9-seguridad-y-despliegue)
-- [Referencias cruzadas](#10-referencias-cruzadas)
 - [Glosario rápido](#glosario-rápido)
 
 ---
 
 ## 1) Visión general
 
-El sistema consta de dos procesos cooperando en tiempo real:
+El sistema se divide en dos procesos que colaboran en tiempo real:
 
-- **GUI (WPF / .NET 8)**: captura imágenes, permite dibujar/rotar la ROI, gestiona datasets de muestras, llama al backend para entrenar/calibrar/inferir y superpone heatmaps sobre el ROI canónico.
-- **Backend (FastAPI / Python 3.10+)**: recibe el ROI ya canónico, extrae embeddings con DINOv2, aplica memoria PatchCore y genera score + heatmap + regiones.
+- **GUI (WPF / .NET 8)**: captura imágenes, permite dibujar/rotar ROIs, gestiona datasets (`datasets/<role>/<roi>/<ok|ng>/`), llama al backend para entrenar/calibrar/inferir y superpone heatmaps.
+- **Backend (FastAPI / Python 3.10+)**: recibe ROIs ya canónicos, extrae embeddings con DINOv2 ViT-S/14, ejecuta PatchCore y devuelve score + heatmap + regiones filtradas.
 
 ```mermaid
 flowchart LR
-    U[Usuario] -->|Carga imagen / Gestiona dataset| G[GUI WPF<br/>OpenCvSharp]
-    G -->|/fit_ok, /calibrate_ng, /infer| B[(FastAPI<br/>PatchCore + DINOv2)]
-    B -->|n_embeddings / threshold / heatmap / regiones| G
-    G -->|Overlay + reporting| U
+    U[Operador] -->|Carga imagen / Ajusta ROI| GUI[GUI WPF]
+    GUI -->|/fit_ok /calibrate_ng /infer| BE[(FastAPI PatchCore)]
+    BE -->|score / threshold / heatmap / regiones| GUI
+    GUI -->|Overlay + reporting| U
 ```
 
 ---
@@ -52,148 +45,100 @@ flowchart LR
 
 ### 2.1 GUI (WPF)
 
-- **MainWindow.xaml / .cs**: orquesta la UI, pestañas de Dataset/Train/Infer y binding con ViewModels.
-- **ROI/**: clases de dominio (`ROI.cs`, `ROIShape.cs`, `AnnulusShape.cs`, etc.) y adorners (`RoiAdorner`, `RoiRotateAdorner`, `ResizeAdorner`). **No modificar** geometrías ni pipelines de canonicalización.
-- **Overlays/**: `RoiOverlay.cs` y helpers que sincronizan el canvas con la imagen (`Stretch="Uniform"`).
-- **BackendClient.cs** (o `BackendAPI.cs`): cliente HTTP async que implementa `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` usando `HttpClient` y `MultipartFormDataContent`.
-- **Datasets/**: utilidades para guardar PNG + metadata JSON por `(role_id, roi_id)` en `datasets/<role>/<roi>/<ok|ng>/`.
+- **MainWindow.xaml/.cs** — Orquesta pestañas Dataset/Train/Infer y binding con `WorkflowViewModel`.
+- **Workflow/BackendClient.cs** — Cliente HTTP asíncrono para `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` (gestiona `HttpClient`, JSON y errores).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs†L20-L218】
+- **Workflow/DatasetManager.cs** — Exporta ROIs canónicos (PNG) y metadatos (`shape_json`, `mm_per_px`, `angle`, `timestamp`).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetManager.cs†L18-L80】
+- **Workflow/DatasetSample.cs** — Lee metadatos y genera thumbnails para la UI.【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs†L1-L120】
+- **ROI/*.cs & RoiAdorner.cs** — Adorners y modelo ROI; NO modificar geometría ni transformaciones.【F:gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs†L1-L200】
+- **RoiCropUtils.cs** — Pipeline de canonicalización (rotación + recorte) y máscara ROI.【F:gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs†L62-L200】
 
 ### 2.2 Backend (FastAPI)
 
-- **app.py**: define endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` y maneja orquestación de inferencia (lectura de archivos, respuesta JSON).【F:backend/app.py†L1-L199】
-- **features.py**: wrapper sobre `timm` para cargar `vit_small_patch14_dinov2.lvd142m`, normalizar entrada y devolver embeddings + `token_shape`.【F:backend/features.py†L1-L200】
-- **patchcore.py**: implementación del coreset k-center greedy y kNN (FAISS/NearestNeighbors).【F:backend/patchcore.py†L1-L200】
-- **infer.py**: lógica de inferencia (distancias→heatmap→score→contornos) e integración con máscaras (`roi_mask.py`).【F:backend/infer.py†L1-L200】
-- **storage.py**: persistencia de `memory.npz`, `index.faiss` y `calib.json` en `models/<role>/<roi>/`.【F:backend/storage.py†L1-L200】
-- **calib.py**: cálculo del umbral a partir de scores OK/NG (percentiles configurables).【F:backend/calib.py†L1-L160】
+- **app.py** — Endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, manejo de errores y conversión heatmap→PNG.【F:backend/app.py†L1-L214】
+- **features.py** — `DinoV2Features` (modelo `vit_small_patch14_dinov2.lvd142m`) con resize y normalización automática.【F:backend/features.py†L1-L200】
+- **patchcore.py** — Construcción de memoria (coreset k-center greedy) y kNN (FAISS opcional).【F:backend/patchcore.py†L1-L200】
+- **infer.py** — `InferenceEngine.run` genera heatmap, percentiles, máscaras y regiones con áreas px/mm².【F:backend/infer.py†L17-L181】
+- **calib.py** — Selección de threshold a partir de percentiles OK/NG (`choose_threshold`).【F:backend/calib.py†L1-L120】
+- **storage.py** — Persistencia en `models/<role>/<roi>/` (`memory.npz`, `index.faiss`, `calib.json`).【F:backend/storage.py†L12-L79】
+- **roi_mask.py** — Reconstrucción de máscaras (`rect`, `circle`, `annulus`) para enmascarar heatmaps.【F:backend/roi_mask.py†L1-L160】
 
 ---
 
-## 3) Flujo de datos (end-to-end)
+## 3) Flujo de datos end-to-end
 
 ```mermaid
 sequenceDiagram
-    participant U as Usuario
+    participant U as Operador
     participant GUI as GUI WPF
-    participant ROI as Canonical ROI Pipeline
-    participant BE as Backend FastAPI
+    participant DS as DatasetManager
+    participant BE as FastAPI
     participant PC as PatchCore/DINOv2
 
-    U->>GUI: Cargar imagen / ajustar ROI
-    GUI->>ROI: Exportar ROI canónico (crop + rotación)
-    GUI->>Datasets: Guardar PNG + metadata (opcional)
+    U->>GUI: Cargar imagen / dibujar ROI
+    GUI->>GUI: Canonicalizar ROI (RoiCropUtils)
+    GUI->>DS: Guardar PNG + metadata (role, roi, mm_per_px, shape_json)
     GUI->>BE: POST /fit_ok (images[])
-    BE->>PC: Extraer embeddings + coreset + persistir memoria
+    BE->>PC: Extraer embeddings, coreset, guardar memory.npz
     GUI->>BE: POST /calibrate_ng (scores OK/NG)
-    BE->>storage: Guardar calib.json
+    BE->>storage: Guardar calib.json (threshold, percentiles)
     GUI->>BE: POST /infer (image + shape)
-    BE->>PC: Calcular distancias → heatmap → score
-    PC->>BE: Contornos + regiones filtradas por área_mm²
-    BE-->>GUI: JSON (score, threshold, heatmap_png_base64, regions)
-    GUI->>GUI: Superponer heatmap + mostrar métricas
+    BE->>PC: Calcular heatmap + score + regiones
+    PC-->>BE: Resultado (score, threshold, heatmap, regions)
+    BE-->>GUI: JSON + heatmap PNG base64
+    GUI->>GUI: Overlay heatmap + mostrar métricas
 ```
 
 Notas clave:
-- El backend **no** realiza rotaciones ni recortes; depende del ROI canónico generado en la GUI.
-- La máscara `shape` permite limitar el área evaluada (rectángulo, círculo o annulus) dentro del ROI canónico.
+- El backend nunca rota ni recorta imágenes; depende del ROI canónico exportado por la GUI.
+- El `shape` opcional limita la zona evaluada dentro del ROI.
 
 ---
 
-## 4) Sincronización de coordenadas GUI ↔ imagen
+## 4) Sincronización de coordenadas
 
-### 4.1 Letterboxing y canvas
-
-La imagen principal se muestra con `Stretch="Uniform"`. El canvas que contiene adorners y overlays replica la zona visible mediante:
-
-```
-scale = min(ImageHost.ActualWidth  / PixelWidth,
-            ImageHost.ActualHeight / PixelHeight)
-drawWidth  = PixelWidth  * scale
-drawHeight = PixelHeight * scale
-offsetX = (ImageHost.ActualWidth  - drawWidth)  / 2
-offsetY = (ImageHost.ActualHeight - drawHeight) / 2
-
-CanvasROI.Width  = drawWidth
-CanvasROI.Height = drawHeight
-Canvas.SetLeft(CanvasROI, offsetX)
-Canvas.SetTop(CanvasROI,  offsetY)
-```
-
-### 4.2 Conversión de coordenadas
-
-- **Imagen → Canvas**: `(canvasX, canvasY) = (imageX * sx, imageY * sy)` con `sx = CanvasROI.Width / PixelWidth`.
-- **Canvas → Imagen**: `(imageX, imageY) = (canvasX / sx, canvasY / sy)`.
-
-### 4.3 Canonicalización del ROI
-
-La GUI reutiliza el mismo pipeline que “Save Master/Pattern” (`TryBuildRoiCropInfo(...)` → `TryGetRotatedCrop(...)`) para:
-1. Rotar la imagen completa alrededor del centro del ROI (`Cv2.GetRotationMatrix2D` + `Cv2.WarpAffine`).
-2. Recortar el subrectángulo resultante (mínimo 10×10 px).
-3. Generar PNG + metadata JSON; el tamaño resultante define el espacio para el heatmap devuelto.
+- La imagen principal se muestra con `Stretch="Uniform"`; `RoiOverlay` calcula escala y offsets para mantener la relación imagen↔canvas.
+- Conversión:
+  - Imagen → Canvas: `canvas = image * scale + offset`.
+  - Canvas → Imagen: `image = (canvas - offset) / scale`.
+- El heatmap devuelto (`heatmap_png_base64`) tiene el mismo tamaño que el ROI canónico; se superpone directamente usando `ImageBrush` en la GUI.
 
 ---
 
 ## 5) Backend — inferencia y persistencia
 
-1. **Lectura**: el archivo recibido (`UploadFile`) se decodifica con `cv2.imdecode` a BGR (`np.uint8`).
-2. **Carga de memoria**: `storage.ModelStore.load_memory()` obtiene embeddings (`memory.npz`) y metadatos (`token_shape`, `coreset_rate`). Se reconstruye FAISS si existe `index.faiss`.
-3. **Embeddings**: `DinoV2Features.extract()` realiza resize al tamaño soportado (múltiplo de 14, por defecto 448) y devuelve `embeddings` + `(Ht, Wt)`.
-4. **PatchCore**: `InferenceEngine.run()` calcula distancias kNN (`k=1`), interpola el mapa a tamaño ROI, aplica blur, máscara `shape`, percentile `p_score` y filtrado por `area_mm2_thr` (conversión px/mm²).
-5. **Respuesta**: se codifica el heatmap en PNG Base64 y se devuelven `score`, `threshold`, `regions` (bbox, área px/mm², contorno) y `token_shape`.
-
-Persistencia:
-- `/fit_ok` guarda `memory.npz` con `emb`, `token_h`, `token_w` y metadata del coreset.
-- `/calibrate_ng` guarda `calib.json` con `threshold`, `p99_ok`, `p5_ng`, `mm_per_px`, `area_mm2_thr`, `score_percentile`.
-- `/infer` reutiliza los artefactos anteriores sin reentrenar.
+1. **Carga de imagen**: `app.py` lee el `UploadFile`, lo decodifica con OpenCV y extrae embeddings (`DinoV2Features`).【F:backend/app.py†L46-L92】
+2. **Memoria**: `ModelStore.load_memory` reconstruye el coreset y, si existe, el índice FAISS guardado en disco.【F:backend/storage.py†L38-L64】
+3. **Inferencia**: `InferenceEngine.run` genera heatmap, aplica máscara (`roi_mask.build_mask`), calcula score (p99) y filtra contornos por `area_mm2_thr`.【F:backend/infer.py†L66-L181】
+4. **Respuesta**: `app.py` convierte el heatmap a PNG base64, añade `token_shape`, `regions` y `threshold` (si calibrado).【F:backend/app.py†L168-L214】
+5. **Persistencia**: `/fit_ok` sobrescribe `memory.npz`/`index.faiss`; `/calibrate_ng` guarda `calib.json` con percentiles y parámetros.
 
 ---
 
 ## 6) Extensibilidad segura
 
-- **GUI**: se pueden añadir nuevas vistas, comandos o reportes siempre que se reutilice la canonicalización existente y no se modifiquen adorners u overlays base.
-- **Backend**: las extensiones deben mantener estables los endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`. Nuevas rutas deben documentarse en `API_REFERENCE.md`.
-- **Persistencia**: cualquier cambio en el formato de `memory.npz`, `index.faiss` o `calib.json` requiere versionado explícito y migraciones.
-- **Observabilidad**: revisar `LOGGING.md` para mantener la correlación GUI↔backend (`X-Correlation-Id`) y la rotación de logs.
+- **GUI**: se pueden añadir nuevas vistas o reportes, pero debe reutilizarse `RoiCropUtils` y respetar adorners existentes (no alterar geometría ni transformaciones).
+- **Backend**: los endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` son contratos estables. Añadir rutas nuevas requiere documentarlas en `API_REFERENCE.md`.
+- **Persistencia**: cualquier cambio en el formato de `memory.npz`, `index.faiss` o `calib.json` debe versionarse explícitamente y acompañarse de migraciones/documentación.
+- **Observabilidad**: seguir [LOGGING.md](LOGGING.md) para mantener correlación GUI↔backend y rotación de logs.
 
 ---
 
 ## 7) Recursos cruzados
 
-- [API_REFERENCE.md](API_REFERENCE.md) — contratos HTTP detallados y ejemplos `curl`.
-- [DATA_FORMATS.md](DATA_FORMATS.md) — estructuras JSON, metadatos y archivos generados.
-- [DEV_GUIDE.md](DEV_GUIDE.md) — preparación de entorno, scripts y debugging.
-- [ROI_AND_MATCHING_SPEC.md](ROI_AND_MATCHING_SPEC.md) — definición formal del ROI canónico y máscaras.
-- [backend/README_backend.md](backend/README_backend.md) — guía operativa del microservicio.
-
----
-
-Para cualquier modificación sustancial, coordina con los responsables listados en `docs/mcp/overview.md` y registra el cambio en `docs/mcp/latest_updates.md`.
-- **Mejoras GUI**: snapping, restricción angular, sectores en annulus, múltiples ROIs y *batch analyze*.
-
----
-
-## 9) Seguridad y despliegue
-
-- Uso local por defecto (`127.0.0.1`).
-- Para red/local/red interna: habilitar host `0.0.0.0` y proteger con firewall/VPN.
-- Añadir logs con niveles por entorno (DEBUG/INFO/WARN/ERROR).
-
----
-
-## 10) Referencias cruzadas
-
-- **README.md** (visión general y *quick start*)
-- **API_REFERENCE.md** (contratos/ejemplos)
-- **ROI_AND_MATCHING_SPEC.md** (geometría y reglas ROI)
-- **DEV_GUIDE.md** (setup detallado)
-- **DEPLOYMENT.md** (smoke tests)
-- **LOGGING.md** (política de logs)
+- [README.md](README.md) — Visión general y quick start.
+- [DEV_GUIDE.md](DEV_GUIDE.md) — Setup de desarrollo y estándares de código.
+- [API_REFERENCE.md](API_REFERENCE.md) — Contratos HTTP y ejemplos `curl`.
+- [DATA_FORMATS.md](DATA_FORMATS.md) — Esquemas de requests/responses y artefactos en disco.
+- [ROI_AND_MATCHING_SPEC.md](ROI_AND_MATCHING_SPEC.md) — Geometría ROI, canonicalización y máscaras.
+- [DEPLOYMENT.md](DEPLOYMENT.md) — Despliegues locales/producción y troubleshooting.
+- [LOGGING.md](LOGGING.md) — Política de observabilidad.
 
 ---
 
 ## Glosario rápido
 
-- **ROI canónica**: imagen resultante de rotar y recortar la ROI dibujada en la GUI; es la única que llega al backend.
-- **Coreset**: subconjunto representativo de embeddings OK utilizado por PatchCore para acelerar el kNN.
-- **Token shape**: altura y anchura del grid de tokens DINOv2 antes de reescalar al tamaño del ROI.
-- **Shape mask**: JSON que describe la región válida (rect/círculo/annulus) dentro de la ROI canónica.
+- **ROI canónica**: recorte alineado (crop + rotación) generado por la GUI; es la entrada directa al backend.
+- **PatchCore**: algoritmo que usa un coreset de embeddings OK para realizar kNN y detectar anomalías.
+- **Token shape**: dimensiones (`Ht`, `Wt`) del grid DINOv2 previo al reescalado; se mantiene constante entre entrenamiento e inferencia.
+- **Shape JSON**: máscara opcional (`rect`, `circle`, `annulus`) expresada en píxeles del ROI canónico; se usa para recortar el heatmap.
+- **Threshold**: valor obtenido en `/calibrate_ng` que se aplica para decidir regiones relevantes en `/infer`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,12 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+**Cambios clave documentados en esta versión:**
+- Se referencia el nuevo `PROJECT_OVERVIEW.txt` como material de onboarding rápido.
+- Se mantiene el flujo de contribución para backend y GUI alineado con los contratos actuales.
 
 # CONTRIBUTING — BrakeDiscInspector
 
-Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este documento describe el flujo de colaboración y las normas de estilo para el backend FastAPI y la GUI WPF.
+Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este documento describe el flujo de colaboración y las normas de estilo para el backend FastAPI y la GUI WPF. Consulta también `PROJECT_OVERVIEW.txt` para obtener una visión técnica condensada antes de iniciar cualquier tarea.
 
 ---
 
@@ -44,7 +39,7 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
    cd BrakeDiscInspector
    git checkout -b feat/nueva-funcionalidad
    ```
-3. Configura tu entorno siguiendo [DEV_GUIDE.md](DEV_GUIDE.md).
+3. Configura tu entorno siguiendo [DEV_GUIDE.md](DEV_GUIDE.md) y revisa `PROJECT_OVERVIEW.txt` para entender el flujo completo.
 
 ---
 
@@ -58,7 +53,7 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
 
 ### GUI (C# / WPF)
 - Convenciones .NET (PascalCase, `_camelCase` para privados).
-- `async/await` para todas las llamadas HTTP (`HttpClient`).
+- `async/await` para todas las llamadas HTTP (`BackendClient`).
 - Mantener adorners (`RoiAdorner`, `RoiRotateAdorner`, `ResizeAdorner`) sin cambios salvo instrucciones explícitas.
 - Utilizar `ObservableCollection` para listas visibles y respetar MVVM.
 
@@ -68,7 +63,7 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
   ```
   <type>(scope): resumen breve
   ```
-  Ejemplo: `docs: update architecture with patchcore flow`.
+  Ejemplo: `docs: update architecture overview`.
 
 ---
 
@@ -91,7 +86,7 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
   curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Test -F roi_id=ROI -F mm_per_px=0.2 -F images=@sample_ok.png
   curl -X POST http://127.0.0.1:8000/infer -F role_id=Test -F roi_id=ROI -F mm_per_px=0.2 -F image=@sample_ok.png
   ```
-- Si añades lógica nueva, crea tests en `backend/tests/` (ej. PyTest) y documenta cómo ejecutarlos.
+- Si añades lógica nueva, crea tests en `backend/tests/` (PyTest) y documenta cómo ejecutarlos.
 
 ### GUI
 - Compila solución (`Build > Build Solution`).
@@ -102,7 +97,7 @@ Gracias por tu interés en contribuir al proyecto **BrakeDiscInspector**. Este d
 
 ## 6) Documentación
 
-- Mantén el README y las guías actualizadas con cualquier cambio relevante.
+- Mantén el README, `PROJECT_OVERVIEW.txt` y las guías actualizadas con cualquier cambio relevante.
 - Añade diagramas o ejemplos cuando simplifiquen la comprensión.
 - Registra eventos importantes en `docs/mcp/latest_updates.md` cuando afecten contratos o despliegues.
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -1,17 +1,13 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+**Cambios clave documentados en esta versión:**
+- Se unifica el flujo de onboarding para backend (FastAPI PatchCore) y GUI (WPF) con énfasis en datasets `datasets/<role>/<roi>/<ok|ng>/`.
+- Se añaden referencias explícitas a los módulos de código vigentes (`app.py`, `InferenceEngine`, `BackendClient`, `DatasetManager`).
+- Se consolida el plan de pruebas mínimas (smoke + GUI) y variables de entorno utilizadas en 2025.
 
 # DEV_GUIDE — BrakeDiscInspector
 
-Guía de desarrollo para configurar, extender y probar el proyecto en entornos locales. Cubre el backend FastAPI (PatchCore + DINOv2) y la GUI WPF.
+Guía de desarrollo para configurar, extender y validar BrakeDiscInspector en entornos locales. Cubre el backend FastAPI (PatchCore + DINOv2) y la GUI WPF.
 
 ---
 
@@ -20,7 +16,7 @@ Guía de desarrollo para configurar, extender y probar el proyecto en entornos l
 - [Preparación del repositorio](#1-preparación-del-repositorio)
 - [Backend (Python)](#2-backend-python)
 - [GUI (WPF)](#3-gui-wpf)
-- [Scripts auxiliares](#4-scripts-auxiliares-scripts)
+- [Scripts auxiliares](#4-scripts-auxiliares)
 - [Estándares de código](#5-estándares-de-código)
 - [Testing](#6-testing)
 - [Roadmap sugerido](#7-roadmap-sugerido)
@@ -39,8 +35,8 @@ Estructura general:
 ```
 backend/   # Microservicio FastAPI (PatchCore + DINOv2)
 gui/       # WPF (.NET 8) para gestión de ROI/datasets
+docs/      # MCP y documentación extendida
 scripts/   # utilidades (PowerShell)
-docs/      # documentación (arquitectura, MCP, etc.)
 ```
 
 ---
@@ -50,7 +46,7 @@ docs/      # documentación (arquitectura, MCP, etc.)
 ### 2.1 Requisitos
 - Python 3.10 o superior
 - `pip` actualizado (`python -m pip install -U pip`)
-- GPU opcional (CUDA/cuDNN) — funciona también en CPU
+- GPU opcional (funciona en CPU; se detecta con `torch.cuda.is_available()`)
 
 ### 2.2 Instalación
 ```bash
@@ -60,46 +56,45 @@ source .venv/bin/activate      # PowerShell: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
 ```
 
-> El archivo `requirements.txt` incluye `torch`, `timm`, `opencv-python`, `faiss-cpu` (opcional) y `fastapi`.
+`requirements.txt` incluye PyTorch 2.x, `timm`, `opencv-python`, `faiss-cpu` (opcional), `fastapi`, `uvicorn`, `scikit-learn` y utilidades NumPy/SciPy.
 
 ### 2.3 Archivos clave
-- `app.py` — endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`.
-- `features.py` — wrapper DINOv2 (`vit_small_patch14_dinov2.lvd142m`).
-- `patchcore.py` — memoria PatchCore (coreset + kNN).
-- `infer.py` — pipeline de inferencia y posprocesado (heatmap, contornos).
-- `calib.py` — selección de umbral con percentiles.
-- `storage.py` — persistencia en `models/<role>/<roi>/`.
-- `README_backend.md` — guía operativa y ejemplos `curl`.
+- `app.py` — Define `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` y orquesta la persistencia.【F:backend/app.py†L1-L199】
+- `features.py` — Wrapper `DinoV2Features` (modelo `vit_small_patch14_dinov2.lvd142m`, resize a múltiplos de 14).【F:backend/features.py†L1-L200】
+- `patchcore.py` — Implementa `PatchCoreMemory.build` y el kNN (FAISS opcional).【F:backend/patchcore.py†L1-L200】
+- `infer.py` — `InferenceEngine.run` calcula heatmap, score (p99), aplica máscara y genera regiones/contornos.【F:backend/infer.py†L17-L181】
+- `calib.py` — `choose_threshold` mezcla percentiles OK/NG y guarda `calib.json`.【F:backend/calib.py†L1-L120】
+- `storage.py` — Persistencia en `models/<role>/<roi>/` para `memory.npz`, `index.faiss`, `calib.json`.【F:backend/storage.py†L1-L80】
 
 ### 2.4 Ejecución en desarrollo
 ```bash
-uvicorn backend.app:app --reload --port 8000
+uvicorn backend.app:app --reload --host 127.0.0.1 --port 8000
 # Documentación interactiva: http://127.0.0.1:8000/docs
 ```
 
-### 2.5 Pruebas rápidas
+### 2.5 Smoke tests rápidos
 ```bash
 curl http://127.0.0.1:8000/health
-curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.2 -F images=@sample_ok.png
-curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.2 -F image=@sample_ok.png
+curl -X POST http://127.0.0.1:8000/fit_ok -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.20 -F images=@sample_ok.png
+curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_per_px=0.20 -F image=@sample_ok.png
 ```
 
-> Los comandos anteriores generan/usan artefactos en `backend/models/Demo/ROI1/`.
+Los artefactos generados se almacenan en `backend/models/Demo/ROI1/`.
 
-### 2.6 Debugging
-- Activar logs (`uvicorn --log-level debug`).
-- Revisar `logging` dentro de `app.py` y `infer.py` para tiempos parciales.
-- Ejecutar scripts/unit tests en `backend/tests/` para validar componentes aislados.
+### 2.6 Depuración
+- Ajustar `uvicorn` con `--log-level debug` para inspeccionar llamadas.
+- Revisar trazas en las respuestas JSON (`{"error","trace"}`) cuando hay excepciones.
+- Ejecutar pruebas unitarias/funcionales en `backend/tests/` (si existen) con `pytest`.
 
 ### 2.7 Variables de entorno útiles
 
 | Variable | Uso | Comentario |
 |----------|-----|------------|
-| `DEVICE` | Forzar `cpu`/`cuda`. | Por defecto se autodetecta; útil cuando la GPU está ocupada. |
-| `CORESET_RATE` | Ajustar tamaño del coreset. | Acepta valores 0.01–0.05; comprueba memoria disponible antes de subirlo. |
-| `INPUT_SIZE` | Cambiar tamaño de entrada (múltiplo de 14). | Impacta en `token_shape` y en los heatmaps devueltos. |
-| `MODELS_DIR` | Definir carpeta de modelos. | Permite montar almacenamiento persistente fuera del repositorio. |
-| `UVICORN_PORT` | Sobre-escribir puerto en scripts. | Respaldado por `uvicorn` si se usa `python backend/app.py`. |
+| `DEVICE` | Forzar `cpu`/`cuda`. | Por defecto el extractor elige automáticamente. |
+| `CORESET_RATE` | Ajusta proporción del coreset (0.02 por defecto). | Se lee al construir la memoria; valores altos consumen más RAM. |
+| `INPUT_SIZE` | Tamaño de entrada del extractor (múltiplo de 14, por defecto 448). | Cambiarlo altera `token_shape`. |
+| `MODELS_DIR` | Carpeta raíz de artefactos persistidos. | Permite montar almacenamiento externo. |
+| `BRAKEDISC_BACKEND_HOST` / `PORT` | Host/puerto usados cuando se ejecuta `python app.py`. | Facilita desplegar en LAN. |
 
 ---
 
@@ -112,83 +107,90 @@ curl -X POST http://127.0.0.1:8000/infer -F role_id=Demo -F roi_id=ROI1 -F mm_pe
 - Paquetes NuGet principales: `OpenCvSharp4`, `OpenCvSharp4.runtime.win`, `OpenCvSharp4.Extensions`, `CommunityToolkit.Mvvm`.
 
 ### 3.2 Archivos principales
-- `MainWindow.xaml` / `.cs` — layout y binding principal.
-- `BackendClient.cs` — cliente HTTP async para `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`.
-- `ROI/` — modelos/adorners (no modificar geometría base).
-- `Overlays/` — sincronización canvas ↔ imagen (`RoiOverlay`).
-- `Datasets/` — helpers para guardar PNG + JSON en `datasets/<role>/<roi>/<ok|ng>/`.
+- `MainWindow.xaml` / `.cs` — Pestañas Dataset/Train/Infer, binding y comandos.
+- `Workflow/BackendClient.cs` — Cliente HTTP async (fit/calibrate/infer) con DTOs resilientes.【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs†L20-L218】
+- `Workflow/DatasetManager.cs` — Exporta PNG + metadata JSON (`shape_json`, `mm_per_px`, `angle`).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetManager.cs†L18-L80】
+- `Workflow/DatasetSample.cs` — Carga thumbnails y `SampleMetadata` (timestamp, origen).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs†L1-L120】
+- `ROI/*.cs`, `RoiOverlay.cs` — Adorners y sincronización (no modificar geometría).【F:gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs†L1-L200】
 
 ### 3.3 Configuración
-`appsettings.json` ejemplo:
+`appsettings.json` de ejemplo:
 ```json
 {
   "Backend": {
     "BaseUrl": "http://127.0.0.1:8000",
-    "DatasetRoot": "C:\\data\\brakedisc\\datasets"
+    "DatasetRoot": "C:\\data\\brakedisc\\datasets",
+    "MmPerPx": 0.20
   }
 }
 ```
 
-Puedes sobrescribir `BaseUrl` desde variables de entorno:
-
-```powershell
-$env:BRAKEDISC_BACKEND_BASEURL="http://192.168.1.20:8000"
-```
-
-o definir `BRAKEDISC_BACKEND_HOST` + `BRAKEDISC_BACKEND_PORT` para construir la URL automáticamente.
+Variables de entorno opcionales: `BRAKEDISC_BACKEND_BASEURL`, `BRAKEDISC_BACKEND_HOST`, `BRAKEDISC_BACKEND_PORT` para sobreescribir la URL sin recompilar.
 
 ### 3.4 Flujo recomendado
-1. Cargar imagen y dibujar ROI (respetando mínimo 10×10 px).
-2. Exportar ROI canónico desde la pestaña **Dataset** (`Add OK/NG from current ROI`).
-3. Entrenar con **Train memory (fit_ok)**.
-4. Calibrar (opcional) con **Calibrate threshold**.
-5. Ejecutar **Infer current ROI** para obtener `score`, `threshold`, heatmap y regiones.
+1. Cargar imagen y dibujar ROI (rect/círculo/annulus) con los adorners existentes.
+2. Exportar ROI canónico con **Add OK/NG from Current ROI** (genera PNG + `.json`).
+3. Entrenar memoria con **Train memory (`/fit_ok`)** y revisar respuesta (`n_embeddings`, `coreset_size`, `token_shape`).
+4. Recolectar scores y ejecutar **Calibrate (`/calibrate_ng`)** para fijar `threshold` y `area_mm2_thr`.
+5. Evaluar la imagen actual con **Infer current ROI**, superponer el heatmap y revisar `regions`.
 
-### 3.5 Debugging GUI
-- Usar `AppendLog` o `TraceSource` para registrar acciones y respuestas del backend.
-- Validar que el heatmap se superpone correctamente (revisar tamaño del PNG vs. `Image.Source`).
-- En caso de errores HTTP, mostrar mensaje amigable + detalle técnico en panel de logs.
-## 4) Scripts auxiliares (`scripts/`)
+### 3.5 Depuración GUI
+- Usar los logs de la vista (`AppendLog` o similar) para registrar request/response (incluyendo `X-Correlation-Id`).
+- Verificar overlays cargando el PNG devuelto (`heatmap_png_base64`) en un `ImageBrush` con la misma anchura/altura que el ROI canónico.
+- Manejar errores HTTP (`HttpRequestException`) mostrando mensajes claros al usuario y detalles en el panel de logs.
+
+---
+
+## 4) Scripts auxiliares
 
 | Script | Descripción |
 |--------|-------------|
-| `setup_dev.ps1` | Crea venv y ejecuta `pip install -r backend/requirements.txt`. |
-| `run_backend.ps1` | Activa el venv y lanza `uvicorn backend.app:app`. |
-| `run_gui.ps1` | Abre la solución WPF en Visual Studio. |
-| `check_env.ps1` | Verifica dependencias básicas (Python, dotnet, git). |
-> Ejecutar los scripts desde PowerShell con permisos adecuados (`Set-ExecutionPolicy -Scope Process RemoteSigned`).
+| `scripts/setup_dev.ps1` | Crea entorno virtual y ejecuta `pip install -r backend/requirements.txt`. |
+| `scripts/run_backend.ps1` | Activa la venv y lanza `uvicorn backend.app:app`. |
+| `scripts/run_gui.ps1` | Abre la solución WPF en Visual Studio. |
+| `scripts/check_env.ps1` | Comprueba dependencias (Python, dotnet, git). |
+
+Ejecutar con `PowerShell` habilitando `Set-ExecutionPolicy -Scope Process RemoteSigned` si es necesario.
+
+---
+
 ## 5) Estándares de código
-- Python: seguir PEP8, tipado opcional (`typing`) y logging estructurado (`logging.getLogger(__name__)`).
-- C#: respetar convenciones .NET (PascalCase para métodos/clases, `_camelCase` para privados), usar `async/await` para I/O.
-- Commits: mensajes en inglés (`feat:`, `fix:`, `docs:`, etc.).
+
+- **Python**: seguir PEP8, usar `typing` y logging estructurado (`logging.getLogger(__name__)`).
+- **C#**: convenciones .NET, `async/await` para I/O, aprovechar `ObservableCollection` para listas en UI.
+- **Commits**: idioma inglés, formato `type(scope): resumen` (estilo Conventional Commits).
 
 ---
 
 ## 6) Testing
 
 ### 6.1 Backend
-- Tests unitarios en `backend/tests/` (FAISS opcional). Ejecutar con `pytest` si está disponible.
-- Smoke tests manuales (`curl /fit_ok`, `/infer`, `/calibrate_ng`).
+- Ejecutar smoke tests (`/health`, `/fit_ok`, `/infer`).
+- Añadir pruebas en `backend/tests/` para `PatchCoreMemory`, `InferenceEngine` o utilidades cuando se modifique su comportamiento.
 
 ### 6.2 GUI
 - Compilar solución (`Build > Build Solution`).
-- Validar flujo dataset → fit → calibrate → infer con muestras de prueba.
-- Verificar alineación ROI/heatmap tras redimensionar la ventana.
+- Validar el flujo completo Dataset → `/fit_ok` → `/calibrate_ng` → `/infer` usando muestras de ejemplo (OK/NG).
+- Confirmar que el heatmap permanece alineado tras redimensionar la ventana o recargar imagen.
+
+---
+
 ## 7) Roadmap sugerido
 
-- [ ] Automatizar `pytest` y linters (GitHub Actions).
-- [ ] Añadir modo batch para procesar múltiples ROIs.
-- [ ] Persistir manifiestos por ROI con estado de entrenamiento/calibración.
-- [ ] Integrar exportación de reportes (CSV/JSON) desde la GUI.
-- [ ] Instrumentar métricas Prometheus desde FastAPI.
-- [ ] Soportar múltiples ROIs simultáneos en la GUI sin romper adorners.
-- [ ] Añadir modo *batch analyze* y exportación a CSV/DB.
-- [ ] Investigar entrenamiento incremental / *online* para PatchCore.
-- [ ] Documentar integración con Prometheus/Grafana.
+- [ ] Automatizar `pytest` y análisis estático (GitHub Actions).
+- [ ] Persistir manifiestos por ROI (`datasets/<role>/<roi>/manifest.json`).
+- [ ] Incorporar exportación de reportes (CSV/JSON) desde la GUI.
+- [ ] Añadir métricas Prometheus en el backend (`prometheus_fastapi_instrumentator`).
+- [ ] Implementar modo batch en la GUI manteniendo restricciones de adorners.
+
+---
+
 ## 8) Referencias cruzadas
-- [ARCHITECTURE.md](ARCHITECTURE.md) — Visión de alto nivel y flujo de datos.
+
+- [README.md](README.md) — Visión general y quick start.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Componentes y diagramas.
 - [API_REFERENCE.md](API_REFERENCE.md) — Contratos HTTP detallados.
-- [DATA_FORMATS.md](DATA_FORMATS.md) — Esquemas de requests/responses y archivos persistidos.
-- [DEPLOYMENT.md](DEPLOYMENT.md) — Guía de despliegue local/prod.
-- [LOGGING.md](LOGGING.md) — Política de logging y correlación GUI↔backend.
-- [docs/mcp/overview.md](docs/mcp/overview.md) — Maintenance & Communication Plan.
+- [DATA_FORMATS.md](DATA_FORMATS.md) — Esquemas de requests/responses y archivos.
+- [DEPLOYMENT.md](DEPLOYMENT.md) — Guía de despliegue y smoke tests.
+- [LOGGING.md](LOGGING.md) — Política de observabilidad.
+- [docs/mcp/overview.md](docs/mcp/overview.md) — Plan de coordinación y responsabilidades.

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,13 +1,9 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+**Cambios clave documentados en esta versión:**
+- Se detalla cómo instrumentar `app.py` e `InferenceEngine` con logs estructurados para `/fit_ok`, `/calibrate_ng`, `/infer`.
+- Se alinean los destinos de log de la GUI con los archivos creados durante dataset/inferencia (`roi_analyze_master.log`, etc.).
+- Se incluyen recomendaciones de correlación (`X-Correlation-Id`) y rotación en despliegues Windows/Linux.
 
 # LOGGING — BrakeDiscInspector
 
@@ -27,96 +23,95 @@ Política de logging y trazabilidad para el backend FastAPI (PatchCore + DINOv2)
 
 ## 1) Principios
 
-- **Observabilidad**: registrar tiempos, tamaños y resultados clave sin exponer datos sensibles.
-- **Correlación**: usar `X-Correlation-Id` para unir eventos GUI ↔ backend.
-- **Retención**: rotar y conservar logs críticos según políticas de planta.
+- **Observabilidad**: registrar inicio, parámetros y tiempos de cada operación crítica.
+- **Correlación**: propagar un identificador (`X-Correlation-Id`) desde la GUI hacia el backend para unir eventos.
+- **Retención**: definir rotación y purgado acorde al entorno (laboratorio vs producción).
 
 ---
 
 ## 2) Backend (FastAPI)
 
-### 2.1 Configuración básica
+### 2.1 Configuración
+- El módulo raíz (`app.py`) obtiene un `logger` con `logging.getLogger(__name__)` y crea registros al arrancar mediante `logging.basicConfig` cuando se ejecuta como script.【F:backend/app.py†L1-L214】
+- Al ejecutar con Uvicorn/Gunicorn usar `--log-level info` y, si se necesita más detalle, habilitar `uvicorn.error` y `uvicorn.access` en un fichero aparte.
 
-- El backend usa `logging.getLogger(__name__)` en módulos como `app.py`, `infer.py` y `storage.py`.
-- Inicializa logging en `if __name__ == "__main__"` cuando se ejecuta con `uvicorn backend.app:app` (usar `--log-level info`).
-- Para despliegues con Gunicorn, definir `log-config` o variables `LOG_LEVEL` según necesidad.
-- Habilita `uvicorn.access` si necesitas auditoría HTTP; puede redirigirse a fichero separado usando la configuración de Gunicorn/Uvicorn.
-
-### 2.2 Eventos mínimos
+### 2.2 Eventos recomendados
 
 | Evento | Campos sugeridos |
 |--------|------------------|
-| Inicio del servicio | versión, dispositivo (`cpu`/`cuda`), `models_dir` activo. |
-| `/fit_ok` | `role_id`, `roi_id`, nº de imágenes, bytes totales, `n_embeddings`, `coreset_size`, `token_shape`, tiempo total. |
-| `/calibrate_ng` | `role_id`, `roi_id`, tamaño arrays OK/NG, `threshold`, `score_percentile`, `area_mm2_thr`. |
-| `/infer` | `role_id`, `roi_id`, tamaño PNG, presencia de `shape`, `score`, `threshold`, nº regiones, latencia total. |
+| Inicio | versión (`0.1.0`), dispositivo (`cpu`/`cuda`), `MODELS_DIR` activo. |
+| `/fit_ok` | `role_id`, `roi_id`, nº imágenes, bytes totales, `n_embeddings`, `coreset_size`, `token_shape`, `coreset_rate`. |
+| `/calibrate_ng` | `role_id`, `roi_id`, len arrays OK/NG, `threshold`, `area_mm2_thr`, `score_percentile`. |
+| `/infer` | `role_id`, `roi_id`, tamaño imagen, `shape` presente, `score`, `threshold`, nº regiones, tiempo total. |
 | Errores | Mensaje y `traceback` completo (`logger.exception`). |
 
-Ejemplo (pseudocódigo):
+Pseudocódigo:
 ```python
-cid = headers.get("X-Correlation-Id", uuid.uuid4().hex[:8])
-t0 = time.perf_counter()
-log.info("[%s] /infer start role=%s roi=%s bytes=%d shape=%s", cid, role_id, roi_id, len(data), bool(shape))
-...
-dt = (time.perf_counter() - t0) * 1000
-log.info("[%s] /infer end score=%.2f thr=%s regions=%d dt_ms=%.1f", cid, out["score"], out.get("threshold"), len(out["regions"]), dt)
+cid = headers.get("X-Correlation-Id") or uuid.uuid4().hex[:8]
+log.info("[%s] /infer start role=%s roi=%s bytes=%d shape=%s", cid, role_id, roi_id, len(raw), bool(shape))
+try:
+    result = engine.run(...)
+    log.info("[%s] /infer end score=%.2f thr=%s regions=%d", cid, result["score"], result.get("threshold"), len(result["regions"]))
+except Exception:
+    log.exception("[%s] /infer failed", cid)
+    raise
 ```
 
-### 2.3 Rotación
-
-- **Linux**: usar `logrotate` (ejemplo `/etc/logrotate.d/brakedisc` con rotación semanal + compresión).
-- **Windows**: emplear Task Scheduler o NSSM para rotar ficheros en `backend/logs/`.
-- Registrar la ruta exacta en documentación de despliegue.
+### 2.3 Rotación y destino
+- **Linux**: configurar `/var/log/brakedisc/backend.log` con `logrotate` semanal (7 versiones comprimidas).
+- **Windows/NSSM**: redirigir `stdout`/`stderr` a un fichero (`backend\logs\backend.log`) y rotarlo mediante Task Scheduler o NSSM `AppRotateFiles`.
 
 ### 2.4 Métricas opcionales
-
-- Promedio y percentil 95 de latencias `/infer`.
-- Conteo de `OK` vs `NG` por rol/ROI.
-- Uso opcional de Prometheus (`prometheus_fastapi_instrumentator`) para exponer métricas.
+- Latencias p95 de `/infer` y `/fit_ok` (exportables vía `prometheus_fastapi_instrumentator`).
+- Conteo de inferencias por `(role_id, roi_id)` para seguimiento de uso.
 
 ---
 
 ## 3) GUI (WPF)
 
-### 3.1 Recomendaciones
-
-- Centralizar logs en `gui/logs/gui.log` (añadir a `.gitignore`).
-- Usar un `ConcurrentQueue` o `ObservableCollection` para mostrar eventos en pantalla y escribirlos en disco.
-- Formato sugerido: `yyyy-MM-dd HH:mm:ss.fff [Nivel] Mensaje`.
+### 3.1 Destinos de log
+- Registrar eventos en `%LOCALAPPDATA%/BrakeDiscInspector/logs/` (sugerido):
+  - `roi_analyze_master.log` → exportación de ROIs y generación de dataset.
+  - `roi_load_coords.log` → carga/guardado de layouts y presets.
+  - `gui_heatmap.log` → resultados de `/fit_ok`, `/calibrate_ng`, `/infer` (score, threshold, nº regiones).
+- Utilizar `StreamWriter` asíncrono o `Serilog` si ya está integrado en la solución.
 
 ### 3.2 Eventos mínimos
 
 | Evento | Contenido |
 |--------|-----------|
-| Inicio de la app | Versión, ruta del dataset, backend configurado. |
-| Carga de imagen | Nombre de archivo (anonimizado) y dimensiones. |
-| ROI exportada | `role_id`, `roi_id`, tamaño PNG generado, ángulo, `shape`. |
-| `/fit_ok` | Tiempo de ejecución y resumen de respuesta (`n_embeddings`, `coreset_size`). |
-| `/calibrate_ng` | `threshold` devuelto, tamaños de arrays. |
-| `/infer` | `score`, `threshold`, nº regiones, latencia. |
-| Errores | Mensaje y detalles (`HttpRequestException`, validaciones). |
+| Inicio de app | Versión GUI, `DatasetRoot`, `Backend.BaseUrl`. |
+| Carga imagen | Ruta (anonimizada) y dimensiones originales. |
+| Exportar ROI | `role_id`, `roi_id`, `shape`, tamaño PNG, `mm_per_px`, ángulo. |
+| `/fit_ok` | Nº imágenes enviadas, `n_embeddings`, `coreset_size`, duración. |
+| `/calibrate_ng` | Arrays OK/NG usados, `threshold` devuelto. |
+| `/infer` | `score`, `threshold`, nº regiones, duración, path del heatmap temporal. |
+| Errores | Mensaje amigable + detalle técnico (`HttpRequestException`, validaciones). |
 
-### 3.3 Correlación con backend
+### 3.3 Correlación GUI ↔ backend
+- Generar `X-Correlation-Id` por operación (`Guid.NewGuid().ToString("N").Substring(0,8)`) y adjuntarlo en `BackendClient` vía `HttpRequestMessage.Headers` antes de cada POST/GET.
+- Registrar el ID en los logs GUI y backend para facilitar el trazado cuando se analicen incidencias.
 
-- Generar `X-Correlation-Id` por cada operación (ej. `Guid.NewGuid().ToString("N").Substring(0,8)`).
-- Adjuntar el header en todas las llamadas HTTP y registrar el mismo ID en los logs GUI.
+### 3.4 Supervisión visual
+- Al recibir `heatmap_png_base64`, guardar temporalmente el PNG con el mismo `CorrelationId` para comparar con los logs.
+- Almacenar respuestas completas (JSON) cuando se depuren umbrales o regresiones.
 
 ---
 
 ## 4) Seguridad
 
-- No registrar rutas completas del usuario ni datos sensibles.
-- Evitar almacenar imágenes o blobs en logs (solo tamaños/nombres anónimos).
-- Asegurar permisos restrictivos en carpetas de log (`chmod 750` en Linux; ACLs en Windows).
+- No registrar rutas completas ni IDs sensibles; anonimizar nombres de archivo cuando sea posible.
+- Revisar periódicamente los logs para asegurarse de que no contienen imágenes o datos confidenciales.
+- Establecer permisos restringidos (`chmod 750` en Linux, ACL específica en Windows) sobre carpetas de logs.
 
 ---
 
 ## 5) Checklist
 
-- [ ] Backend registra inicio, `/fit_ok`, `/calibrate_ng`, `/infer` y errores con correlation id.
-- [ ] Rotación de logs configurada en el entorno objetivo.
-- [ ] GUI guarda logs locales sin PII y muestra últimos eventos al usuario.
-- [ ] `X-Correlation-Id` presente en ambas mitades (GUI ↔ backend).
-- [ ] Métricas opcionales documentadas en `docs/mcp/latest_updates.md` si se habilitan.
+- [ ] Backend registra inicio, `/fit_ok`, `/calibrate_ng`, `/infer` con tiempos y correlation id.
+- [ ] La GUI escribe logs en disco y muestra los últimos eventos al usuario.
+- [ ] La rotación de logs está configurada en el entorno objetivo (logrotate, Task Scheduler, etc.).
+- [ ] Se documenta en `docs/mcp/latest_updates.md` cualquier cambio en política de logging.
+- [ ] Métricas opcionales (si se habilitan) quedan enlazadas desde el MCP.
 
-Para coordinación entre equipos revisar [docs/mcp/overview.md](docs/mcp/overview.md).
+Para coordinación adicional consulta [docs/mcp/overview.md](docs/mcp/overview.md).

--- a/PROJECT_OVERVIEW.txt
+++ b/PROJECT_OVERVIEW.txt
@@ -1,0 +1,90 @@
+PROJECT OVERVIEW — BrakeDiscInspector (October 2025)
+====================================================
+
+Purpose
+-------
+BrakeDiscInspector combines a WPF GUI (MainWindow.xaml/.cs and supporting workflow classes) with a FastAPI backend (backend/app.py) to detect defects on brake discs using a good-only anomaly detection pipeline. The backend relies on PatchCore memory over DINOv2 ViT-S/14 embeddings, while the GUI ensures that every Region of Interest (ROI) sent to the backend is already cropped, rotated, and expressed in canonical coordinates. The system supports multiple manufacturing roles (e.g., Master1, Master2, Inspection) and maintains a persistent anomaly memory per `(role_id, roi_id)` so that plant operators can reuse training and calibration results across sessions.
+
+Data Flow Summary
+-----------------
+1. **Image Load**: The GUI opens an inspection image and displays it with `Stretch="Uniform"`, keeping track of the scale/offset used to render the bitmap inside the window.
+2. **ROI Definition**: Operators draw ROIs using the existing adorners (rectangle, circle, annulus). Rotation is supported and reflected by `AngleDeg` in the ROI model.
+3. **Canonical Crop Export**: The GUI calls `RoiCropUtils.TryGetRotatedCrop` to rotate the source image around the ROI pivot, extract the exact ROI rectangle, and generate a canonical PNG. A companion JSON stores metadata (`role_id`, `roi_id`, `mm_per_px`, `shape_json`, `angle`, `timestamp`).
+4. **Dataset Persistence**: `DatasetManager.SaveSampleAsync` writes PNG+JSON pairs to `datasets/<role>/<roi>/<ok|ng>/`, creating a ready-to-train corpus of canonical ROIs.
+5. **Training (`/fit_ok`)**: The GUI bundles canonical OK samples and calls `BackendClient.FitOkAsync`. The backend extracts DINOv2 embeddings, performs PatchCore coreset selection, and persists `memory.npz` + `index.faiss` under `backend/models/<role>/<roi>/`.
+6. **Calibration (`/calibrate_ng`)**: Once scores are collected for OK and (optionally) NG samples, the GUI posts them to `/calibrate_ng`. The backend computes a percentile-based threshold (`threshold`, `p99_ok`, `p5_ng`) and stores it in `calib.json` alongside `mm_per_px` and `area_mm2_thr`.
+7. **Inference (`/infer`)**: The GUI exports the current ROI, assembles the corresponding `shape_json`, and calls `BackendClient.InferAsync`. The backend reconstructs memory, applies kNN, masks the heatmap, computes the score and threshold, and returns a PNG heatmap (Base64) plus contour regions with areas in px/mm².
+8. **Overlay & Review**: The GUI decodes the Base64 heatmap and overlays it on the canonical ROI preview. Operators inspect `score`, compare it against `threshold`, and review the detected regions. Logs capture each action for traceability.
+
+Frontend Structure
+------------------
+- **Entry point**: `gui/BrakeDiscInspector_GUI_ROI/App.xaml` → `MainWindow.xaml/.cs`.
+- **ROI Models & Adorners**: `ROI/*.cs`, `RoiAdorner.cs`, `RoiOverlay.cs`, `ResizeAdorner.cs`, `RoiRotateAdorner.cs`. These files govern geometry, rendering, and user interaction with ROIs. They must remain untouched to avoid regressions in alignment.
+- **Workflow Layer**: `Workflow/BackendClient.cs` encapsulates HTTP calls using `HttpClient`, multipart forms, and JSON DTOs (`FitOkResult`, `CalibResult`, `InferResult`). `Workflow/DatasetManager.cs` handles dataset persistence. `Workflow/DatasetSample.cs` parses metadata and generates thumbnails. `WorkflowViewModel` orchestrates commands (Add Sample, Train, Calibrate, Infer) and logs outcomes.
+- **Dataset Management**: The GUI ensures that `datasets/<role>/<roi>/ok/` and `/ng/` directories exist before saving. Metadata JSON includes `shape_json` (string) so that the backend receives the same mask used when the sample was collected.
+- **Overlay & Heatmap**: `RoiOverlay.cs` synchronizes the ROI canvas with the displayed image. When inference returns, the GUI loads the heatmap PNG into an `ImageBrush` sized exactly to the canonical ROI and superposes it with adjustable opacity.
+- **Logging**: GUI logs (recommended filenames: `roi_analyze_master.log`, `roi_load_coords.log`, `gui_heatmap.log`) capture dataset exports, backend requests/responses (with correlation IDs), and errors. Logs live under `%LOCALAPPDATA%/BrakeDiscInspector/logs/`.
+
+Backend Structure
+-----------------
+- **app.py**: Defines FastAPI app, endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`. Validates payloads, loads/stores artefacts via `ModelStore`, encodes heatmaps to PNG Base64, and wraps exceptions in JSON responses (`{"error","trace"}`).
+- **features.py**: `DinoV2Features` wrapper around `timm.create_model("vit_small_patch14_dinov2.lvd142m")`. Handles resize (`input_size` default 448), normalization, batching on CPU/GPU, and returns `(embeddings, (Ht, Wt))`.
+- **patchcore.py**: Implements `PatchCoreMemory.build` (coreset via k-center greedy) and nearest-neighbour queries. Supports FAISS if available, falling back to scikit-learn.
+- **infer.py**: `InferenceEngine` consumes embeddings and memory, rebuilds heatmaps (bilinear resize to ROI size), applies Gaussian blur and mask, computes percentile-based score, removes small islands via `area_mm2_thr`, and outputs contours (bbox, area_px, area_mm2, contour points).
+- **calib.py**: `choose_threshold` selects a value between `p99_ok` and `p5_ng` (when NG scores exist); otherwise uses `p99_ok`. Persisted fields include `threshold`, `p99_ok`, `p5_ng`, `mm_per_px`, `area_mm2_thr`, `score_percentile`.
+- **storage.py**: `ModelStore` writes artefacts to `models/<role>/<roi>/`: `memory.npz` (float32 embeddings, token grid, metadata JSON), `index.faiss`, `calib.json`. Provides load/save helpers.
+- **roi_mask.py**: Builds binary masks (rect/circle/annulus) in canonical coordinates, ensuring backend results align with GUI overlays.
+- **utils.py**: Contains helper functions (e.g., `ensure_dir`, Base64 utilities, mm²↔px² conversions).
+
+ROI–Heatmap Synchronization
+---------------------------
+- The GUI displays source images with `Stretch="Uniform"`. It computes scale/offset so the ROI canvas matches the visible bitmap.
+- Canonical crops preserve original ROI width/height and rotation. The backend receives exactly what the GUI displays in the ROI preview.
+- The heatmap returned by the backend uses the canonical ROI resolution. The GUI must overlay this heatmap on the canonical image, not on the full source frame, to avoid misalignment.
+- Letterboxing is handled only in the GUI; backend outputs assume no letterbox. Resize logic (including DPI handling) is frozen and must not be altered.
+- Masks (`shape_json`) use the canonical coordinate system (0..W-1, 0..H-1). Both backend (`roi_mask.py`) and GUI rely on this convention to align scores and contours.
+
+Roles, Datasets, and Artefacts
+------------------------------
+- **Roles**: Represents machine or production variant (e.g., `Master1`, `Master2`, `Inspection`).
+- **ROIs**: Named zones within each role (e.g., `Pattern`, `InnerSurface`).
+- **Dataset layout**: `datasets/<role>/<roi>/ok/` and `/ng/` contain PNG+JSON pairs.
+- **Backend artefacts**: `backend/models/<role>/<roi>/memory.npz`, `index.faiss`, `calib.json`. Each directory is independent and can be moved/restored as a unit.
+- **Shared server**: In production, mount `MODELS_DIR` on persistent storage (e.g., NAS) and point the backend at it via environment variables.
+
+Logging Strategy
+----------------
+- **GUI logs**: Record dataset exports, backend requests/responses (including correlation IDs), heatmap overlays, and errors. Suggested filenames: `roi_analyze_master.log`, `roi_load_coords.log`, `gui_heatmap.log`.
+- **Backend logs**: Using `logging.getLogger(__name__)`, record service start (device/model), `/fit_ok` summary (`n_embeddings`, `coreset_size`, `token_shape`), `/calibrate_ng` thresholds, `/infer` metrics (`score`, `threshold`, `regions`, duration), and errors (with stack traces). Honor `X-Correlation-Id` header when provided.
+- **Proxy logs**: For production, collect Nginx (access/error) or NSSM logs. Ensure log rotation (logrotate on Linux, Task Scheduler/NSSM on Windows).
+
+Restrictions & Invariants
+-------------------------
+1. Do not modify adorner logic, ROI resizing, canonicalization, or overlay scaling in the GUI.
+2. Backend API signatures are stable; new parameters must be optional and documented.
+3. Canonical ROI export is the single source of truth. Backend must not attempt to recrop or rotate images.
+4. `shape_json` semantics cannot change (rect, circle, annulus only).
+5. File formats (`memory.npz`, `index.faiss`, `calib.json`, dataset JSON) are fixed; versioning is required for changes.
+6. Logging must avoid PII and keep correlation IDs consistent.
+
+Technology Stack
+----------------
+- **Backend**: Python 3.10+, FastAPI, Uvicorn/Gunicorn, PyTorch 2.x, `timm` (DINOv2), NumPy/SciPy, OpenCV, optional FAISS, scikit-learn.
+- **Frontend**: WPF (.NET 8), C#, OpenCvSharp4 for image operations, CommunityToolkit.Mvvm for bindings.
+- **Build/Deploy**: `pip install -r backend/requirements.txt`, `uvicorn backend.app:app`, Windows NSSM service or Linux systemd + Nginx proxy.
+- **Testing**: Manual smoke tests (`/health`, `/fit_ok`, `/infer`), GUI walkthroughs, optional unit tests in `backend/tests/` and `BrakeDiscInspector_GUI_ROI.Tests/`.
+
+Environment & Deployment
+------------------------
+- **Environment variables**: `MODELS_DIR`, `DEVICE`, `CORESET_RATE`, `INPUT_SIZE`, `BRAKEDISC_BACKEND_HOST`, `BRAKEDISC_BACKEND_PORT`, `BRAKEDISC_BACKEND_BASEURL` (GUI override).
+- **Development**: Run backend with `uvicorn --reload` and GUI via Visual Studio.
+- **Laboratory/Windows**: Use NSSM to host backend (`python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000`); configure firewall and log rotation.
+- **Production/Linux**: Deploy under `/opt/brakedisc`, configure systemd service (Gunicorn + Uvicorn workers), front with Nginx, enable HTTPS via certbot if needed. Persist `MODELS_DIR` (e.g., `/var/lib/brakedisc/models`).
+
+Key Takeaways
+-------------
+- Canonical ROI export is untouchable: all training/inference relies on the exact crop generated by the GUI pipeline.
+- Logs must remain synchronized (GUI ↔ backend ↔ proxy) and use correlation IDs when possible.
+- Heatmap/resize logic is immutable; misalignment bugs are considered regressions.
+- Artefacts (`memory.npz`, `index.faiss`, `calib.json`) are scoped per `(role_id, roi_id)` and must be versioned carefully.
+- Maintain documentation parity: whenever code changes, update the relevant markdown and this overview.

--- a/Prompt_Backend_PatchCore_DINOv2.md
+++ b/Prompt_Backend_PatchCore_DINOv2.md
@@ -1,288 +1,115 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
+**Cambios clave documentados en esta versión:**
+- Prompt alineado con el backend actual basado en FastAPI (`app.py`) y módulos (`features.py`, `patchcore.py`, `infer.py`, `calib.py`, `storage.py`).
+- Se refuerza el uso obligatorio de DINOv2 ViT-S/14, PatchCore y persistencia por `(role_id, roi_id)` (`backend/models/<role>/<roi>/`).
+- Se detallan los contratos de los endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` y las expectativas de logging/observabilidad.
 
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+# Prompt para agentes — Backend PatchCore + DINOv2 (sin tocar la GUI)
 
-# Prompt para Codex — Backend de Detección de Anomalías (PatchCore + DINOv2) — **Sin EfficientNet**
+Este prompt guía a cualquier agente/desarrollador que deba mantener o extender el backend de BrakeDiscInspector. La GUI WPF ya provee ROIs canónicos; el backend sólo debe procesarlos con PatchCore + DINOv2 respetando los contratos establecidos.
 
-## 🔧 CONTEXTO DEL PROYECTO (NO CAMBIAR LA GUI)
+---
 
-- La **GUI WPF** ya permite: dibujar ROI (rect/círculo/annulus), rotar, guardar/recargar, y mostrar overlays (heatmaps/contornos).  
-- Tenemos utilidades fiables de **recorte + rotación canónica** del ROI (p. ej., `RoiCropUtils` en C#) y ya generamos **ROI canónicos** (imágenes alineadas).  
-- **No modifiques la GUI** ni los Adorners: solo **backend**.  
-- El backend debe exponer **endpoints HTTP** limpios para:  
-  - `POST /fit_ok` (acumular OK para “aprender lo normal”)  
-  - `POST /calibrate_ng` (0–3 NG para umbral por ROI/rol)  
-  - `POST /infer` (devolver score, heatmap y contornos)  
-- **Descarta EfficientNet** para este trabajo. Usa **DINOv2 ViT-S** como extractor de características *congelado*.  
-- Piezas: **metálicas o pintadas en gris** (discos de freno, manguetas). Defectos **de milímetros**. Nosotros ya aportamos **ROI canónico** (rotado/recortado) antes de enviar al backend.  
-- Necesitamos detección por **anomalía “good-only”** estilo **PatchCore** con **coreset** y kNN (FAISS/sklearn), **sin entrenar** con NG, y usar **0–3 NG** solo para **calibrar** el umbral.
+## 1. Objetivo técnico
 
+Implementar y mantener un microservicio FastAPI capaz de:
+1. Recibir ROIs canónicos (PNG/JPG) junto con `role_id`, `roi_id`, `mm_per_px` y máscaras opcionales (`shape`).
+2. Extraer embeddings con **DINOv2 ViT-S/14 congelado** (`timm`, modelo `vit_small_patch14_dinov2.lvd142m`).
+3. Construir memoria **PatchCore** (coreset k-center greedy + kNN FAISS opcional) a partir de muestras OK (`/fit_ok`).
+4. Calibrar thresholds con scores OK/NG (`/calibrate_ng`).
+5. Inferir anomalías (`/infer`) devolviendo `score`, `threshold`, `heatmap_png_base64`, `regions`, `token_shape`.
+6. Persistir artefactos por `(role_id, roi_id)` en `backend/models/<role>/<roi>/` (`memory.npz`, `index.faiss`, `calib.json`).
 
-## 🧭 Índice rápido
+**Restricciones**: no modificar la GUI, no introducir nuevos endpoints ni alterar la firma de los existentes. Mantener compatibilidad con Python 3.10+.
 
-- [Objetivo técnico](#-objetivo-técnico)
-- [Estructura propuesta](#-estructura-propuesta-código-y-módulos)
-- [Extractor DINOv2](#-extractor-dinov2-vit-s--sin-entrenamiento)
-- [Memoria OK (PatchCore)](#-memoria-ok-patchcore--coreset--knn)
-- [Inferencia](#-inferencia)
-- [Calibración](#-calibración-con-0–3-ng)
-- [Endpoints HTTP](#-endpoints-http-fastapi)
+---
 
-## 🎯 OBJETIVO TÉCNICO
-
-Implementar un **microservicio backend** (Python) con FastAPI (o Flask), que:
-
-1) **Recibe ROI canónico** (p. ej., 384×384) + metadatos del ROI (id, rol, mm/px y shape opcional para enmascarado).  
-2) **Extractor**: DINOv2 ViT-S **congelado** (pretrained) → **features por parches** multi-escala.  
-3) **Memoria OK (PatchCore)**:
-   - Construye embeddings por parche.  
-   - Aplica **coreset** (k-center greedy) para reducir a **1–5%** (configurable).  
-   - Crea índice **kNN** con FAISS (o `sklearn.NearestNeighbors` si no hay FAISS).  
-4) **Inferencia**:
-   - kNN por parche → **mapa de distancias** (heatmap).  
-   - **Score global** = p99 (o p95) del mapa (configurable).  
-5) **Calibración** (roles/ROIs):  
-   - Con **0–3 NG**: fija umbral por ROI entre **p99 de OK** y **p5 de NG** (si hay NG).  
-   - Persistir **threshold** por `role_id`/`roi_id`.  
-6) **Posproceso**:
-   - **Suavizado** ligero (Gaussian blur).  
-   - **Máscara** del ROI (rect/círculo/annulus) para limitar el heatmap (si se proporciona shape).  
-   - **Eliminar islas** con área inferior a **X mm²** (convertir a px con `px_area_thr = area_mm2 / (mm_per_px^2)`).  
-   - **Contornos** y **bounding boxes** (OpenCV).  
-7) **Salida** para la GUI:
-   - **Score** (float), **threshold** aplicado,  
-   - **Heatmap** (PNG base64 o ruta temporal),  
-   - **Contornos**: lista con bbox en píxeles, área en px y **área en mm²** (usar `mm_per_px`).  
-
-**Requisitos hard**:  
-- **No usar EfficientNet**.  
-- **No toca GUI**.  
-- **Determinismo** opcional (seed).  
-- **Device**: usar GPU si existe, si no CPU.  
-- **Artefactos persistentes** por `role_id`/`roi_id` (memoria, índice, calibración).
-
-
-## 📦 ESTRUCTURA PROPUESTA (código y módulos)
+## 2. Arquitectura del backend
 
 ```
 backend/
-  app.py                # FastAPI con endpoints /fit_ok, /calibrate_ng, /infer, /health
-  features.py           # Wrapper DINOv2 ViT-S (timm), preprocesado, extracción multi-escala
-  patchcore.py          # Memoria OK, coreset (k-center greedy), kNN (FAISS/sklearn)
-  calib.py              # Calibración/thresholds por ROI/rol con 0–3 NG
-  infer.py              # Pipeline inferencia: embeddings -> knn -> heatmap -> posproceso
-  roi_mask.py           # Máscara (rect/circle/annulus) en tamaño ROI (384x384)
-  storage.py            # Persistencia artefactos (npz/json) por role_id/roi_id
-  utils.py              # helpers: mm/px, seed, logging, timers
-  requirements.txt      # torch, timm (dinov2), faiss-cpu, fastapi, uvicorn, numpy, opencv-python, scikit-learn, scipy
-  README_backend.md     # cómo levantar el servicio y formatos I/O
-  models/
-    <role_id>/<roi_id>/memory.npz        # embeddings coreset, token_shape, etc.
-    <role_id>/<roi_id>/index.faiss       # índice FAISS (si aplica)
-    <role_id>/<roi_id>/calib.json        # threshold, p99_ok, p5_ng, mm_per_px, params
+  app.py          # FastAPI (endpoints, validaciones, heatmap PNG)
+  features.py     # DinoV2Features (timm) - input_size múltiplo de 14
+  patchcore.py    # PatchCoreMemory (coreset + kNN)
+  infer.py        # InferenceEngine (heatmap, percentiles, contornos)
+  calib.py        # choose_threshold (percentiles OK/NG)
+  roi_mask.py     # build_mask rect/circle/annulus
+  storage.py      # ModelStore (memory.npz, index.faiss, calib.json)
+  requirements.txt
+  models/<role>/<roi>/
+     memory.npz
+     index.faiss (opcional)
+     calib.json
 ```
 
+### 2.1 `app.py`
+- Define `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`.
+- Decodifica imágenes (`cv2.imdecode`), valida `token_shape`, reconstruye memoria desde disco y normaliza respuestas.【F:backend/app.py†L46-L214】
 
-## 🧠 EXTRACTOR (DINOv2 ViT-S) — **sin entrenamiento**
+### 2.2 `features.py`
+- `DinoV2Features` carga `vit_small_patch14_dinov2.lvd142m` desde `timm`, rescalea a `input_size` (448 por defecto) y devuelve embeddings + `token_shape` (`Ht`, `Wt`).【F:backend/features.py†L1-L200】
 
-- Usa `timm` con **dinov2 pequeño**:  
-  `timm.create_model('vit_small_patch14_dinov2.lvd142m', pretrained=True)`  
-- **Congelado** (`eval()`, `requires_grad=False`).  
-- Preprocesado: normalización ImageNet (o la que requiera el peso).  
-- **Entrada** ROI canónico **384×384** (configurable).
-- **Multi-escala** simple:  
-  - o **multi-nivel** (obtener token embeddings de 2–3 capas internas),  
-  - o **multi-resize** (p. ej., 256 y 384) y concatenar.  
-- Resultado: **mapa de tokens** (H_token × W_token × D). Para patch=14, 384→**27×27** tokens.  
-- **L2 normalize** embeddings por parche.
+### 2.3 `patchcore.py`
+- `PatchCoreMemory.build(E, coreset_rate)` selecciona un coreset con k-center greedy y construye kNN (FAISS si disponible).【F:backend/patchcore.py†L1-L200】
 
-> Implementa `FeaturesExtractor` con:  
-> `forward(np.uint8 HxWx3) -> (embeddings: np.ndarray [N_tokens, D], token_hw: (H,W))`.
+### 2.4 `infer.py`
+- `InferenceEngine.run` aplica kNN, reescala heatmap, enmascara (`roi_mask`), calcula percentil (`score`) y filtra contornos por `area_mm2_thr` usando `mm_per_px`. Devuelve `heatmap_u8`, `regions`, `token_shape`.【F:backend/infer.py†L17-L181】
 
+### 2.5 `calib.py`
+- `choose_threshold(ok_scores, ng_scores, percentile=99)` calcula thresholds entre `p99_ok` y `p5_ng` cuando hay NG disponibles.【F:backend/calib.py†L1-L120】
 
-## 🧩 MEMORIA OK (PatchCore) + CORESEt + kNN
+### 2.6 `storage.py`
+- `ModelStore` guarda/carga `memory.npz` (embeddings, token shape, metadata), `index.faiss` y `calib.json`. Rutas: `models/<role>/<roi>/`.【F:backend/storage.py†L12-L79】
 
-- `fit_ok(images_ok: List[np.uint8])`:
-  - Extrae embeddings de cada OK (concatenar por ROI).  
-  - **Coreset k-center greedy** para reducir a **1–5%** (`target_rate` configurable).  
-  - Construye índice **FAISS IndexFlatL2** (o `NearestNeighbors` sklearn si no hay FAISS).  
-  - Persistir: `memory.npz` (embeddings coreset, token_hw, D), `index.faiss`.  
+---
 
-**Coreset k-center greedy** (pseudocódigo):
-```
-Input: E = [e1..eM] (L2-normalized), size M × D, target m = ceil(M * target_rate)
-Pick first center c0 (aleatorio o más representativo)
-While |C| < m:
-  d_i = min_{c in C} ||e_i - c||_2
-  pick argmax_i d_i  -> nuevo centro
-```
+## 3. Contrato HTTP (FastAPI)
 
+| Endpoint | Método | Descripción |
+|----------|--------|-------------|
+| `/health` | GET | Estado del servicio, dispositivo, modelo, versión. |
+| `/fit_ok` | POST (multipart) | Entrena memoria PatchCore a partir de imágenes OK. Devuelve `n_embeddings`, `coreset_size`, `token_shape`, ratios. |
+| `/calibrate_ng` | POST (JSON) | Calcula y guarda `threshold`, percentiles, `mm_per_px`, `area_mm2_thr`. |
+| `/infer` | POST (multipart) | Ejecuta inferencia: devuelve `score`, `threshold` (nullable), `heatmap_png_base64`, `regions`, `token_shape`. |
 
-## 🔎 INFERENCIA
+Errores se devuelven como `{ "error": "mensaje", "trace": "stacktrace" }` con códigos 4xx/5xx.【F:backend/app.py†L108-L214】
 
-- `infer(image_roi: np.uint8, role_id, roi_id, mm_per_px, [shape])`:
-  1. Extrae embeddings → `E_q` (Nq × D).  
-  2. Para cada parche, distancia `d_i` al **vecino más cercano** en la memoria.  
-  3. **Heatmap**: `H_token×W_token` con `d_i`, reescala a **384×384** (`cv2.resize` bilineal).  
-  4. **Score global**: percentil **p99** (o **p95**) del heatmap (config).  
-  5. **Posproceso**:
-     - **Gaussian blur** (σ pequeño).  
-     - **Máscara ROI** (rect/círculo/annulus) → pone a 0 fuera del ROI.  
-     - **Umbral**: si calibrado, usar `threshold` (sino modo “score-only”).  
-     - **Islas**: elimina contornos con área < `px_area_thr = area_mm2_thr/(mm_per_px^2)`.  
-     - **Contornos**: `cv2.findContours`; exporta `bbox`, `area_px`, `area_mm2`.  
-  6. Devuelve:
-     ```json
-     {
-       "role_id": "...",
-       "roi_id": "...",
-       "score": 0.0,
-       "threshold": 0.0,
-       "heatmap_png_base64": "...",
-       "regions": [
-         {"bbox": [x,y,w,h], "area_px": n, "area_mm2": a, "contour": [[x1,y1], ...]}
-       ],
-       "token_shape": [H_token, W_token],
-       "params": { "extractor": "dinov2-vit-s/14", "coreset_rate": 0.02, "k": 1, "p_score": 99, "blur_sigma": 1.0 }
-     }
-     ```
-- **Tiempo**: vectoriza distancias; en FAISS, consulta en batch.
+---
 
+## 4. Persistencia y datasets
 
-## ⚖️ CALIBRACIÓN (con 0–3 NG)
+- **Backend**: `models/<role>/<roi>/memory.npz`, `index.faiss`, `calib.json`. Cada `memory.npz` incluye `emb` (float32) y `token_h/w`.
+- **GUI**: exporta `datasets/<role>/<roi>/<ok|ng>/SAMPLE_*.png` + `.json` con `role_id`, `roi_id`, `mm_per_px`, `shape_json`, `angle`, `timestamp`. No tocar esta estructura; el backend se apoya en ella para entrenar.
 
-- `calibrate_ng(role_id, roi_id, samples_ok_scores, samples_ng_scores)`:
-  - Si **hay NG**: `threshold` entre **p99(OK)** y **p5(NG)**; prueba grid corto (o mediana) para minimizar FP/FN.  
-  - Si **no hay NG**: `threshold = p99(OK)` (+ margen configurable).  
-  - Guarda `calib.json`: `{"threshold": t, "p99_ok": x, "p5_ng": y|null, "mm_per_px": z, "area_mm2_thr": A, "score_percentile": 99}`.
+---
 
-> `area_mm2_thr` configurable por ROI/rol (p. ej. 1.0–2.0 mm²). Convierte a px dentro de `infer`.
+## 5. Buenas prácticas
 
+1. **GPU/CPU**: respetar `DEVICE` (`auto` por defecto). El código debe funcionar sin GPU; usar `torch.cuda.is_available()` solo dentro de `features.py`.
+2. **Coreset**: exponer `CORESET_RATE` configurable (0.02 por defecto). Validar que `token_shape` coincide entre entrenamiento/inferencia.
+3. **Logging**: usar `logging.getLogger(__name__)`, registrar inicio, `/fit_ok`, `/calibrate_ng`, `/infer`, y propagar `X-Correlation-Id` si se recibe. Ver [LOGGING.md](LOGGING.md).
+4. **Errores claros**: devolver `400` en lugar de `500` para condiciones controladas (`Token grid mismatch`, memoria ausente).
+5. **Tests manuales**: siempre ejecutar smoke tests (`/health`, `/fit_ok`, `/infer`) tras cambios.
 
-## 🛠️ ENDPOINTS HTTP (FastAPI)
+---
 
-### `POST /fit_ok`
-- **multipart/form-data**:
-  - `role_id`: str  
-  - `roi_id`: str  
-  - `mm_per_px`: float  
-  - `images`: uno o varios PNG/JPG (ROI canónico; si no es 384, redimensionar internamente)
-- **acción**: extraer features, acumular, coreset, construir índice, persistir.
-- **respuesta**: JSON con conteos (`n_ok_total`, `n_embeddings`, `coreset_rate_applied`) y checksum.
+## 6. Checklist para modificaciones
 
-### `POST /calibrate_ng`
-- **JSON**:
-  ```json
-  {
-    "role_id": "...",
-    "roi_id": "...",
-    "mm_per_px": 0.2,
-    "ok_scores": [ ... ],
-    "ng_scores": [ ... ],
-    "area_mm2_thr": 1.0,
-    "score_percentile": 99
-  }
-  ```
-- **acción**: fija y guarda `threshold` por ROI/rol.
-- **respuesta**: JSON con `threshold`, `p99_ok`, `p5_ng` (si aplica).
+- [ ] Mantener estables rutas y nombres de campos (`role_id`, `roi_id`, `mm_per_px`, `shape`).
+- [ ] Actualizar documentación relevante (`API_REFERENCE.md`, `DATA_FORMATS.md`) si se añade funcionalidad.
+- [ ] Registrar nuevos parámetros en `DEV_GUIDE.md` / `DEPLOYMENT.md` si afectan despliegues.
+- [ ] Garantizar compatibilidad con modelos guardados (`memory.npz` existentes) o documentar migraciones.
+- [ ] Añadir logs y manejar excepciones con mensajes accionables.
 
-### `POST /infer`
-- **multipart/form-data**:
-  - `role_id`, `roi_id`, `mm_per_px`  
-  - `shape` (opcional): `{ "kind": "circle"|"annulus"|"rect", "cx":..., "cy":..., "r":..., "r_inner":..., "w":..., "h":... }`  
-  - `image`: PNG/JPG (ROI canónico 384×384 ideal; si no, resize interno).
-- **acción**: embeddings → kNN → heatmap → posproceso → score + contornos.
-- **respuesta**: JSON como arriba.
+---
 
-### `GET /health`
-- `{ "status": "ok", "device": "cuda"|"cpu", "model": "dinov2-vit-s/14", "version": "..." }`.
+## 7. Fuera de alcance
 
+- No cambiar la GUI, adorners o pipeline de canonicalización.
+- No introducir nuevos frameworks de deep learning (seguir con PyTorch + timm + PatchCore).
+- No eliminar FAISS opcional; mantener fallback a `sklearn` si FAISS no está presente.
 
-## ✅ CRITERIOS DE ACEPTACIÓN
+---
 
-- **Sin EfficientNet** (ni código ni deps).  
-- Arranca con `uvicorn app:app`.  
-- `/fit_ok`, `/calibrate_ng`, `/infer` funcionales con artefactos persistentes por `(role_id, roi_id)`.  
-- **Determinismo** opcional (seed).  
-- **CUDA si existe**, si no CPU.  
-- **Tests mínimos**:
-  - Fit con 20–50 OK → coreset 1–5%.  
-  - Infer con 1 OK y 1 “simulada NG” → heatmap razonable.  
-  - Calibración con 0 NG (p99 OK) y con 1–3 NG (umbral entre p99 OK y p5 NG).  
-  - Eliminación de islas < área_mm2_thr (mm ↔ px correcto).  
-- Rendimiento orientativo (GPU): `<60 ms` por ROI 384×384 (extract + kNN coreset ~10k). CPU aceptable con batch pequeño.
-
-
-## 📝 DETALLES DE IMPLEMENTACIÓN
-
-- **features.py**
-  - `class DinoV2Features:`  
-    - `__init__(model_name='vit_small_patch14_dinov2.lvd142m', device='auto', out_indices=(9, 11))`  
-    - `extract(img_bgr_uint8) -> (embeddings[N,D], (Ht,Wt))`  
-      - Preprocesa a RGB, resize a 384, normaliza.  
-      - Extrae tokens de capas `out_indices`; concatena y **L2-normalize**.  
-- **patchcore.py**
-  - `build_memory(emb_list: List[np.ndarray], coreset_rate=0.02, seed=0)` → `memory: np.ndarray[M,D]`  
-  - `build_index(memory)` → `faiss.IndexFlatL2` (o sklearn)  
-  - `knn(query: np.ndarray[N,D], k=1)` → `dist_min[N]`  
-  - Persistencia con `np.savez` y FAISS `write_index`.
-- **infer.py**
-  - `infer_one(image, role_id, roi_id, mm_per_px, shape=None, k=1, p_score=99, blur_sigma=1.0, area_mm2_thr=1.0)`  
-    - Usa `storage.load(role, roi)` para memoria/índice/threshold.  
-    - Heatmap token → resize → blur → mask → binariza con `threshold` (si calibrado) → contornos.  
-    - `area_mm2 = area_px * (mm_per_px**2)`.  
-- **roi_mask.py**
-  - Genera máscara binaria 384×384 desde `shape` (rect/circle/annulus).  
-- **calib.py**
-  - `calibrate(ok_scores, ng_scores=None, percentile=99)` → `threshold`.
-- **storage.py**
-  - Rutas `models/<role>/<roi>/...`, manejo JSON.
-
-
-## 📡 EJEMPLO DE LLAMADA DESDE C# (GUI ACTUAL)
-
-```csharp
-// infer
-var content = new MultipartFormDataContent();
-content.Add(new StringContent(roleId), "role_id");
-content.Add(new StringContent(roiId), "roi_id");
-content.Add(new StringContent(mmPerPx.ToString(CultureInfo.InvariantCulture)), "mm_per_px");
-content.Add(new StreamContent(File.OpenRead(roiPngPath)), "image", "roi.png");
-// opcional: content.Add(new StringContent(JsonConvert.SerializeObject(shape)), "shape");
-
-var resp = await http.PostAsync($"{baseUrl}/infer", content);
-var json = await resp.Content.ReadAsStringAsync();
-// parsea score, threshold, heatmap (base64), regions[bbox...]
-```
-
-
-## ❓ PREGUNTAS QUE PUEDE HACER EL MODELO
-
-1) ¿Confirmas **entrada** del backend será **ROI canónico** (rotado/recortado)? (sí)  
-2) ¿Formato de `shape` para máscara (circle/annulus/rect) lo envía la GUI? (opcional; si falta, aplicar máscara “lleno”)  
-3) ¿Tamaño fijo 384×384 o configurable? (por defecto 384; param `input_size`)  
-4) ¿FAISS disponible en despliegue o usar sklearn si no? (soporta ambos)  
-5) ¿Dónde guardar artefactos? (ruta `models/`)  
-6) `area_mm2_thr` por ROI/rol, ¿valor inicial? (p. ej. **1.0 mm²**)  
-7) ¿Devolver heatmap **base64** o **ruta temporal**? (base64 por defecto)  
-
-
-## ⛔ EXCLUSIONES
-
-- **No** usar EfficientNet ni cargar sus pesos.  
-- **No** tocar GUI ni lógica WPF.  
-- **No** suponer que hay más de 0–3 NG reales para entrenar.  
-
-
-## ✅ ENTREGA ESPERADA
-
-- Código completo bajo `backend/` con los módulos descritos, `requirements.txt`, `README_backend.md`.  
-- Servidor FastAPI ejecutable (`uvicorn app:app`) y endpoints funcionando.  
-- Scripts/funciones unitarias mínimas para probar `fit_ok`, `calibrate_ng`, `infer`.
+Siguiendo estas directrices, el backend seguirá alineado con la GUI y con los contratos documentados a octubre de 2025.

--- a/ROI_AND_MATCHING_SPEC.md
+++ b/ROI_AND_MATCHING_SPEC.md
@@ -1,17 +1,13 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
-
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+**Cambios clave documentados en esta versión:**
+- Definición de ROI basada en `RoiCropUtils` y adorners actuales; se aclara que la GUI exporta PNG + `shape_json` sin alterar geometría.
+- Sincronización de máscaras con `backend/roi_mask.py` y conversión px↔mm² usada en `InferenceEngine`.
+- Se detalla el flujo de canonicalización (rotación con `Cv2.WarpAffine`, recorte centrado) y la alineación del heatmap en la GUI.
 
 # ROI_AND_MATCHING_SPEC — BrakeDiscInspector
 
-Especificación de las Regiones de Interés (ROI) y de la información geométrica que intercambian la GUI y el backend PatchCore. La funcionalidad de *template matching* legado ha sido retirada; este documento se centra en el flujo ROI → backend.
+Especificación de las Regiones de Interés (ROI) y de la información geométrica compartida entre la GUI y el backend PatchCore. El pipeline legado de template matching está retirado; la prioridad es mantener los contratos ROI ↔ backend estables.
 
 ---
 
@@ -19,8 +15,8 @@ Especificación de las Regiones de Interés (ROI) y de la información geométri
 
 - [Modelo de ROI en la GUI](#1-modelo-de-roi-en-la-gui)
 - [Canonicalización del ROI](#2-canonicalización-del-roi)
-- [Shapes soportados](#3-shapes-soportados-por-el-backend)
-- [Conversión de coordenadas](#4-conversión-de-coordenadas-gui--imagen)
+- [Shapes soportados](#3-shapes-soportados)
+- [Conversión de coordenadas](#4-conversión-de-coordenadas)
 - [Integración con el backend](#5-integración-con-el-backend)
 - [Persistencia de datasets](#6-persistencia-de-datasets)
 - [Áreas y unidades](#7-áreas-y-unidades)
@@ -29,65 +25,57 @@ Especificación de las Regiones de Interés (ROI) y de la información geométri
 
 ## 1) Modelo de ROI en la GUI
 
+Las clases `ROI.cs` y `RoiShape.cs` describen el modelo utilizado por los adorners (`RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`). Cada ROI almacena:
+
 | Campo | Tipo | Descripción |
 |-------|------|-------------|
-| `X` | double | Coordenada X del centro (en píxeles de la imagen original). |
-| `Y` | double | Coordenada Y del centro. |
-| `Width` | double | Ancho del rectángulo que delimita el ROI (mínimo 10 px). |
-| `Height` | double | Alto del rectángulo. |
-| `AngleDeg` | double | Ángulo de rotación (grados) aplicado alrededor del centro. |
-| `Legend` | string | Etiqueta descriptiva (ej. `"Pattern"`, `"Inspection"`). |
+| `Left` / `Top` | double | Coordenadas del bounding box en píxeles de la imagen original. |
+| `Width` / `Height` | double | Dimensiones del rectángulo. Para círculos/annulus se normaliza a bbox cuadrado. |
+| `AngleDeg` | double | Rotación aplicada desde la GUI (horario). |
+| `Shape` | enum | `Rectangle`, `Circle` o `Annulus`. |
+| `R`, `RInner` | double | Radios para círculos/annulus. |
 
-Restricciones:
-- El ROI debe permanecer dentro de los límites de la imagen; si se sale parcialmente, la GUI recorta la zona válida.
-- `AngleDeg` solo se utiliza en la GUI. El backend recibe un PNG ya rotado (ROI canónico).
+Los adorners mantienen la posición y ángulo en sincronía con la imagen mostrada usando `Stretch="Uniform"`, preservando la relación imagen↔canvas.【F:gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs†L1-L200】
 
 ---
 
 ## 2) Canonicalización del ROI
 
-1. La GUI rota la imagen completa usando `Cv2.GetRotationMatrix2D` y `Cv2.WarpAffine` alrededor del centro del ROI.
-2. Posteriormente recorta el rectángulo `Width × Height` sobre la imagen rotada.
-3. El resultado es un PNG (ROI canónico) que se envía al backend en `/fit_ok` y `/infer`.
-4. La GUI genera un archivo JSON asociado con metadatos:
-   ```json
-   {
-     "role_id": "Master1",
-     "roi_id": "Pattern",
-     "mm_per_px": 0.20,
-     "shape": { "kind": "circle", "cx": 192, "cy": 192, "r": 180 },
-     "source_path": "C:/datasets/raw.png",
-     "angle": 32.0,
-     "timestamp": "2024-06-01T12:34:56.789Z"
-   }
-   ```
+`RoiCropUtils` centraliza el pipeline utilizado para exportar el ROI canónico (idéntico al que se usa en “Save Master/Pattern”):
+
+1. `TryBuildRoiCropInfo` calcula el bounding box exacto y el pivote de rotación en coordenadas de imagen para cualquier shape.【F:gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs†L5-L60】
+2. `TryGetRotatedCrop` aplica `Cv2.WarpAffine` sobre la imagen original usando el pivote y el ángulo negativo (para “deshacer” la rotación del adorner), y recorta el rectángulo con las dimensiones originales del ROI.【F:gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs†L62-L134】
+3. `BuildRoiMask` genera una máscara 8-bit alineada con el recorte, centrando círculos/annulus en el ROI canónico.【F:gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs†L136-L200】
+4. El PNG resultante (BGR) y la máscara opcional se serializan en disco junto con `shape_json`.
+
+Resultado: el backend recibe siempre imágenes alineadas, sin necesidad de re-rotar o recortar.
 
 ---
 
-## 3) Shapes soportados por el backend
+## 3) Shapes soportados
 
-El campo `shape` es opcional y se expresa siempre en coordenadas del ROI canónico (post rotación/crop).
+El `shape_json` que acompaña a cada ROI se expresa en coordenadas del ROI canónico. La GUI reutiliza la misma estructura al llamar a `/infer`:
 
-- **Rectángulo completo**:
+- Rectángulo completo
   ```json
   {"kind":"rect","x":0,"y":0,"w":W,"h":H}
   ```
-- **Círculo**:
+- Círculo centrado
   ```json
   {"kind":"circle","cx":CX,"cy":CY,"r":R}
   ```
-- **Annulus**:
+- Annulus
   ```json
   {"kind":"annulus","cx":CX,"cy":CY,"r":R_OUTER,"r_inner":R_INNER}
   ```
 
-Si el shape no se envía, el backend asume todo el ROI.
+`backend/roi_mask.py` reconstruye estas máscaras para enmascarar heatmaps y regiones antes de devolver resultados.【F:backend/roi_mask.py†L1-L160】
 
 ---
 
-## 4) Conversión de coordenadas GUI ↔ imagen
+## 4) Conversión de coordenadas
 
-La imagen se muestra con `Stretch="Uniform"`. Para alinear el canvas de ROI:
+La imagen principal se muestra con `Stretch="Uniform"`. `MainWindow` y `RoiOverlay` calculan el canvas visible mediante:
 
 ```
 scale = min(ImageHost.ActualWidth  / PixelWidth,
@@ -96,48 +84,47 @@ drawWidth  = PixelWidth  * scale
 drawHeight = PixelHeight * scale
 offsetX = (ImageHost.ActualWidth  - drawWidth)  / 2
 offsetY = (ImageHost.ActualHeight - drawHeight) / 2
-
-CanvasROI.Width  = drawWidth
-CanvasROI.Height = drawHeight
-Canvas.SetLeft(CanvasROI, offsetX)
-Canvas.SetTop(CanvasROI,  offsetY)
 ```
 
-Conversión:
-- **Imagen → Canvas**: `(canvasX, canvasY) = (imageX * sx, imageY * sy)`.
-- **Canvas → Imagen**: `(imageX, imageY) = (canvasX / sx, canvasY / sy)`.
+- **Imagen → Canvas**: `canvas = image * scale + offset`.
+- **Canvas → Imagen**: `image = (canvas - offset) / scale`.
+
+Los adorners operan exclusivamente en coordenadas de imagen, evitando drift al redimensionar la ventana.
 
 ---
 
 ## 5) Integración con el backend
 
-- `/fit_ok` y `/infer` reciben siempre el PNG canónico (no raw image) y, opcionalmente, el `shape` JSON serializado como string.
-- `/calibrate_ng` consume únicamente los scores devueltos por `/infer`; no recibe geometría.
-- El backend devuelve `regions` en píxeles del ROI canónico; la GUI puede convertirlos a mm² usando `mm_per_px`.
+- `/fit_ok` y `/infer` reciben el PNG canónico; no se envía la imagen original ni se realizan rotaciones en el backend.【F:backend/app.py†L46-L118】
+- `/infer` acepta `shape` como string JSON; se aplica en `InferenceEngine.run` para limitar el heatmap antes de calcular percentiles y contornos.【F:backend/infer.py†L66-L132】
+- Las `regions` devueltas están en píxeles del ROI canónico; la GUI puede convertirlas a la imagen original si necesita superponer bounding boxes en la vista general.
 
 ---
 
 ## 6) Persistencia de datasets
 
-La GUI guarda muestras en `datasets/<role>/<roi>/<ok|ng>/` con pares PNG/JSON. Se recomienda mantener consistencia en la nomenclatura:
+`DatasetManager.SaveSampleAsync` crea la estructura `datasets/<role>/<roi>/<ok|ng>/SAMPLE_yyyyMMdd_HHmmssfff.png` y su JSON asociado:
+```json
+{
+  "role_id": "Master1",
+  "roi_id": "Pattern",
+  "mm_per_px": 0.20,
+  "shape_json": "{...}",
+  "source_path": "C:/captures/raw.png",
+  "angle": 32.0,
+  "timestamp": "2025-09-28T12:34:56.789Z"
+}
 ```
-datasets/Master1/Pattern/ok/OK_20240601_123456.png
-datasets/Master1/Pattern/ok/OK_20240601_123456.json
-```
-
-Los archivos JSON deben incluir `role_id`, `roi_id`, `mm_per_px`, `shape`, `angle`, `timestamp` y `source_path` (opcional).
+Este esquema coincide con `SampleMetadata` y se usa para reconstruir listas de muestras en la GUI.【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetManager.cs†L38-L74】【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs†L72-L120】
 
 ---
 
 ## 7) Áreas y unidades
 
-- El backend aplica un filtro de islas usando `area_mm2_thr` (mm²). La GUI debe proporcionar `mm_per_px` correcto para evitar falsos positivos/negativos.
-- Las áreas devueltas en `regions` contienen tanto `area_px` como `area_mm2` ya convertida.
+- `mm_per_px` se conserva desde la exportación del dataset hasta las llamadas al backend para asegurar coherencia.
+- `InferenceEngine` convierte `area_mm2_thr` a píxeles (`mm2_to_px2`) antes de filtrar contornos y calcula `area_mm2` en la respuesta para cada región.【F:backend/infer.py†L133-L181】
+- La GUI debe mostrar ambos valores (px y mm²) y permitir comparar `score` vs `threshold` calibrado.
 
 ---
 
-## 8) Referencias cruzadas
-
-- [ARCHITECTURE.md](ARCHITECTURE.md) — flujo completo GUI ↔ backend.
-- [API_REFERENCE.md](API_REFERENCE.md) — contratos de `/fit_ok`, `/calibrate_ng`, `/infer`.
-- [DATA_FORMATS.md](DATA_FORMATS.md) — esquemas de archivos y JSON.
+Para más detalles sobre arquitectura y contratos, revisa [ARCHITECTURE.md](ARCHITECTURE.md) y [API_REFERENCE.md](API_REFERENCE.md).

--- a/docs/mcp/latest_updates.md
+++ b/docs/mcp/latest_updates.md
@@ -9,9 +9,17 @@ This log records notable Maintenance & Communication Plan (MCP) events for Brake
 
 ## Quick index
 
+- [2025-10-07 — Markdown & Memory Restoration Refresh](#2025-10-07--markdown--memory-restoration-refresh)
 - [2024-06-12 — Comprehensive Markdown Refresh](#2024-06-12--comprehensive-markdown-refresh)
 - [2024-06-05 — PatchCore Documentation Refresh](#2024-06-05--patchcore-documentation-refresh)
 - [2024-05-28 — Initial MCP Publication](#2024-05-28--initial-mcp-publication)
+
+## 2025-10-07 — Markdown & Memory Restoration Refresh
+
+- **Owners:** MCP Maintainer, Backend Lead, GUI Lead
+- **Summary:** Realigned every markdown in the repo (README, ARCHITECTURE, DEV_GUIDE, API_REFERENCE, DATA_FORMATS, DEPLOYMENT, LOGGING, ROI spec, backend prompt, GUI instructions, MCP docs) with the current FastAPI (`app.py`) and GUI (`BackendClient`, `DatasetManager`) implementations. Added `PROJECT_OVERVIEW.txt` for rapid onboarding/memory restoration and documented storage layout `backend/models/<role>/<roi>/` plus dataset expectations.
+- **Evidence:** Updated markdown files in repo root and `docs/mcp/`, backend sources (`backend/app.py`, `backend/infer.py`, `backend/storage.py`), GUI workflow files.
+- **Next Steps:** Share the new `PROJECT_OVERVIEW.txt` with onboarding teams; capture feedback on clarity and identify gaps for future automation.
 
 ## 2024-06-12 — Comprehensive Markdown Refresh
 

--- a/docs/mcp/overview.md
+++ b/docs/mcp/overview.md
@@ -1,6 +1,6 @@
 # MCP Overview
 
-The Maintenance & Communication Plan (MCP) keeps all contributors aligned on how BrakeDiscInspector evolves. It complements the architectural, data-format and API guides by clarifying responsibilities, coordination workflows and artefact ownership.
+The Maintenance & Communication Plan (MCP) keeps all contributors aligned on how BrakeDiscInspector evolves. It complements the architectural, data-format and API guides by clarifying responsibilities, coordination workflows and artefact ownership. For rapid onboarding use `PROJECT_OVERVIEW.txt` alongside this document.
 
 ## Quick index
 
@@ -18,7 +18,7 @@ The Maintenance & Communication Plan (MCP) keeps all contributors aligned on how
 The MCP covers every change that can affect:
 
 - The FastAPI backend in [`backend/`](../../backend) and its contracts (`/health`, `/fit_ok`, `/calibrate_ng`, `/infer`).
-- The WPF GUI in [`gui/`](../../gui) that manages ROI datasets and interacts with the backend.
+- The WPF GUI in [`gui/`](../../gui) that manages ROI datasets and interacts with the backend via `BackendClient`/`DatasetManager`.
 - Shared datasets, trained artefacts under `backend/models/<role>/<roi>/`, and calibration thresholds persisted in `calib.json`.
 - Operational tooling (PowerShell scripts, logging, deployment flows) referenced across the repository.
 
@@ -27,7 +27,7 @@ The MCP covers every change that can affect:
 | Role | Primary Responsibilities | Reference Material |
 |------|--------------------------|--------------------|
 | MCP Maintainer | Curate this documentation, track action items, publish updates in [`latest_updates.md`](latest_updates.md). | This folder |
-| Backend Lead | Own API/contract stability, PatchCore artefacts, deployment readiness. | [`API_REFERENCE.md`](../../API_REFERENCE.md), [`backend/README_backend.md`](../../backend/README_backend.md) |
+| Backend Lead | Own API/contract stability, PatchCore artefacts, deployment readiness. | [`API_REFERENCE.md`](../../API_REFERENCE.md), [`backend/app.py`](../../backend/app.py) |
 | GUI Lead | Coordinate GUI release cadence, ROI tooling updates, dataset UX. | [`ARCHITECTURE.md`](../../ARCHITECTURE.md), [`DEV_GUIDE.md`](../../DEV_GUIDE.md) |
 | Data Steward | Version datasets, manage `models/<role>/<roi>/memory.npz` and `calib.json`, ensure mm/px consistency. | [`DATA_FORMATS.md`](../../DATA_FORMATS.md), [`ROI_AND_MATCHING_SPEC.md`](../../ROI_AND_MATCHING_SPEC.md) |
 
@@ -37,7 +37,7 @@ The MCP covers every change that can affect:
 2. **Assess impact** with relevant role owners (backend, GUI, data). Confirm compatibility with existing artefacts.
 3. **Validate** using procedures in [`DEV_GUIDE.md`](../../DEV_GUIDE.md) and smoke tests from [`DEPLOYMENT.md`](../../DEPLOYMENT.md).
 4. **Document** the outcome:
-   - Update the pertinent guide(s).
+   - Update the pertinent guide(s) and, if needed, `PROJECT_OVERVIEW.txt`.
    - Record the summary in [`latest_updates.md`](latest_updates.md) with date, owner, links to evidence.
 5. **Communicate** the release to the wider team (Slack/email) with links to the updated markdown files.
 
@@ -85,6 +85,6 @@ Expectations are centralised in [`LOGGING.md`](../../LOGGING.md):
 
 ## Maintaining this Folder
 
-- Scope limited to MCP coordination topics.
-- Add a dated entry to [`latest_updates.md`](latest_updates.md) for every meaningful change.
-- Cross-link new MCP documents from here and ensure README references remain valid.
+- Scope limitado a coordinación MCP.
+- Añadir una entrada fechada a [`latest_updates.md`](latest_updates.md) por cada cambio significativo.
+- Asegurar que `PROJECT_OVERVIEW.txt` y las guías enlazadas reflejan cualquier decisión reciente.

--- a/instructions_codex_gui_workflow.md
+++ b/instructions_codex_gui_workflow.md
@@ -1,232 +1,109 @@
-
 # 📌 Actualización — 2025-10-07
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
+**Cambios clave documentados en esta versión:**
+- Guía actualizada para el flujo GUI Dataset → `/fit_ok` → `/calibrate_ng` → `/infer` usando `BackendClient` y `DatasetManager` actuales.
+- Se refuerzan las restricciones sobre adorners, canonicalización (`RoiCropUtils`) y máscaras `shape_json`.
+- Se añaden referencias a DTOs y manejo de errores presente en `Workflow/BackendClient.cs`.
 
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+# Instructions for Agents — WPF GUI workflow (Dataset → Train → Calibrate → Infer)
 
-# Instructions for Codex — WPF GUI: Dataset → Train (fit_ok) → Calibrate → Infer (backend PatchCore+DINOv2)
-
-**Goal**: Implement in the existing WPF GUI a complete workflow to (1) collect ROI samples, (2) train the model memory on the backend, (3) optionally calibrate thresholds, and (4) run inference — all **without changing adorner/ROI drawing logic** or the backend service contract.
+**Goal**: Mantener y extender la GUI WPF sin romper el pipeline de ROI canónico. Toda interacción con el backend PatchCore+DINOv2 debe respetar las rutas `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` implementadas en `backend/app.py`.
 
 ---
 
-## Quick index
+## 1. Scope & Non-Regression Rules
 
-- [Scope & Non-Regression Rules](#scope--non-regression-rules)
-- [Backend Contract](#backend-contract-summary)
-- [New GUI Features](#new-gui-features-tabs-or-wizard)
-- [Shape JSON mapping](#shape-json-mapping-from-existing-roi-types)
-- [File/Folder Structure](#filefolder-structure-gui-side)
-- [New/Updated Code](#newupdated-code-wpf)
-- [Error Handling & UX](#error-handling--ux)
-- [Acceptance Criteria](#acceptance-criteria)
-- [Testing Plan](#testing-plan)
-- [Coding Standards](#coding-standards)
-- [Deliverables](#deliverables)
-- [Do/Don’t Summary](#dodont-summary)
+1. **No modificar** adorners ni overlays base (`RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`, `RoiOverlay`).【F:gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs†L1-L200】
+2. Reutilizar `RoiCropUtils` para exportar ROIs canónicos; no reescribir transformaciones (`TryBuildRoiCropInfo`, `TryGetRotatedCrop`).【F:gui/BrakeDiscInspector_GUI_ROI/RoiCropUtils.cs†L62-L134】
+3. Todas las llamadas HTTP deben ser `async` (usar `BackendClient`), evitando bloquear el hilo UI.【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs†L20-L218】
+4. No cambiar nombres de campos enviados al backend (`role_id`, `roi_id`, `mm_per_px`, `images`, `shape`).
+5. Mantener la estructura de datasets `datasets/<role>/<roi>/<ok|ng>/` (PNG + JSON con `shape_json`, `mm_per_px`, `angle`).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetManager.cs†L38-L74】
 
 ---
 
-## Scope & Non‑Regression Rules
+## 2. Backend Contract (summary)
 
-1. **Scope**: Modify **GUI (WPF)** only. The backend (FastAPI) already exposes `/fit_ok`, `/calibrate_ng`, `/infer`, `/health`.
-2. **Must NOT change** any of these GUI subsystems, to avoid regressions in ROI alignment:
-   - Adorners (`RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`) and overlay (`RoiOverlay`).
-   - ROI coordinate spaces and the image/canvas letterboxing logic.
-   - The ROI canonicalization logic (crop+rotation) used by the existing “Save Master”/“Save Pattern”. Reuse it.
-3. **Threading/UI**: All HTTP calls must be **async**. Do not block the UI thread. Disable buttons while requests are in-flight.
-4. **Logging**: Use the GUI’s existing logging method (e.g., `AppendLog(...)`) to trace user actions and backend replies. Include timings and file paths.
-5. **Configuration**: The backend base URL must be configurable in the GUI (default `http://127.0.0.1:8000`).
+- `GET /health` → `{ status, device, model, version }`.
+- `POST /fit_ok` (multipart) → campos `role_id`, `roi_id`, `mm_per_px`, `images[]`; respuesta con `n_embeddings`, `coreset_size`, `token_shape`.
+- `POST /calibrate_ng` (JSON) → `role_id`, `roi_id`, `mm_per_px`, `ok_scores[]`, opcional `ng_scores[]`, `area_mm2_thr`, `score_percentile`; respuesta con `threshold`, `p99_ok`, `p5_ng`.
+- `POST /infer` (multipart) → `role_id`, `roi_id`, `mm_per_px`, `image`, opcional `shape`; respuesta con `score`, `threshold?`, `heatmap_png_base64`, `regions`, `token_shape`.
+
+La GUI debe mapear estas respuestas a DTOs (`FitOkResult`, `CalibResult`, `InferResult`) usando `System.Text.Json` (`JsonSerializerDefaults.Web`).【F:gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs†L150-L218】
 
 ---
 
-## Backend Contract (summary)
+## 3. Features to maintain in the GUI
 
-- `GET /health` → status, device, model, version.
-- `POST /fit_ok` (multipart): `role_id`, `roi_id`, `mm_per_px`, multiple `images[]` (PNG/JPG). Returns `n_embeddings`, `coreset_size`, `token_shape`.
-- `POST /calibrate_ng` (JSON): `role_id`, `roi_id`, `mm_per_px`, arrays `ok_scores`, optional `ng_scores`, `area_mm2_thr`, `score_percentile`. Returns `threshold` and stats.
-- `POST /infer` (multipart): `role_id`, `roi_id`, `mm_per_px`, `image`, optional `shape` (JSON string). Returns `score`, `threshold` (0 if none), `heatmap_png_base64`, `regions` (bbox + area px/mm²).
+### Dataset tab
+- Selectores `RoleId`, `RoiId`, `MmPerPx`.
+- Botones **Add OK/NG from Current ROI** → exportar PNG+JSON usando `DatasetManager.SaveSampleAsync`.
+- Listas `OK samples` / `NG samples` con thumbnails (`DatasetSample.Thumbnail`).
+- Botón **Open folder** para abrir `datasets/<role>/<roi>/`.
 
-> **Important**: Backend expects **canonical ROI image** (already cropped+rotated by GUI). The optional `shape` is used to mask inference (rect/circle/annulus).
+### Train tab
+- Botón **Train memory (fit_ok)** → empaquetar muestras OK (`images[]`) y llamar a `BackendClient.FitOkAsync`.
+- Mostrar `n_embeddings`, `coreset_size`, `token_shape` devueltos.
 
----
+### Calibrate tab
+- Recopilar scores OK/NG (reutilizando `/infer` sin threshold) y llamar a `BackendClient.CalibrateAsync`.
+- Mostrar `threshold`, `p99_ok`, `p5_ng`, `score_percentile`, `area_mm2_thr`.
 
-## New GUI Features (Tabs or Wizard)
-
-### A) **Dataset** (per role/ROI)
-Controls:
-- Selectors: `RoleId` (e.g., `Master1`, `Inspection`, ...), `RoiId` (e.g., `Pattern`, `Search`, ...).
-- Numeric: `MmPerPx` (pre-filled from your camera/layout).
-- Lists with thumbnails: `OK Samples`, `NG Samples` (optional).
-- Buttons:
-  - **“Add OK from Current ROI”**
-  - **“Add NG from Current ROI”** (optional)
-  - **“Remove Selected”**
-  - **“Open Dataset Folder”**
-
-Behaviour:
-- On “Add OK/NG from Current ROI”:
-  1. Canonicalize ROI (same routine used by your current Save Master/Pattern): **crop + rotation**.
-     - **Reuse** your internal pipeline (e.g., `TryBuildRoiCropInfo(...)` → `TryGetRotatedCrop(...)`). **Do not rewrite adorner code**.
-  2. Save PNG to: `datasets/<role>/<roi>/<ok|ng>/SAMPLE_yyyyMMdd_HHmmssfff.png`.
-  3. Save metadata JSON next to image:
-     ```json
-     {
-       "role_id": "Master1",
-       "roi_id": "Pattern",
-       "mm_per_px": 0.20,
-       "shape": { "kind": "circle", "cx": 192, "cy": 192, "r": 180 },
-       "source_path": "C:\images\part.png",
-       "angle": 32.0,
-       "timestamp": "2025-09-28T12:34:56.789Z"
-     }
-     ```
-  4. Refresh the dataset list in UI.
-
-### B) **Train / Calibrate**
-- **“Train memory (fit_ok)”**: bundles all OK PNGs of current `(RoleId, RoiId)` and calls backend `/fit_ok`.
-  - Display result: `n_embeddings`, `coreset_size`, `token_shape`.
-- **“Calibrate threshold (calibrate_ng)”**:
-  - Option A: If you have zero or few NGs, let the user skip or set percentile (p95/p99).
-  - Option B: If you have NGs or want score-driven calibration:
-    - Compute **scores** by calling `/infer` for all OK and NG samples (with no threshold). Collect `score` values.
-    - Send arrays to `/calibrate_ng` and show returned `threshold`.
-
-### C) **Inference**
-- **“Evaluate Current ROI”**: canonicalize and POST to `/infer` with `shape` JSON built from the current ROI.
-- Overlay returned `heatmap` (decode base64 PNG) on the ROI in the preview (with opacity slider).
-- Show `score`, `threshold`, and list `regions` (bbox, area px, area mm²).
-- Add a **local threshold slider** for interactive exploration (does not change backend threshold unless user confirms a “Save Threshold” action).
+### Infer tab
+- Botón **Infer current ROI** → exportar ROI canónico temporal, construir `shape_json` y llamar a `BackendClient.InferAsync`.
+- Mostrar `score`, `threshold`, nº `regions`, overlay del `heatmap_png_base64`.
+- Slider de opacidad local (no modifica `threshold` backend).
 
 ---
 
-## Shape JSON mapping (from existing ROI types)
+## 4. Shape JSON mapping
 
-Produce one of these JSONs (as string) for the `shape` field in `/infer`:
+- `Rectangle`: `{ "kind":"rect", "x":0, "y":0, "w":W, "h":H }`
+- `Circle`: `{ "kind":"circle", "cx":CX, "cy":CY, "r":R }`
+- `Annulus`: `{ "kind":"annulus", "cx":CX, "cy":CY, "r":R_OUTER, "r_inner":R_INNER }`
 
-- **Rectangle**:
-  ```json
-  {"kind":"rect","x":0,"y":0,"w":W,"h":H}
-  ```
-  (If the exported ROI is exactly the rectangle, you can use full canvas: 0,0,W,H)
-
-- **Circle**:
-  ```json
-  {"kind":"circle","cx":CX,"cy":CY,"r":R}
-  ```
-
-- **Annulus**:
-  ```json
-  {"kind":"annulus","cx":CX,"cy":CY,"r":R_OUTER,"r_inner":R_INNER}
-  ```
-
-All coordinates are **in the canonical ROI image space** (pixels), **after** crop/rotation.
+Las coordenadas siempre están en píxeles del ROI canónico (tras crop + rotación). Enviar como `StringContent` (`application/json` o texto) en el campo `shape` del multipart.
 
 ---
 
-## File/Folder Structure (GUI side)
+## 5. Error handling & UX
 
-- Dataset root: `datasets/<role>/<roi>/`
-  - `ok/` → PNG + JSON metadata
-  - `ng/` → PNG + JSON metadata
-  - `manifest.json` (optional): counts, last trained version, last calibration, etc.
-
----
-
-## New/Updated Code (WPF)
-
-### 1) Backend client (C#)
-Create `BackendClient` with:
-- `Task<(int nEmb, int coreset, int[] tokenShape)> FitOkAsync(string roleId, string roiId, double mmPerPx, IEnumerable<string> okImagePaths)`
-- `Task<CalibResult> CalibrateAsync(string roleId, string roiId, double mmPerPx, IEnumerable<double> okScores, IEnumerable<double>? ngScores = null, double areaMm2Thr = 1.0, int scorePercentile = 99)`
-- `Task<InferResult> InferAsync(string roleId, string roiId, double mmPerPx, string imagePath, string? shapeJson = null)`
-
-Use `HttpClient`, `MultipartFormDataContent`, async/await, and JSON (System.Text.Json). Timeout 120s.
-
-### 2) ROI export
-Add helper `ExportCurrentRoiCanonicalAsync(out string pngPath, out string shapeJson)`:
-- Reuse the **same internal code path** used by the existing Save Master (e.g., `TryBuildRoiCropInfo(...)`, `TryGetRotatedCrop(...)`).
-- Output a PNG (e.g., `Temp/roi_current.png`) and the corresponding `shapeJson` in canonical space.
-
-### 3) Commands / ViewModel
-- `AddOkFromCurrentRoiCommand`
-- `AddNgFromCurrentRoiCommand` (optional)
-- `TrainFitCommand`
-- `CalibrateCommand`
-- `InferFromCurrentRoiCommand`
-
-Each command must guard against invalid state (no role/roi, no ROI drawn, missing backend URL, etc.) and show progress/logs.
-
-### 4) Heatmap Overlay
-- Decode `heatmap_png_base64` to byte[] and display as Image overlay.
-- Provide opacity slider [0..1].
-- Ensure no DPI/scaling mismatch: overlay exactly on the ROI preview (use the canonical ROI image size).
+- Capturar `HttpRequestException` en cada llamada y mostrar mensaje amigable + detalles en panel de logs.
+- Validar entradas antes de llamar al backend (role, roi, mm_per_px > 0, ROI dibujado, muestras disponibles).
+- Deshabilitar botones mientras la tarea está en curso, reactivarlos en `finally`.
+- Registrar en logs (GUI) el `CorrelationId` y la respuesta completa (`score`, `threshold`, `regions.Count`).
 
 ---
 
-## Error Handling & UX
+## 6. Testing Plan
 
-- Show backend error messages (and `trace` if present) in a collapsible log panel.
-- Gracefully handle network errors, timeouts, or invalid responses.
-- Disable buttons while a request is ongoing; re-enable on completion/failure.
-- For long operations (many samples), show a progress bar (`i/n` files uploaded).
-
----
-
-## Acceptance Criteria
-
-- Able to add ≥50 OK samples and see them listed with thumbnails.
-- `/fit_ok` succeeds and returns `n_embeddings > 0`, `coreset_size > 0`.
-- If NG provided, `/calibrate_ng` returns a valid `threshold`.
-- `/infer` returns non-empty `heatmap_png_base64` and a numeric `score`.
-- Heatmap overlay matches the ROI visualization (no drift/scale errors).
-- No regressions in ROI placement/adorner behaviour (window resize, image reload).
+1. **Startup**: llamar a `/health` y mostrar `device`/`model`.
+2. **Dataset**: exportar ≥5 muestras OK/NG y verificar que se crean PNG+JSON en `datasets/`.
+3. **Train**: ejecutar `/fit_ok`, comprobar `n_embeddings` y `coreset_size` positivos.
+4. **Calibrate**: recolectar scores y enviar a `/calibrate_ng`, verificar `threshold` persistido.
+5. **Infer**: llamar a `/infer`, superponer heatmap, listar `regions` (área px/mm²).
+6. **Resize/Reload**: confirmar que la superposición se mantiene al redimensionar la ventana o recargar imagen.
 
 ---
 
-## Testing Plan
+## 7. Deliverables when extending the GUI
 
-1. **Health**: GUI calls `/health` on startup; show device/model in status bar.
-2. **Dataset**: Add 5 OK samples from different parts; verify file system & metadata are created.
-3. **Train**: Run `/fit_ok`; validate counts. Retry train after adding 20 more OKs.
-4. **Calibrate**: If you have NGs, compute scores via `/infer` (without threshold) and run `/calibrate_ng`; store/display returned threshold.
-5. **Infer**: Evaluate ROI; verify heatmap overlays and `regions` appear; adjust local slider.
-6. **Resize/Reload**: Check that overlays remain aligned after window maximize and image reload (non-regression).
+- Cambios en XAML (nuevos controles o bindings).
+- Actualizaciones en ViewModels/Commands (`WorkflowViewModel`, comandos async).
+- Ajustes en `BackendClient`, `DatasetManager`, `DatasetSample` si se introducen nuevos campos.
+- Tests (unitarios o manuales) documentados en el PR.
 
 ---
 
-## Coding Standards
+## 8. Do / Don’t summary
 
-- C# 10+, async/await everywhere for I/O.
-- MVVM: Commands + ViewModels; no heavy logic in code-behind.
-- Use `ObservableCollection<>` for sample lists; thumbnails generated in background.
-- Keep all paths `Path.Combine(...)`; avoid hard-coded separators.
-- Localize UI strings if your project already uses resources.
-
----
-
-## Deliverables
-
-- Updated XAML (new tabs/panels, bindings).
-- `BackendClient.cs` (or similar) with 3 public methods (FitOkAsync, CalibrateAsync, InferAsync) y DTOs (`InferResult`, `CalibResult`, `Region`).
-- ROI export helper (reusing existing crop+rotate pipeline).
-- ViewModels/Commands for Dataset, Train/Calibrate, Infer.
-- Basic unit/integration tests if your solution includes a testing project (optional).
+| ✅ Hacer | ❌ No hacer |
+|---------|-------------|
+| Reutilizar pipeline de exportación (`RoiCropUtils`) | Alterar adorners, overlays o transformaciones base |
+| Usar `async/await` en todos los requests | Bloquear el hilo UI con `.Result`/`.Wait()` |
+| Guardar PNG+JSON en `datasets/<role>/<roi>/<label>/` | Cambiar la estructura de carpetas o nombres de archivo |
+| Mapear DTOs a campos existentes (`score`, `threshold`, `regions`) | Renombrar campos esperados por el backend |
+| Registrar operaciones y respuestas en logs GUI | Ignorar excepciones del backend o descartarlas silenciosamente |
 
 ---
 
-## Do/Don’t Summary
-
-- ✅ **Do**: Reuse existing ROI export pipeline (crop+rotate); keep adorner & overlay logic intact.
-- ✅ **Do**: Make all backend calls async; add progress & logs.
-- ✅ **Do**: Persist datasets under `datasets/<role>/<roi>/` with PNG + metadata JSON.
-- ❌ **Don’t**: Change adorner geometry, overlay scaling, or canvas/image transforms.
-- ❌ **Don’t**: Move ROI in canvas space or introduce new coordinate transforms.
-- ❌ **Don’t**: Touch backend endpoints or their names.
-
-If any ambiguity arises (method names for the existing canonical ROI export, or how to access `mm_per_px`), **ask before changing behaviour**.
+Para dudas adicionales revisar [README.md](README.md), [DEV_GUIDE.md](DEV_GUIDE.md) y [API_REFERENCE.md](API_REFERENCE.md).


### PR DESCRIPTION
## Summary
- refresh all top-level documentation to match the current FastAPI and WPF workflow, including updated quick starts and API details
- align data, ROI, deployment, logging, and MCP guides with the 2025 backend/frontend implementations
- add PROJECT_OVERVIEW.txt for rapid technical onboarding and memory restoration

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68eeb4de26a083309bb9d8df4133c635