### PR TITLE
Fix batch ROI reposition delegate signature mismatch

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -128,7 +128,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         private readonly Action _clearHeatmap;
         private readonly Action<bool?> _updateGlobalBadge;
         private readonly Action<int>? _activateInspectionIndex;
-        private readonly Func<string, CancellationToken, Task>? _repositionInspectionRoisAsync;
+        private readonly Func<string, long, CancellationToken, Task>? _repositionInspectionRoisAsync;
 
         private ObservableCollection<InspectionRoiConfig>? _inspectionRois;
         private RoiModel? _inspection1;
@@ -228,7 +228,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             Action<bool?> updateGlobalBadge,
             Action<int>? activateInspectionIndex = null,
             Func<InspectionRoiConfig, string?>? resolveModelDirectory = null,
-            Func<string, CancellationToken, Task>? repositionInspectionRoisAsync = null)
+            Func<string, long, CancellationToken, Task>? repositionInspectionRoisAsync = null)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _datasetManager = datasetManager ?? throw new ArgumentNullException(nameof(datasetManager));
@@ -3765,7 +3765,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             try
             {
-                await _repositionInspectionRoisAsync(imagePath, ct).ConfigureAwait(false);
+                var stepId = BatchStepId;
+                await _repositionInspectionRoisAsync(imagePath, stepId, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -228,7 +228,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             Action<bool?> updateGlobalBadge,
             Action<int>? activateInspectionIndex = null,
             Func<InspectionRoiConfig, string?>? resolveModelDirectory = null,
-            Func<string, long, CancellationToken, Task>? repositionInspectionRoisAsync = null)
+            Func<string, CancellationToken, Task>? repositionInspectionRoisAsync = null)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _datasetManager = datasetManager ?? throw new ArgumentNullException(nameof(datasetManager));
@@ -3606,8 +3606,6 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     rowIndex++;
                     row.IndexOneBased = rowIndex;
                     BeginBatchStep(rowIndex, row.FullPath);
-                    var stepId = BatchStepId;
-
                     processed = rowIndex;
                     SetBatchStatusSafe($"[{processed}/{total}] {row.FileName}");
 
@@ -3625,7 +3623,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                     SetBatchBaseImage(row.FullPath);
 
-                    await RepositionInspectionRoisForImageAsync(row.FullPath, stepId, ct).ConfigureAwait(false);
+                    await RepositionInspectionRoisForImageAsync(row.FullPath, ct).ConfigureAwait(false);
 
                     for (int roiIndex = 1; roiIndex <= 4; roiIndex++)
                     {
@@ -3718,8 +3716,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                         }
                     }
 
-                    bool isNg = IsRowNg(row);
-                    BatchRowOk = !isNg;
+                    BatchRowOk = !IsRowNg(row);
 
                     await OnRowCompletedAsync(row, ct).ConfigureAwait(false);
                     UpdateBatchProgress(processed, total);
@@ -3759,7 +3756,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             InvokeOnUi(() => BatchHeatmapRoiIndex = Math.Max(1, Math.Min(4, roiIndex)));
         }
 
-        private async Task RepositionInspectionRoisForImageAsync(string imagePath, long stepId, CancellationToken ct)
+        private async Task RepositionInspectionRoisForImageAsync(string imagePath, CancellationToken ct)
         {
             if (string.IsNullOrWhiteSpace(imagePath) || _repositionInspectionRoisAsync == null)
             {
@@ -3768,7 +3765,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             try
             {
-                await _repositionInspectionRoisAsync(imagePath, stepId, ct).ConfigureAwait(false);
+                await _repositionInspectionRoisAsync(imagePath, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
## Summary
- align the batch ROI reposition delegate signature with its field usage
- update batch processing to call the delegate with the unified signature and drop the unused step id
- compute `BatchRowOk` without redeclaring the `isNg` local to avoid scope conflicts

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918a0414014832ba09fc5ca0f6fc2cf)