### PR TITLE
Avoid null-conditional assignment when syncing recipe id

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3212,7 +3212,10 @@ namespace BrakeDiscInspector_GUI_ROI
         private void SyncRecipeIdWithLayout(string layoutName)
         {
             var effective = string.IsNullOrWhiteSpace(layoutName) ? "DefaultLayout" : layoutName;
-            _backendClient?.RecipeId = effective;
+            if (_backendClient != null)
+            {
+                _backendClient.RecipeId = effective;
+            }
             BackendAPI.SetRecipeId(effective);
         }
 


### PR DESCRIPTION
## Summary
- guard backend client recipe assignment to avoid using null-conditional setters unsupported by current C# version
- preserve BackendAPI recipe synchronization behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c35ad8fd0832e883d9e62546d53f3)