### PR TITLE
Fix Master2 editor group visibility lookup

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4531,9 +4531,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 Master1EditorGroup.Visibility = Visibility.Collapsed;
             }
 
-            if (Master2EditorGroup != null)
+            if (FindName("Master2EditorGroup") is System.Windows.FrameworkElement master2EditorGroupElem)
             {
-                Master2EditorGroup.Visibility = Visibility.Collapsed;
+                master2EditorGroupElem.Visibility = Visibility.Collapsed;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the direct Master2EditorGroup field usage with a runtime FindName lookup before collapsing its visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_6904f01c9858832ea67884d6e24f3268