### PR TITLE
Ensure ROI toolbar overlays viewer

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -299,6 +299,23 @@
             </Grid>
           </Grid>
         </AdornerDecorator>
+
+        <!-- ROI Toolbar (overlay) -->
+        <ToolBarTray x:Name="DrawToolbar"
+                     Panel.ZIndex="1000"
+                     HorizontalAlignment="Left"
+                     VerticalAlignment="Top"
+                     Margin="8"
+                     IsLocked="True"
+                     Background="#222"
+                     Visibility="Visible">
+          <ToolBar>
+            <ToggleButton Content="Rect"   ToolTip="Rectángulo"/>
+            <ToggleButton Content="Circle" ToolTip="Círculo"/>
+            <ToggleButton Content="Annulus" ToolTip="Anillo"/>
+            <Button Content="Borrar" ToolTip="Borrar selección"/>
+          </ToolBar>
+        </ToolBarTray>
       </Grid>
       <Grid x:Name="DiskStatusHUD"
             HorizontalAlignment="Right"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3756,6 +3756,18 @@ namespace BrakeDiscInspector_GUI_ROI
         }
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
+            if (DrawToolbar != null)
+            {
+                Panel.SetZIndex(DrawToolbar, 1000);
+                DrawToolbar.Visibility = Visibility.Visible;
+
+                if (VisualTreeHelper.GetParent(DrawToolbar) is Canvas)
+                {
+                    Canvas.SetLeft(DrawToolbar, 8);
+                    Canvas.SetTop(DrawToolbar, 8);
+                }
+            }
+
             ScheduleSyncOverlay(force: true);
             UpdateHeatmapOverlayLayoutAndClip();
             RedrawAnalysisCrosses();


### PR DESCRIPTION
## Summary
- add an overlay ToolBarTray within the image viewer grid so the drawing controls stay visible in the top-left corner
- force the toolbar to remain visible and maintain a high Z-index during the window Loaded event, correcting Canvas positioning if necessary

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68fd3a0e547c832ba32b73c73f50c1b7