### PR TITLE
Align VS Code Python settings with backend package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  // WSL scenario (recommended): set the interpreter inside your WSL venv
+  "python.defaultInterpreterPath": "/home/millylinux/venv/bin/python",
+
+  // Help Pylance resolve the local backend package
+  "python.analysis.extraPaths": [
+    "${workspaceFolder}/backend"
+  ],
+
+  // Analyze only files in the workspace (avoids noise from global site-packages)
+  "python.analysis.diagnosticMode": "workspace",
+
+  // OPTIONAL: if you enable unit tests in VS Code
+  "python.testing.unittestEnabled": true,
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s", "backend/tests",
+    "-p", "test_*.py"
+  ]
+
+  /* Windows-native fallback (if not using WSL Remote).
+     Replace the path below with your Windows venv (example):
+     "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+  */
+}

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,1 @@
-"""BrakeDiscInspector backend package."""
-
-__all__ = []
+# empty package marker

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# empty package marker for test discovery

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,6 @@
+{
+  "pythonVersion": "3.12",
+  "reportMissingImports": "warning",
+  "venvPath": ".",
+  "venv": ".venv"
+}


### PR DESCRIPTION
## Summary
- configure the workspace interpreter and analysis paths so VS Code resolves backend imports
- add package markers for the backend and its tests to help discovery in tooling
- provide a pyright configuration that downgrades missing import diagnostics while environments align

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_b_68fd346cc1d0832b8d0c1f36e3b97956