### PR TITLE
Fix inspection edit toggle using global state

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -6516,7 +6516,13 @@ namespace BrakeDiscInspector_GUI_ROI
 
             SetActiveInspectionIndex(index);
 
-            bool makeEditable = !config.IsEditable;
+            bool isActiveEditable =
+                _globalUnlocked &&
+                !string.IsNullOrWhiteSpace(_activeEditableRoiId) &&
+                !string.IsNullOrWhiteSpace(roiId) &&
+                string.Equals(_activeEditableRoiId, roiId, StringComparison.OrdinalIgnoreCase);
+
+            bool makeEditable = !isActiveEditable;
 
             if (makeEditable)
             {


### PR DESCRIPTION
## Summary
- derive inspection edit toggling from the global unlocked state and active ROI id
- keep config flags in sync after entering or exiting inspection edit mode

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929e58b9c18832e95eb54d7a9ccd941)