### PR TITLE
Add FormattableString overload for AppendLog

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -8280,6 +8280,17 @@ namespace BrakeDiscInspector_GUI_ROI
             LogToFileAndUI(line);
         }
 
+        // Compatibilidad con llamadas que usan interpolated strings con FormattableString.Invariant
+        private void AppendLog(FormattableString line)
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            AppendLog(FormattableString.Invariant(line));
+        }
+
         private void AppendLogBulk(IEnumerable<string> lines)
         {
             foreach (var entry in lines)


### PR DESCRIPTION
## Summary
- add an `AppendLog(FormattableString)` overload that funnels interpolated messages through the existing string logger so both call sites compile

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916e56b7ff8832ea3ee09fd63ced315)