### PR TITLE
Fix side panel inspection edit buttons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -271,19 +271,17 @@
                           Tag="1"
                           Click="BtnCreateInspection_Click"
                           Content="Create ROI 1"/>
-                  <Button x:Name="BtnEditInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
+                  <Button Margin="4,0,0,0"
+                          Padding="12,4"
                           MinHeight="26"
-                          Click="BtnEditInspection1_Click">
+                          Content="Editar"
+                          DataContext="{Binding DataContext.InspectionRois[0], ElementName=WorkflowHost}"
+                          Click="BtnToggleEdit_Click"
+                          IsEnabled="{Binding Enabled}">
                     <Button.Style>
                       <Style TargetType="Button">
-                        <Setter Property="Content" Value="Edit ROI 1"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
-                          <DataTrigger Binding="{Binding DataContext.InspectionRois[0].IsEditable, ElementName=WorkflowHost}" Value="True">
-                            <Setter Property="Content" Value="Save ROI 1"/>
-                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -291,8 +289,8 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                          </Style>
-                        </Button.Style>
+                      </Style>
+                    </Button.Style>
                   </Button>
                   <Button x:Name="BtnAddOkInspection1"
                           Margin="4,0,0,0"
@@ -367,19 +365,17 @@
                           Tag="2"
                           Click="BtnCreateInspection_Click"
                           Content="Create ROI 2"/>
-                  <Button x:Name="BtnEditInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
+                  <Button Margin="4,0,0,0"
+                          Padding="12,4"
                           MinHeight="26"
-                          Click="BtnEditInspection2_Click">
+                          Content="Editar"
+                          DataContext="{Binding DataContext.InspectionRois[1], ElementName=WorkflowHost}"
+                          Click="BtnToggleEdit_Click"
+                          IsEnabled="{Binding Enabled}">
                     <Button.Style>
                       <Style TargetType="Button">
-                        <Setter Property="Content" Value="Edit ROI 2"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
-                          <DataTrigger Binding="{Binding DataContext.InspectionRois[1].IsEditable, ElementName=WorkflowHost}" Value="True">
-                            <Setter Property="Content" Value="Save ROI 2"/>
-                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection2, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -387,8 +383,8 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                          </Style>
-                        </Button.Style>
+                      </Style>
+                    </Button.Style>
                   </Button>
                   <Button x:Name="BtnAddOkInspection2"
                           Margin="4,0,0,0"
@@ -463,19 +459,17 @@
                           Tag="3"
                           Click="BtnCreateInspection_Click"
                           Content="Create ROI 3"/>
-                  <Button x:Name="BtnEditInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
+                  <Button Margin="4,0,0,0"
+                          Padding="12,4"
                           MinHeight="26"
-                          Click="BtnEditInspection3_Click">
+                          Content="Editar"
+                          DataContext="{Binding DataContext.InspectionRois[2], ElementName=WorkflowHost}"
+                          Click="BtnToggleEdit_Click"
+                          IsEnabled="{Binding Enabled}">
                     <Button.Style>
                       <Style TargetType="Button">
-                        <Setter Property="Content" Value="Edit ROI 3"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
-                          <DataTrigger Binding="{Binding DataContext.InspectionRois[2].IsEditable, ElementName=WorkflowHost}" Value="True">
-                            <Setter Property="Content" Value="Save ROI 3"/>
-                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection3, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -483,8 +477,8 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                          </Style>
-                        </Button.Style>
+                      </Style>
+                    </Button.Style>
                   </Button>
                   <Button x:Name="BtnAddOkInspection3"
                           Margin="4,0,0,0"
@@ -559,19 +553,17 @@
                           Tag="4"
                           Click="BtnCreateInspection_Click"
                           Content="Create ROI 4"/>
-                  <Button x:Name="BtnEditInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
+                  <Button Margin="4,0,0,0"
+                          Padding="12,4"
                           MinHeight="26"
-                          Click="BtnEditInspection4_Click">
+                          Content="Editar"
+                          DataContext="{Binding DataContext.InspectionRois[3], ElementName=WorkflowHost}"
+                          Click="BtnToggleEdit_Click"
+                          IsEnabled="{Binding Enabled}">
                     <Button.Style>
                       <Style TargetType="Button">
