### PR TITLE
Align top ROI edit buttons with workflow toggle

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -6453,33 +6453,15 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void ToggleInspectionEditFromButton(int index)
         {
-            if (WorkflowHost?.DataContext is not WorkflowViewModel vm)
+            // Delegamos en el WorkflowControl para que el botón superior
+            // use EXACTAMENTE el mismo flujo que el botón "Edit" del tab.
+            if (WorkflowHost == null)
             {
+                GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton ignored: WorkflowHost is null index={index}");
                 return;
             }
 
-            if (vm.InspectionRois == null || vm.InspectionRois.Count == 0)
-            {
-                GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton ignored: InspectionRois empty index={index}");
-                return;
-            }
-
-            var config = vm.InspectionRois.FirstOrDefault(r => r.Index == index);
-            if (config == null)
-            {
-                GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton unknown ROI index={index}");
-                return;
-            }
-
-            if (!config.Enabled)
-            {
-                GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton aborted: roi='{config.Id}' index={index} disabled");
-                return;
-            }
-
-            GuiLog.Info($"[workflow-edit] top-btn toggle request roi='{config.Id}' index={config.Index} enabled={config.Enabled} isEditable={config.IsEditable}");
-
-            WorkflowHostOnToggleEditRequested(this, new ToggleEditRequestedEventArgs(config.Id, config.Index));
+            WorkflowHost.ToggleInspectionEditFromExternal(index);
         }
 
         private void ToggleInspectionEdit(InspectionRoiConfig config)

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml.cs
@@ -66,6 +66,32 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
         }
 
+        public void ToggleInspectionEditFromExternal(int index)
+        {
+            if (DataContext is not WorkflowViewModel vm)
+            {
+                GuiLog.Warn($"[workflow-edit] ToggleEditRequested (external) ignored: DataContext not WorkflowViewModel index={index}");
+                return;
+            }
+
+            if (vm.InspectionRois == null || vm.InspectionRois.Count == 0)
+            {
+                GuiLog.Warn($"[workflow-edit] ToggleEditRequested (external) ignored: InspectionRois empty index={index}");
+                return;
+            }
+
+            var cfg = vm.InspectionRois.FirstOrDefault(r => r.Index == index);
+            if (cfg == null)
+            {
+                GuiLog.Warn($"[workflow-edit] ToggleEditRequested (external) unknown ROI index={index}");
+                return;
+            }
+
+            GuiLog.Info($"[workflow-edit] ToggleEditRequested (external) roi='{cfg.Id}' index={cfg.Index} enabled={cfg.Enabled} isEditable={cfg.IsEditable}");
+
+            ToggleEditRequested?.Invoke(this, new ToggleEditRequestedEventArgs(cfg.Id, cfg.Index));
+        }
+
         private void DatasetImage_Click(object sender, MouseButtonEventArgs e)
         {
             if (sender is Image image && image.DataContext is DatasetPreviewItem item && File.Exists(item.Path))


### PR DESCRIPTION
## Summary
- add a helper in WorkflowControl to toggle ROI editing externally using the existing ToggleEditRequested event
- route the top Edit ROI buttons through WorkflowControl so they share the same edit flow as the tab buttons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692a00ff5c3c832eb8dd50f66652d6d5)