### PR TITLE
Fix /health status for CPU-only deployments

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -115,7 +115,8 @@ def health(request: Request):
         cuda_available = False
 
     request_id, recipe_id = _resolve_request_context(request)
-    status = "ok" if cuda_available else "error"
+    # CPU-only deployments are valid: report OK while surfacing CUDA absence separately.
+    status = "ok"
     resp = {
         "status": status,
         "device": "cuda" if cuda_available else "cpu",


### PR DESCRIPTION
## Summary
- keep /health returning ok on CPU-only deployments while still indicating CUDA availability
- preserve reason field so missing GPU is surfaced without tripping readiness

## Testing
- pytest backend/tests/test_app_fastapi.py *(fails: existing tests expect artifact files saved during fit/calibrate stubs)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c1ebdaef4832eb99fbfeb0af3f7e6)