-                        <Setter Property="Content" Value="Edit ROI 4"/>
                         <Setter Property="IsEnabled" Value="True"/>
                         <Style.Triggers>
-                          <DataTrigger Binding="{Binding DataContext.InspectionRois[3].IsEditable, ElementName=WorkflowHost}" Value="True">
-                            <Setter Property="Content" Value="Save ROI 4"/>
-                          </DataTrigger>
                           <DataTrigger Binding="{Binding DataContext.Inspection4, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
@@ -579,8 +571,8 @@
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
-                          </Style>
-                        </Button.Style>
+                      </Style>
+                    </Button.Style>
                   </Button>
                   <Button x:Name="BtnAddOkInspection4"
                           Margin="4,0,0,0"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3528,26 +3528,6 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void UpdateInspectionEditButtons()
         {
-            if (BtnEditInspection1 != null)
-            {
-                BtnEditInspection1.Content = _editingInspectionSlot == 1 ? "Save ROI 1" : "Edit ROI 1";
-            }
-
-            if (BtnEditInspection2 != null)
-            {
-                BtnEditInspection2.Content = _editingInspectionSlot == 2 ? "Save ROI 2" : "Edit ROI 2";
-            }
-
-            if (BtnEditInspection3 != null)
-            {
-                BtnEditInspection3.Content = _editingInspectionSlot == 3 ? "Save ROI 3" : "Edit ROI 3";
-            }
-
-            if (BtnEditInspection4 != null)
-            {
-                BtnEditInspection4.Content = _editingInspectionSlot == 4 ? "Save ROI 4" : "Edit ROI 4";
-            }
-
             RaiseInspectionCommandStates();
         }
 
@@ -6474,19 +6454,6 @@ namespace BrakeDiscInspector_GUI_ROI
             });
         }
 
-        private void ToggleInspectionEditFromButton(int index)
-        {
-            // Delegamos en el WorkflowControl para que el botón superior
-            // use EXACTAMENTE el mismo flujo que el botón "Edit" del tab.
-            if (WorkflowHost == null)
-            {
-                GuiLog.Warn($"[workflow-edit] ToggleInspectionEditFromButton ignored: WorkflowHost is null index={index}");
-                return;
-            }
-
-            WorkflowHost.ToggleInspectionEditFromExternal(index);
-        }
-
         private void ToggleInspectionEdit(InspectionRoiConfig config)
         {
             var index = config.Index;
@@ -6572,13 +6539,18 @@ namespace BrakeDiscInspector_GUI_ROI
                 $"globalUnlocked={_globalUnlocked} activeEditableRoiId='{_activeEditableRoiId}'");
         }
 
-        private void BtnEditInspection1_Click(object sender, RoutedEventArgs e) => ToggleInspectionEditFromButton(1);
-
-        private void BtnEditInspection2_Click(object sender, RoutedEventArgs e) => ToggleInspectionEditFromButton(2);
-
-        private void BtnEditInspection3_Click(object sender, RoutedEventArgs e) => ToggleInspectionEditFromButton(3);
-
-        private void BtnEditInspection4_Click(object sender, RoutedEventArgs e) => ToggleInspectionEditFromButton(4);
+        private void BtnToggleEdit_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.DataContext is InspectionRoiConfig cfg)
+            {
+                GuiLog.Info($"[workflow-edit] BtnToggleEdit_Click(main) roi='{cfg.Id}' index={cfg.Index} enabled={cfg.Enabled} isEditable={cfg.IsEditable}");
+                ApplyInspectionToggleEdit(cfg.Id, cfg.Index);
+            }
+            else
+            {
+                GuiLog.Warn("[workflow-edit] BtnToggleEdit_Click(main) ignored: invalid sender/DataContext");
+            }
+        }
 
         private void BtnCreateInspection_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- replace side panel inspection edit buttons with bindings to inspection configurations and reuse the shared toggle handler
- remove legacy per-inspection click handlers that routed through WorkflowHost external toggling

## Testing
- Not run (environment missing `dotnet` CLI)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692b27aabc60832baa013e8813daaed3)