### PR TITLE
Fix: mark helper methods static to avoid CS0120

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -141,7 +141,7 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         // True geometric center by shape; safe even if RoiModel lacks a GetCenter() helper.
-        private (double cx, double cy) GetCenterShapeAware(RoiModel r)
+        private static (double cx, double cy) GetCenterShapeAware(RoiModel r)
         {
             switch (r.Shape)
             {
@@ -159,7 +159,7 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         // Set center in IMAGE space; updates CX/CY and Left/Top
-        private void SetRoiCenterImg(RoiModel r, double cx, double cy)
+        private static void SetRoiCenterImg(RoiModel r, double cx, double cy)
         {
             r.CX = cx; r.CY = cy;
             r.Left = cx - r.Width * 0.5;


### PR DESCRIPTION
## Summary
- update `GetCenterShapeAware` to be a static helper so it can be used from static contexts
- mark `SetRoiCenterImg` static as well since it does not depend on instance state

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68f386515f4c832bbab3b29e90b12758