### PR TITLE
Fix layout of the viewer toolbars

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -301,7 +301,7 @@
         </AdornerDecorator>
 
         <!-- ROI Toolbar (overlay) -->
-        <ToolBarTray x:Name="DrawToolbar"
+        <ToolBarTray x:Name="TopLeftTray"
                      Panel.ZIndex="1000"
                      HorizontalAlignment="Left"
                      VerticalAlignment="Top"
@@ -309,10 +309,12 @@
                      IsLocked="True"
                      Background="#222"
                      Visibility="Visible">
-          <ToolBar>
+          <ToolBar x:Name="TbDrawShapes" Band="0" BandIndex="0">
             <ToggleButton Content="Rect"   ToolTip="Rectángulo"/>
             <ToggleButton Content="Circle" ToolTip="Círculo"/>
             <ToggleButton Content="Annulus" ToolTip="Anillo"/>
+          </ToolBar>
+          <ToolBar x:Name="TbRoiActions" Band="0" BandIndex="1">
             <Button Content="Borrar" ToolTip="Borrar selección"/>
           </ToolBar>
         </ToolBarTray>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3756,15 +3756,15 @@ namespace BrakeDiscInspector_GUI_ROI
         }
         private void MainWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            if (DrawToolbar != null)
+            if (TopLeftTray != null)
             {
-                Panel.SetZIndex(DrawToolbar, 1000);
-                DrawToolbar.Visibility = Visibility.Visible;
+                Panel.SetZIndex(TopLeftTray, 1000);
+                TopLeftTray.Visibility = Visibility.Visible;
 
-                if (VisualTreeHelper.GetParent(DrawToolbar) is Canvas)
+                if (VisualTreeHelper.GetParent(TopLeftTray) is Canvas)
                 {
-                    Canvas.SetLeft(DrawToolbar, 8);
-                    Canvas.SetTop(DrawToolbar, 8);
+                    Canvas.SetLeft(TopLeftTray, 8);
+                    Canvas.SetTop(TopLeftTray, 8);
                 }
             }
 


### PR DESCRIPTION
## Summary
- move the top-left ROI toolbars into a single locked ToolBarTray with sequential band indices
- keep the shape toggles and delete action separated into dedicated ToolBars for better wrapping
- ensure the tray stays visible and correctly positioned at runtime by updating the Loaded handler

## Testing
- not run (UI layout change)


------
https://chatgpt.com/codex/tasks/task_b_68fd3dedbfe8832b82cba6c81ce9e77c