### PR TITLE
Fix Dispatcher invocation await usage

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4598,9 +4598,8 @@ namespace BrakeDiscInspector_GUI_ROI
             }
             else
             {
-                useLocalMatcher = await Dispatcher
-                    .InvokeAsync(() => ChkUseLocalMatcher?.IsChecked == true)
-                    .ConfigureAwait(false);
+                var dispatcherOp = Dispatcher.InvokeAsync(() => ChkUseLocalMatcher?.IsChecked == true);
+                useLocalMatcher = await dispatcherOp.Task.ConfigureAwait(false);
             }
 
             SWPoint? c1 = null;


### PR DESCRIPTION
## Summary
- avoid calling ConfigureAwait on DispatcherOperation by awaiting its Task
- keep the background context free when reading the local matcher checkbox

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69188a85d870832b878e3e47164adeee)