### PR TITLE
Remove Analyze ROI and Center Patterns actions from GUI

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -59,8 +59,6 @@
             <Separator Margin="0,12,0,12"/>
 
             <Button x:Name="BtnAnalyzeMaster" Content="Analyze Master" Margin="0,0,0,8" Click="BtnAnalyzeMaster_Click"/>
-            <Button x:Name="BtnAnalyzeROI" Content="Analyze ROI" Margin="0,0,0,8" Click="BtnAnalyzeROI_Click"/>
-            <Button x:Name="BtnCenterPatterns" Content="Center Patterns on Crosses"/>
 
             <Separator Margin="0,12,0,12"/>
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -5049,32 +5049,6 @@ namespace BrakeDiscInspector_GUI_ROI
             // 5) Lanzar análisis
             _ = AnalyzeMastersAsync();
         }
-
-
-
-        private async void BtnAnalyzeROI_Click(object sender, RoutedEventArgs e)
-        {
-            if (string.IsNullOrWhiteSpace(_currentImagePathWin)) { Snack("No hay imagen actual"); return; }
-            if (_layout.Inspection == null) { Snack("Falta ROI de Inspección"); return; }
-
-
-            var resp = await BackendAPI.InferAsync(_currentImagePathWin, _layout.Inspection, _preset, AppendLog);
-            if (!resp.ok || resp.result == null)
-            {
-                Snack(resp.error ?? "Error en Analyze");
-                return;
-            }
-
-            var result = resp.result;
-            bool pass = !result.threshold.HasValue || result.score <= result.threshold.Value;
-            string thrText = result.threshold.HasValue ? result.threshold.Value.ToString("0.###") : "n/a";
-            Snack(pass
-                ? $"Resultado OK (score={result.score:0.000}, thr={thrText})"
-                : $"Resultado NG (score={result.score:0.000}, thr={thrText})");
-        }
-
-
-
         // ====== Overlay persistente + Adorner ======
         private void OnRoiChanged(Shape shape, RoiModel roi)
         {


### PR DESCRIPTION
## Summary
- remove the Analyze ROI and Center Patterns buttons from the Alignment tab
- delete the unused Analyze ROI click handler from the main window code-behind

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_b_68f670d235b0832b8926750a9cd38ff2