### PR TITLE
Implement per-anchor ROI repositioning

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3334,7 +3334,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     CreateMasterRoiFromWorkflowAsync,
                     ToggleEditSaveMasterRoiFromWorkflowAsync,
                     RemoveMasterRoiFromWorkflowAsync,
-                    CanEditMasterRoiFromWorkflow);
+                    CanEditMasterRoiFromWorkflow,
+                    Snack);
 
                 _workflowViewModel.SetLayoutName(GetCurrentLayoutName());
 
@@ -6204,7 +6205,6 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             DrawCross(c1Canvas.X, c1Canvas.Y, 20, Brushes.LimeGreen, 2);
             DrawCross(c2Canvas.X, c2Canvas.Y, 20, Brushes.Orange, 2);
-            DrawCross(midCanvas.X, midCanvas.Y, 24, Brushes.Red, 2);
         }
 
         private SWPoint ImageToCanvasPoint(SWPoint imagePoint)


### PR DESCRIPTION
## Summary
- implement per-anchor ROI repositioning using detected master anchors, scaling, and rotation with shared anchor context
- skip repositioning when anchor detection fails while logging and showing a snackbar to the user
- remove the midpoint cross drawing from the Analyze Master overlay

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bc3e4c2e4832b9b251f02b9ab0bfa)