### PR TITLE
Fix dispatcher affinity for model manifest loading

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -8763,7 +8763,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     return;
                 }
 
-                bool loaded = await _workflowViewModel.LoadModelManifestAsync(roiConfig, dialog.FileName).ConfigureAwait(false);
+                bool loaded = await _workflowViewModel.LoadModelManifestAsync(roiConfig, dialog.FileName);
                 if (!loaded)
                 {
                     return;

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -1989,7 +1989,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             try
             {
-                var json = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
+                var json = await File.ReadAllTextAsync(filePath);
                 var manifest = JsonSerializer.Deserialize<InspectionModelManifest>(json, ManifestJsonOptions);
                 if (manifest == null)
                 {


### PR DESCRIPTION
## Summary
- ensure model manifest loading resumes on the UI dispatcher by removing ConfigureAwait(false)
- keep the load button handler on the dispatcher thread so MessageBox remains STA

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_690747f9c664832e9201713f2e3a6a0b