### PR TITLE
Fix snack logging overloads

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -9959,12 +9959,43 @@ namespace BrakeDiscInspector_GUI_ROI
             // _trainTimer.Start(); // opcional
         }
 
+        private void Snack(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            var payload = "[SNACK] " + message;
+
+            try
+            {
+                AppendLog(payload);
+            }
+            catch
+            {
+                // Never allow snack logging to throw.
+            }
+
+            try
+            {
+                GuiLog.Info(payload);
+            }
+            catch
+            {
+                // Ignore logging failures (e.g., during early boot).
+            }
+        }
+
         private void Snack(FormattableString msg)
         {
-            // CODEX: render FormattableString snacks once using invariant culture.
-            var rendered = FormattableString.Invariant(msg);
-            AppendLog(FormattableString.Invariant($"[INFO] {rendered}")); // CODEX: keep snack messages consistent in logs.
-            System.Diagnostics.Debug.WriteLine(rendered);
+            if (msg == null)
+            {
+                return;
+            }
+
+            var rendered = msg.ToString(CultureInfo.InvariantCulture);
+            Snack(rendered);
         }
 
         private void SyncModelFromShape(Shape shape)

--- a/gui/BrakeDiscInspector_GUI_ROI/Util/GuiLog.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Util/GuiLog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace BrakeDiscInspector_GUI_ROI.Util
@@ -13,23 +14,69 @@ namespace BrakeDiscInspector_GUI_ROI.Util
 
         private static readonly string LogFilePath = Path.Combine(LogDirectory, "gui.log");
 
+        public static void Info(string message)
+            => Write("INFO", message);
+
         // CODEX: accept FormattableString to keep structured logging with invariant culture.
         public static void Info(FormattableString message)
-            => Write("INFO", FormattableString.Invariant(message));
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            Info(message.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static void Warn(string message)
+            => Write("WARN", message);
 
         // CODEX: FormattableString overload maintains parity with Info logging behavior.
         public static void Warn(FormattableString message)
-            => Write("WARN", FormattableString.Invariant(message));
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            Warn(message.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static void Error(string message)
+            => Write("ERROR", message);
 
         // CODEX: unify error logging across severities using FormattableString inputs.
         public static void Error(FormattableString message)
-            => Write("ERROR", FormattableString.Invariant(message));
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            Error(message.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static void Error(string message, Exception exception)
+        {
+            var baseMessage = message ?? string.Empty;
+            var rendered = exception == null
+                ? baseMessage
+                : string.IsNullOrEmpty(baseMessage)
+                    ? exception.ToString()
+                    : $"{baseMessage} :: {exception}";
+
+            Write("ERROR", rendered);
+        }
 
         public static void Error(FormattableString message, Exception exception)
         {
-            // CODEX: render interpolated error once and append exception safely.
-            var rendered = FormattableString.Invariant(message);
-            Write("ERROR", $"{rendered} :: {exception}");
+            if (message == null)
+            {
+                Error((string?)null, exception);
+                return;
+            }
+
+            Error(message.ToString(CultureInfo.InvariantCulture), exception);
         }
 
         private static void Write(string level, string message)


### PR DESCRIPTION
## Summary
- replace the Snackbar helper with a logging-only implementation that accepts both string and `FormattableString` inputs
- add string overloads to `GuiLog` so any existing literal strings can be logged without compile errors

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916f9d5a224832e8c9ccdf1f88c20a4)