### PR TITLE
Fix namespace for MasterAnchorChoice

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows;
+using BrakeDiscInspector_GUI_ROI.Models;
 using BrakeDiscInspector_GUI_ROI.Util;
 using OpenCvSharp;
 


### PR DESCRIPTION
## Summary
- import the Models namespace in InspectionAlignmentHelper to resolve MasterAnchorChoice references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bda16cacc832ba94b901a6c40c59b)