### PR TITLE
UI: WPF fix — remove unsupported StackPanel.Spacing; use child Margins in Heatmap HUD

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -260,14 +260,22 @@
                 CornerRadius="6"
                 Padding="8"
                 IsHitTestVisible="True">
-          <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
-            <CheckBox x:Name="ChkHeatmap" Content="Heatmap" IsChecked="True"/>
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <CheckBox x:Name="ChkHeatmap"
+                      Content="Heatmap"
+                      IsChecked="True"
+                      Margin="0,0,8,0"/>
             <TextBlock x:Name="HeatmapScaleLabel"
                        Text="Heatmap Scale: 1.00"
                        Foreground="#39FF14"
-                       FontFamily="Segoe UI" FontWeight="SemiBold"/>
+                       FontFamily="Segoe UI"
+                       FontWeight="SemiBold"
+                       Margin="0,0,8,0"/>
             <Slider x:Name="HeatmapScaleSlider"
-                    Width="160" Minimum="0.10" Maximum="2.00" Value="1.00"/>
+                    Width="160"
+                    Minimum="0.10"
+                    Maximum="2.00"
+                    Value="1.00"/>
           </StackPanel>
         </Border>
       </Grid>


### PR DESCRIPTION
## Summary
- remove the unsupported StackPanel.Spacing usage in the heatmap HUD
- add equivalent spacing via child margins to maintain layout

## Testing
- dotnet build *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f60994a2f0832bbc15da0c404eeede