### PR TITLE
Restore background continuation for heatmap decode

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4886,7 +4886,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private async Task ShowHeatmapOverlayAsync(Workflow.RoiExportResult export, byte[] heatmapBytes, double opacity)
         {
-            await EnsureOverlayAlignedForHeatmapAsync();
+            await EnsureOverlayAlignedForHeatmapAsync().ConfigureAwait(false);
 
             if (export == null || heatmapBytes == null || heatmapBytes.Length == 0)
                 return;


### PR DESCRIPTION
## Summary
- restore ConfigureAwait(false) when aligning the heatmap overlay so decoding continues on a background thread
- keep UI updates on the dispatcher after the heavy work completes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691882a75d80832b9b321f2e6cd4e0e4)