### PR TITLE
Ensure ROI activation stays aligned with selection

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -289,6 +289,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     OnPropertyChanged(nameof(SelectedInspectionShape));
                     UpdateSelectedRoiState();
                     OpenDatasetFolderCommand.RaiseCanExecuteChanged();
+
+                    if (value != null)
+                    {
+                        _log($"[ui] activate ROI {value.Index} from SelectedInspectionRoi setter");
+                        _activateInspectionIndex?.Invoke(value.Index);
+                    }
                 }
             }
         }
@@ -1982,7 +1988,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 return;
             }
 
-            _log($"[eval] export ROI for {roi.Name}");
+            _activateInspectionIndex?.Invoke(roi.Index);
+            _log($"[eval] export ROI for {roi.Name} (index={roi.Index})");
+
             var export = await _exportRoiAsync().ConfigureAwait(false);
             if (export == null)
             {


### PR DESCRIPTION
## Summary
- activate the selected inspection ROI on the canvas whenever the tab selection changes so overlays stay synchronized
- ensure individual ROI evaluations activate and log the correct ROI index before exporting

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_6905e2ca6440832eb6d5a43439b6db28