### PR TITLE
Unify ROI edit toggle behavior and remove legacy save buttons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -288,15 +288,9 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                      </Style>
-                    </Button.Style>
+                          </Style>
+                        </Button.Style>
                   </Button>
-                  <Button x:Name="BtnSaveInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Click="BtnSaveInspection1_Click"
-                          Content="Save 1"/>
                   <Button x:Name="BtnAddOkInspection1"
                           Margin="4,0,0,0"
                           Padding="4,2"
@@ -387,15 +381,9 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                      </Style>
-                    </Button.Style>
+                          </Style>
+                        </Button.Style>
                   </Button>
-                  <Button x:Name="BtnSaveInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Click="BtnSaveInspection2_Click"
-                          Content="Save 2"/>
                   <Button x:Name="BtnAddOkInspection2"
                           Margin="4,0,0,0"
                           Padding="4,2"
@@ -486,15 +474,9 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                      </Style>
-                    </Button.Style>
+                          </Style>
+                        </Button.Style>
                   </Button>
-                  <Button x:Name="BtnSaveInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Click="BtnSaveInspection3_Click"
-                          Content="Save 3"/>
                   <Button x:Name="BtnAddOkInspection3"
                           Margin="4,0,0,0"
                           Padding="4,2"
@@ -585,15 +567,9 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                      </Style>
-                    </Button.Style>
+                          </Style>
+                        </Button.Style>
                   </Button>
-                  <Button x:Name="BtnSaveInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Click="BtnSaveInspection4_Click"
-                          Content="Save 4"/>
                   <Button x:Name="BtnAddOkInspection4"
                           Margin="4,0,0,0"
                           Padding="4,2"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -6404,14 +6404,6 @@ namespace BrakeDiscInspector_GUI_ROI
             };
         }
 
-        private void BtnSaveInspection1_Click(object sender, RoutedEventArgs e) => SaveCurrentInspectionToSlot(1);
-
-        private void BtnSaveInspection2_Click(object sender, RoutedEventArgs e) => SaveCurrentInspectionToSlot(2);
-
-        private void BtnSaveInspection3_Click(object sender, RoutedEventArgs e) => SaveCurrentInspectionToSlot(3);
-
-        private void BtnSaveInspection4_Click(object sender, RoutedEventArgs e) => SaveCurrentInspectionToSlot(4);
-
         private void ToggleInspectionEdit(int index)
         {
             var config = GetInspectionConfigByIndex(index);
@@ -6451,8 +6443,12 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void ToggleInspectionEditFromButton(int index)
         {
-            var vm = WorkflowHost?.DataContext as WorkflowViewModel ?? ViewModel;
-            if (vm?.InspectionRois == null || vm.InspectionRois.Count == 0)
+            if (WorkflowHost?.DataContext is not WorkflowViewModel vm)
+            {
+                return;
+            }
+
+            if (vm.InspectionRois == null || vm.InspectionRois.Count == 0)
             {
                 GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton ignored: InspectionRois empty index={index}");
                 return;
@@ -6473,7 +6469,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             GuiLog.Info($"[workflow-edit] top-btn toggle request roi='{config.Id}' index={config.Index} enabled={config.Enabled} isEditable={config.IsEditable}");
 
-            ApplyInspectionToggleEdit(config.Id, config.Index);
+            WorkflowHostOnToggleEditRequested(this, new ToggleEditRequestedEventArgs(config.Id, config.Index));
         }
 
         private void ToggleInspectionEdit(InspectionRoiConfig config)


### PR DESCRIPTION
## Summary
- Route the top-level "Edit ROI" buttons through the same ToggleEditRequested pathway used in the Inspection tab
- Remove the redundant "Save" buttons from the Inspection ROI controls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929a8f8cf50832e943fb299db9cd731)