### PR TITLE
Fix ROI tab focus synchronization and logging

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -2065,7 +2065,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 roi.LastScore = result.score;
                 var decisionThreshold = roi.CalibratedThreshold ?? roi.ThresholdDefault;
                 var isNg = result.score >= decisionThreshold;
-                roi.LastResultOk = isNg;
+                roi.LastResultOk = !isNg;
                 roi.LastEvaluatedAt = DateTime.UtcNow;
                 _log($"[eval] done idx={roi.Index} key='{roi.ModelKey}' score={result.score:0.###} thr={decisionThreshold:0.###} => {(isNg ? "NG" : "OK")}");
                 OnPropertyChanged(nameof(SelectedInspectionRoi));


### PR DESCRIPTION
## Summary
- ensure selecting an inspection ROI updates the canvas focus, restores its threshold, and clears stale inference state
- wait for the canvas to focus the requested ROI before exporting and add detailed evaluation logging
- add helpers for canvas activation, inference clearing, and optional tab-change routing
- keep `LastResultOk` true for OK evaluations so global status stays consistent

## Testing
- dotnet build *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_69068f3aeb54832e8d3df65f790ca992