### PR TITLE
Adopt FormattableString logging for GUI instrumentation

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -12,21 +12,21 @@ namespace BrakeDiscInspector_GUI_ROI
         public async Task AnalyzeMastersViaBackend()
         {
             if (_layout?.Master1Pattern == null || _layout?.Master2Pattern == null)
-            { Snack("Faltan ROIs de patrón para Master 1/2"); return; }
+            { Snack($"Faltan ROIs de patrón para Master 1/2"); return; } // CODEX: FormattableString compatibility.
             if (string.IsNullOrWhiteSpace(_currentImagePathWin) || !File.Exists(_currentImagePathWin))
-            { Snack("No hay imagen cargada"); return; }
+            { Snack($"No hay imagen cargada"); return; } // CODEX: FormattableString compatibility.
 
             var inferM1 = await BackendAPI.InferAsync(_currentImagePathWin, _layout.Master1Pattern, _preset, AppendLog);
             if (!inferM1.ok || inferM1.result == null)
             {
-                Snack("Backend Master 1: " + (inferM1.error ?? "error desconocido"));
+                Snack($"Backend Master 1: {inferM1.error ?? "error desconocido"}"); // CODEX: FormattableString compatibility.
                 return;
             }
 
             var inferM2 = await BackendAPI.InferAsync(_currentImagePathWin, _layout.Master2Pattern, _preset, AppendLog);
             if (!inferM2.ok || inferM2.result == null)
             {
-                Snack("Backend Master 2: " + (inferM2.error ?? "error desconocido"));
+                Snack($"Backend Master 2: {inferM2.error ?? "error desconocido"}"); // CODEX: FormattableString compatibility.
                 return;
             }
 
@@ -51,10 +51,10 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 string msg = $"Master1 {(pass1 ? "OK" : "NG")} (score={res1.score:0.###}, thr={thr1}) | " +
                              $"Master2 {(pass2 ? "OK" : "NG")} (score={res2.score:0.###}, thr={thr2})";
-                Snack(msg);
+                Snack($"{msg}"); // CODEX: FormattableString compatibility.
             }
 
-            if (_layout.Inspection == null) { Snack("Falta ROI de Inspección"); return; }
+            if (_layout.Inspection == null) { Snack($"Falta ROI de Inspección"); return; } // CODEX: FormattableString compatibility.
             MoveInspectionTo(_layout.Inspection, c1, c2);
             ClipInspectionROI(_layout.Inspection, _imgW, _imgH);
 
@@ -80,14 +80,14 @@ namespace BrakeDiscInspector_GUI_ROI
 
         public async Task AnalyzeInspectionViaBackend()
         {
-            if (_layout?.Inspection == null) { Snack("Falta ROI de Inspección"); return; }
+            if (_layout?.Inspection == null) { Snack($"Falta ROI de Inspección"); return; } // CODEX: FormattableString compatibility.
             if (string.IsNullOrWhiteSpace(_currentImagePathWin) || !File.Exists(_currentImagePathWin))
-            { Snack("No hay imagen cargada"); return; }
+            { Snack($"No hay imagen cargada"); return; } // CODEX: FormattableString compatibility.
 
             var resp = await BackendAPI.InferAsync(_currentImagePathWin, _layout.Inspection, _preset, AppendLog);
             if (!resp.ok || resp.result == null)
             {
-                Snack("Analyze backend: " + (resp.error ?? "error desconocido"));
+                Snack($"Analyze backend: {resp.error ?? "error desconocido"}"); // CODEX: FormattableString compatibility.
                 return;
             }
 
@@ -98,7 +98,7 @@ namespace BrakeDiscInspector_GUI_ROI
             string msg = pass
                 ? $"Resultado OK (score={result.score:0.###} / thr={thrText})"
                 : $"Resultado NG (score={result.score:0.###} / thr={thrText})";
-            Snack(msg);
+            Snack($"{msg}"); // CODEX: FormattableString compatibility.
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -9959,11 +9959,12 @@ namespace BrakeDiscInspector_GUI_ROI
             // _trainTimer.Start(); // opcional
         }
 
-        private void Snack(string msg)
+        private void Snack(FormattableString msg)
         {
-            // CODEX: FormattableString compatibility.
-            AppendLog($"[INFO] {msg}");
-            System.Diagnostics.Debug.WriteLine(msg);
+            // CODEX: render FormattableString snacks once using invariant culture.
+            var rendered = FormattableString.Invariant(msg);
+            AppendLog(FormattableString.Invariant($"[INFO] {rendered}")); // CODEX: keep snack messages consistent in logs.
+            System.Diagnostics.Debug.WriteLine(rendered);
         }
 
         private void SyncModelFromShape(Shape shape)

