### PR TITLE
Adjust move cursor to ROI geometry

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -57,7 +57,7 @@ namespace BrakeDiscInspector_GUI_ROI
             IsHitTestVisible = true;
 
             // Estilos básicos
-            StyleThumb(_moveThumb, 0, 0, 0, 0, Cursors.SizeAll, 0.0, 0.0, 0.0, 0.0);
+            StyleThumb(_moveThumb, 0, 0, 0, 0, Cursors.Arrow, 0.0, 0.0, 0.0, 0.0);
             _moveThumb.Background = Brushes.Transparent; // grande e invisible
             _moveThumb.IsHitTestVisible = true;
 
@@ -86,6 +86,8 @@ namespace BrakeDiscInspector_GUI_ROI
             _moveThumb.DragStarted += OnThumbDragStarted;
             _moveThumb.DragDelta += MoveThumb_DragDelta;
             _moveThumb.DragCompleted += OnThumbDragCompleted;
+            _moveThumb.MouseMove += MoveThumb_MouseMove;
+            _moveThumb.MouseLeave += MoveThumb_MouseLeave;
 
             _corners[0].DragStarted += OnThumbDragStarted;
             _corners[0].DragDelta += (s, e) => ResizeByCorner(e.HorizontalChange, e.VerticalChange, Corner.NW);
@@ -262,6 +264,23 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         // === Interacciones ===
+
+        private void MoveThumb_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (sender != _moveThumb)
+                return;
+
+            Point p = e.GetPosition(_moveThumb);
+            bool inside = IsPointInsideRoiGeometry(p);
+
+            _moveThumb.Cursor = inside ? Cursors.SizeAll : Cursors.Arrow;
+        }
+
+        private void MoveThumb_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (sender == _moveThumb)
+                _moveThumb.Cursor = Cursors.Arrow;
+        }
 
         private void MoveThumb_DragDelta(object sender, DragDeltaEventArgs e)
         {


### PR DESCRIPTION
## Summary
- set the move thumb cursor to default to a neutral arrow and update it on pointer movement
- align the move cursor feedback with the actual ROI geometry using existing geometry checks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692b52febdec832ba11713af04a363e3)