### PR TITLE
Prevent layout analyze rotation/scale from being overwritten on analyze

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3083,6 +3083,29 @@ namespace BrakeDiscInspector_GUI_ROI
             var layoutAnalyze = _layout?.Analyze;
             var layoutUi = _layout?.Ui;
 
+            // Keep the preset/UI rotation/scale fields aligned with the layout's stored analyze options
+            // so that subsequent Analyze actions do not overwrite tuned values with stale defaults.
+            if (_preset != null && layoutAnalyze != null)
+            {
+                if (layoutAnalyze.RotRange > 0)
+                {
+                    _preset.RotRange = layoutAnalyze.RotRange;
+                    TxtRot.Text = layoutAnalyze.RotRange.ToString(CultureInfo.InvariantCulture);
+                }
+
+                if (layoutAnalyze.ScaleMin > 0)
+                {
+                    _preset.ScaleMin = layoutAnalyze.ScaleMin;
+                    TxtSMin.Text = layoutAnalyze.ScaleMin.ToString(CultureInfo.InvariantCulture);
+                }
+
+                if (layoutAnalyze.ScaleMax > 0)
+                {
+                    _preset.ScaleMax = layoutAnalyze.ScaleMax;
+                    TxtSMax.Text = layoutAnalyze.ScaleMax.ToString(CultureInfo.InvariantCulture);
+                }
+            }
+
             double posTol = layoutAnalyze != null && layoutAnalyze.PosTolPx > 0 ? layoutAnalyze.PosTolPx : defaultPosTol;
             double angTol = layoutAnalyze != null && layoutAnalyze.AngTolDeg > 0 ? layoutAnalyze.AngTolDeg : defaultAngTol;
             bool scaleLock = layoutAnalyze?.ScaleLock ?? defaultScaleLock;


### PR DESCRIPTION
## Summary
- keep preset rotation/scale fields in sync with layout analyze options when a layout is loaded
- prevent stale preset UI values from overwriting layout-specific analyze rotation and scale

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bcdb3e4e4832babdbed8c9da18f95)