### PR TITLE
Handle Point2d magnitude in anchor scale calculation

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -5349,7 +5349,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             var vBase = new Point2d(m2BaselineCenter.X - m1BaselineCenter.X, m2BaselineCenter.Y - m1BaselineCenter.Y);
             var vCurr = new Point2d(m2DetectedCenter.X - m1DetectedCenter.X, m2DetectedCenter.Y - m1DetectedCenter.Y);
 
-            var scale = vCurr.Length / Math.Max(vBase.Length, 1e-3);
+            static double VectorLength(Point2d p) => Math.Sqrt(p.X * p.X + p.Y * p.Y);
+
+            var scale = VectorLength(vCurr) / Math.Max(VectorLength(vBase), 1e-3);
 
             var angBase = Math.Atan2(vBase.Y, vBase.X);
             var angCurr = Math.Atan2(vCurr.Y, vCurr.X);


### PR DESCRIPTION
## Summary
- replace use of non-existent `Point2d.Length` with a local magnitude helper when computing anchor scale
- retain anchor alignment scale calculation even when the baseline vector is near zero

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bdc64ea6c832bba79f4b9a74c89fd)