--- a/gui/BrakeDiscInspector_GUI_ROI/Util/GuiLog.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Util/GuiLog.cs
@@ -13,14 +13,24 @@ namespace BrakeDiscInspector_GUI_ROI.Util
 
         private static readonly string LogFilePath = Path.Combine(LogDirectory, "gui.log");
 
-        public static void Info(string message) => Write("INFO", message);
+        // CODEX: accept FormattableString to keep structured logging with invariant culture.
+        public static void Info(FormattableString message)
+            => Write("INFO", FormattableString.Invariant(message));
 
-        public static void Warn(string message) => Write("WARN", message);
+        // CODEX: FormattableString overload maintains parity with Info logging behavior.
+        public static void Warn(FormattableString message)
+            => Write("WARN", FormattableString.Invariant(message));
 
-        public static void Error(string message) => Write("ERROR", message);
+        // CODEX: unify error logging across severities using FormattableString inputs.
+        public static void Error(FormattableString message)
+            => Write("ERROR", FormattableString.Invariant(message));
 
-        public static void Error(string message, Exception exception)
-            => Write("ERROR", $"{message} :: {exception}");
+        public static void Error(FormattableString message, Exception exception)
+        {
+            // CODEX: render interpolated error once and append exception safely.
+            var rendered = FormattableString.Invariant(message);
+            Write("ERROR", $"{rendered} :: {exception}");
+        }
 
         private static void Write(string level, string message)
         {

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -892,7 +892,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
 
             _isInitializing = true;
-            GuiLog.Info("[workflow] InitializeAsync START");
+            GuiLog.Info($"[workflow] InitializeAsync START"); // CODEX: FormattableString compatibility.
 
             try
             {
@@ -918,16 +918,16 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 }
 
                 _initialized = true;
-                GuiLog.Info("[workflow] InitializeAsync END");
+                GuiLog.Info($"[workflow] InitializeAsync END"); // CODEX: FormattableString compatibility.
             }
             catch (OperationCanceledException)
             {
-                GuiLog.Warn("[workflow] InitializeAsync cancelled");
+                GuiLog.Warn($"[workflow] InitializeAsync cancelled"); // CODEX: FormattableString compatibility.
                 throw;
             }
             catch (Exception ex)
             {
-                GuiLog.Error("[workflow] InitializeAsync failed", ex);
+                GuiLog.Error($"[workflow] InitializeAsync failed", ex); // CODEX: FormattableString compatibility.
                 throw;
             }
             finally
@@ -1805,7 +1805,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             if (export == null)
             {
                 await ShowMessageAsync("No image loaded.", "Dataset");
-                GuiLog.Warn("AddToDataset aborted: no export for legacy roi");
+                GuiLog.Warn($"AddToDataset aborted: no export for legacy roi"); // CODEX: FormattableString compatibility.
                 return;
             }
 
@@ -4045,7 +4045,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
             catch (Exception ex)
             {
-                GuiLog.Error("[batch-hm:VM] SetBatchHeatmapForRoi failed", ex);
+                GuiLog.Error($"[batch-hm:VM] SetBatchHeatmapForRoi failed", ex); // CODEX: FormattableString compatibility.
             }
         }
 
@@ -4071,7 +4071,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     }
                     catch (Exception ex)
                     {
-                        GuiLog.Error("[heatmap] failed to decode batch heatmap", ex);
+                        GuiLog.Error($"[heatmap] failed to decode batch heatmap", ex); // CODEX: FormattableString compatibility.
                         ClearBatchHeatmap();
                     }
                 });
@@ -4106,7 +4106,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
             catch (Exception ex)
             {
-                GuiLog.Error("[heatmap] UpdateHeatmapThreshold failed", ex);
+                GuiLog.Error($"[heatmap] UpdateHeatmapThreshold failed", ex); // CODEX: FormattableString compatibility.
             }
         }
 


### PR DESCRIPTION
## Summary
- update `GuiLog`/`Snack` implementations to consume `FormattableString` inputs so the new logging API keeps invariant-culture payloads and // CODEX breadcrumbs
- fix `MainWindow` partials and the workflow view model to pass interpolated strings (or wrapped variables) to the updated logging/snack helpers

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916eff8c354832eb173b2c5c852009f)