### PR TITLE
Update inspection ROI edit buttons to refresh state immediately

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -275,12 +275,15 @@
                           Margin="4,0,0,0"
                           Padding="4,2"
                           MinHeight="26"
-                          Click="BtnEditInspection1_Click"
-                          Content="Edit ROI 1">
+                          Click="BtnEditInspection1_Click">
                     <Button.Style>
                       <Style TargetType="Button">
+                        <Setter Property="Content" Value="Edit ROI 1"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
+                          <DataTrigger Binding="{Binding DataContext.InspectionRois[0].IsEditable, ElementName=WorkflowHost}" Value="True">
+                            <Setter Property="Content" Value="Save ROI 1"/>
+                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -368,12 +371,15 @@
                           Margin="4,0,0,0"
                           Padding="4,2"
                           MinHeight="26"
-                          Click="BtnEditInspection2_Click"
-                          Content="Edit ROI 2">
+                          Click="BtnEditInspection2_Click">
                     <Button.Style>
                       <Style TargetType="Button">
+                        <Setter Property="Content" Value="Edit ROI 2"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
+                          <DataTrigger Binding="{Binding DataContext.InspectionRois[1].IsEditable, ElementName=WorkflowHost}" Value="True">
+                            <Setter Property="Content" Value="Save ROI 2"/>
+                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection2, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -461,12 +467,15 @@
                           Margin="4,0,0,0"
                           Padding="4,2"
                           MinHeight="26"
-                          Click="BtnEditInspection3_Click"
-                          Content="Edit ROI 3">
+                          Click="BtnEditInspection3_Click">
                     <Button.Style>
                       <Style TargetType="Button">
+                        <Setter Property="Content" Value="Edit ROI 3"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
+                          <DataTrigger Binding="{Binding DataContext.InspectionRois[2].IsEditable, ElementName=WorkflowHost}" Value="True">
+                            <Setter Property="Content" Value="Save ROI 3"/>
+                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection3, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -554,12 +563,15 @@
                           Margin="4,0,0,0"
                           Padding="4,2"
                           MinHeight="26"
-                          Click="BtnEditInspection4_Click"
-                          Content="Edit ROI 4">
+                          Click="BtnEditInspection4_Click">
                     <Button.Style>
                       <Style TargetType="Button">
+                        <Setter Property="Content" Value="Edit ROI 4"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
+                          <DataTrigger Binding="{Binding DataContext.InspectionRois[3].IsEditable, ElementName=WorkflowHost}" Value="True">
+                            <Setter Property="Content" Value="Save ROI 4"/>
+                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection4, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3547,6 +3547,29 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 BtnEditInspection4.Content = _editingInspectionSlot == 4 ? "Save ROI 4" : "Edit ROI 4";
             }
+
+            RaiseInspectionCommandStates();
+        }
+
+        private void RaiseInspectionCommandStates()
+        {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
+            if (ViewModel.AddRoiToOkCommand is AsyncCommand addOk)
+            {
+                addOk.RaiseCanExecuteChanged();
+            }
+
+            if (ViewModel.AddRoiToNgCommand is AsyncCommand addNg)
+            {
+                addNg.RaiseCanExecuteChanged();
+            }
+
+            ViewModel.AddRoiToDatasetOkCommand.RaiseCanExecuteChanged();
+            ViewModel.AddRoiToDatasetNgCommand.RaiseCanExecuteChanged();
         }
 
         private void SetInspectionEditingFlag(int index, bool editing)


### PR DESCRIPTION
## Summary
- bind inspection edit buttons to ROI editability so they switch between Edit/Save after each click
- raise inspection command states when toggling edit mode to keep controls in sync

## Testing
- not run (WPF build not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ae88e9828832b93771f96fa1ff5d2)