### PR TITLE
Fix SelectedInspectionShape null-conditional access

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -287,13 +287,11 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
         }
 
-        // If SelectedInspectionRoi is null -> return "square".
-        // If not null -> Shape is a (nullable) enum; convert to string safely.
+        // Si SelectedInspectionRoi es null => "square"; si no, usa el enum (no anulable) y conviértelo a string.
         public string SelectedInspectionShape =>
-            SelectedInspectionRoi?.Shape?.ToString() ?? "square";
-        // If you need lowercase for downstream components, use:
-        // public string SelectedInspectionShape =>
-        //     (SelectedInspectionRoi?.Shape?.ToString() ?? "square").ToLowerInvariant();
+            SelectedInspectionRoi != null
+                ? SelectedInspectionRoi.Shape.ToString().ToLowerInvariant()
+                : "square";
 
         public void SetInspectionRoisCollection(ObservableCollection<InspectionRoiConfig>? rois)
         {


### PR DESCRIPTION
## Summary
- replace the null-conditional operator on the non-nullable RoiShape enum with an explicit SelectedInspectionRoi null check
- ensure the enum string is returned in lower case to match existing downstream expectations while keeping the null fallback to "square"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fd37833be8832b81c4e544348ff038