### PR TITLE
Unify preparation and alignment tabs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -31,8 +31,8 @@
 
     <!-- ===== Tabs (left) ===== -->
     <TabControl Grid.Row="1" Grid.Column="1" x:Name="MainTabs" TabStripPlacement="Left">
-      <!-- PREPARAR -->
-      <TabItem x:Name="TabMaster1" Header="Preparar">
+      <!-- PREPARACIÓN / ALINEACIÓN -->
+      <TabItem x:Name="TabMaster1" Header="Preparación/Alineación">
         <ScrollViewer VerticalScrollBarVisibility="Auto">
           <StackPanel Margin="10">
             <Button x:Name="BtnLoadLayout" Content="Load Layout" Margin="0,0,0,8" Click="BtnLoadLayout_Click"/>
@@ -56,17 +56,8 @@
                 </Border>
               </StackPanel>
             </GroupBox>
-          </StackPanel>
-        </ScrollViewer>
-      </TabItem>
 
-      <!-- ALINEACIÓN -->
-      <TabItem x:Name="TabMaster2" Header="Alineación">
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
-          <StackPanel Margin="10" Orientation="Vertical" >
-            
-            <!-- ====== Sección: Master 1 ====== -->
-            <GroupBox Header="Master 1">
+            <GroupBox Header="Master 1" Margin="0,10,0,0">
               <StackPanel Margin="0,8,0,0">
                 <TextBlock Text="Tipo:"/>
                 <ComboBox x:Name="ComboM2Role" Margin="0,4,0,8"/>
@@ -83,39 +74,9 @@
               </StackPanel>
             </GroupBox>
 
-            <!-- ====== Sección: Master 2 ====== -->
-            <GroupBox Header="Master 2"
-                      x:Name="Master2EditorGroup"
-                      Margin="0,10,0,0">
-              <StackPanel Margin="0,8,0,0">
-                <WrapPanel VerticalAlignment="Center">
-                  <TextBlock Text="Forma:" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                  <ComboBox x:Name="ComboM2Shape_Align" Width="130" Margin="0,0,12,0" SelectedIndex="0">
-                    <ComboBoxItem Content="Rectángulo"/>
-                    <ComboBoxItem Content="Círculo"/>
-                  </ComboBox>
-                  <Button x:Name="BtnM2_Create" Content="Crear"  Margin="0,0,8,0" MinWidth="90" Click="BtnM2_Create_Click"/>
-                  <Button x:Name="BtnM2_Save"   Content="Guardar" Margin="0,0,8,0" MinWidth="90" Click="BtnM2_Save_Click"/>
-                  <Button x:Name="BtnM2_Remove" Content="Borrar"  Margin="0,0,0,0"  MinWidth="90" Click="BtnM2_Remove_Click"/>
-                </WrapPanel>
-
-                <WrapPanel Margin="0,8,0,0" VerticalAlignment="Center">
-                  <TextBlock Text="Master search 2 - Forma:" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                  <ComboBox x:Name="ComboM2SShape_Align" Width="130" Margin="0,0,12,0" SelectedIndex="0">
-                    <ComboBoxItem Content="Rectángulo"/>
-                    <ComboBoxItem Content="Círculo"/>
-                  </ComboBox>
-                  <Button x:Name="BtnM2S_Create" Content="Crear"  Margin="0,0,8,0" MinWidth="90" Click="BtnM2S_Create_Click"/>
-                  <Button x:Name="BtnM2S_Save"   Content="Guardar" Margin="0,0,8,0" MinWidth="90" Click="BtnM2S_Save_Click"/>
-                  <Button x:Name="BtnM2S_Remove" Content="Borrar"  Margin="0,0,0,0"  MinWidth="90" Click="BtnM2S_Remove_Click"/>
-                </WrapPanel>
-              </StackPanel>
-            </GroupBox>
-
             <WrapPanel Margin="0,12,0,0">
               <Button x:Name="BtnClearCanvas" Content="Borrar Canvas" MinWidth="150" Click="BtnClearCanvas_Click"/>
             </WrapPanel>
-
           </StackPanel>
         </ScrollViewer>
       </TabItem>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2320,18 +2320,22 @@ namespace BrakeDiscInspector_GUI_ROI
 
             // Habilitación de tabs por etapas
             TabMaster1.IsEnabled = true;
-            TabMaster2.IsEnabled = m1Ready;           // puedes definir M2 cuando M1 está completo
             EnablePresetsTab(mastersReady || _hasLoadedImage);     // permite la pestaña de inspección tras cargar imagen o completar masters
 
             // Selección de tab acorde a estado
-            if (_state == MasterState.DrawM1_Pattern || _state == MasterState.DrawM1_Search)
+            if (_state == MasterState.DrawM1_Pattern || _state == MasterState.DrawM1_Search
+                || _state == MasterState.DrawM2_Pattern || _state == MasterState.DrawM2_Search)
+            {
                 MainTabs.SelectedItem = TabMaster1;
-            else if (_state == MasterState.DrawM2_Pattern || _state == MasterState.DrawM2_Search)
-                MainTabs.SelectedItem = TabMaster2;
+            }
             else if (_state == MasterState.DrawInspection)
+            {
                 MainTabs.SelectedItem = TabInspection;
+            }
             else
+            {
                 MainTabs.SelectedItem = TabInspection;
+            }
 
             if (_analysisViewActive && _state != MasterState.Ready)
             {
@@ -4531,10 +4535,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 Master1EditorGroup.Visibility = Visibility.Collapsed;
             }
 
-            if (FindName("Master2EditorGroup") is System.Windows.FrameworkElement master2EditorGroupElem)
-            {
-                master2EditorGroupElem.Visibility = Visibility.Collapsed;
-            }
         }
 
         private void GoToInspectionTab()
@@ -8683,14 +8683,6 @@ namespace BrakeDiscInspector_GUI_ROI
         private void BtnM1S_Create_Click(object sender, RoutedEventArgs e) => StartDrawingFor(MasterState.DrawM1_Search, ComboMasterRoiShape);
         private void BtnM1S_Save_Click  (object sender, RoutedEventArgs e) => SaveFor(MasterState.DrawM1_Search);
         private void BtnM1S_Remove_Click(object sender, RoutedEventArgs e) => RemoveFor(MasterState.DrawM1_Search);
-
-        private void BtnM2_Create_Click(object sender, RoutedEventArgs e) => StartDrawingFor(MasterState.DrawM2_Pattern, ComboM2Shape);
-        private void BtnM2_Save_Click  (object sender, RoutedEventArgs e) => SaveFor(MasterState.DrawM2_Pattern);
-        private void BtnM2_Remove_Click(object sender, RoutedEventArgs e) => RemoveFor(MasterState.DrawM2_Pattern);
-
-        private void BtnM2S_Create_Click(object sender, RoutedEventArgs e) => StartDrawingFor(MasterState.DrawM2_Search, ComboM2Shape);
-        private void BtnM2S_Save_Click  (object sender, RoutedEventArgs e) => SaveFor(MasterState.DrawM2_Search);
-        private void BtnM2S_Remove_Click(object sender, RoutedEventArgs e) => RemoveFor(MasterState.DrawM2_Search);
 
         private void BtnClearCanvas_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- merge the former alignment tab content into the preparation tab and remove the obsolete Master 2 editor group
- adjust the wizard state logic to target the unified tab and drop unused Master 2 helpers

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_69053a0ff3e0832eaa7b7a2cd4648860