### PR TITLE
Add disable rotation option and fix scale lock

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
@@ -60,6 +60,128 @@ public class InspectionAlignmentHelperTests
         AssertClose(firstResult, target, shape);
     }
 
+    [Fact]
+    public void MoveInspectionTo_AppliesRotationAndScale_WhenNotDisabled()
+    {
+        var baselineInspection = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 5,
+            Y = 5,
+            Width = 4,
+            Height = 6,
+            AngleDeg = 10
+        };
+
+        var target = baselineInspection.Clone();
+        var anchors = CreateAnchorContext(scaleLock: false, disableRot: false);
+
+        InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
+
+        Assert.Equal(-9, target.X, 6);
+        Assert.Equal(12, target.Y, 6);
+        Assert.Equal(8, target.Width, 6);
+        Assert.Equal(12, target.Height, 6);
+        Assert.Equal(100, target.AngleDeg, 6);
+    }
+
+    [Fact]
+    public void MoveInspectionTo_DisableRot_TranslatesWithoutRotation()
+    {
+        var baselineInspection = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 5,
+            Y = 5,
+            Width = 4,
+            Height = 6,
+            AngleDeg = 10
+        };
+
+        var target = baselineInspection.Clone();
+        var anchors = CreateAnchorContext(scaleLock: false, disableRot: true);
+
+        InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
+
+        Assert.Equal(11, target.X, 6);
+        Assert.Equal(12, target.Y, 6);
+        Assert.Equal(8, target.Width, 6);
+        Assert.Equal(12, target.Height, 6);
+        Assert.Equal(10, target.AngleDeg, 6);
+    }
+
+    [Fact]
+    public void MoveInspectionTo_ScaleLock_KeepsSizeAndOffsetScale()
+    {
+        var baselineInspection = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 5,
+            Y = 5,
+            Width = 4,
+            Height = 6,
+            AngleDeg = 10
+        };
+
+        var target = baselineInspection.Clone();
+        var anchors = CreateAnchorContext(scaleLock: true, disableRot: false);
+
+        InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
+
+        Assert.Equal(-4, target.X, 6);
+        Assert.Equal(7, target.Y, 6);
+        Assert.Equal(4, target.Width, 6);
+        Assert.Equal(6, target.Height, 6);
+        Assert.Equal(100, target.AngleDeg, 6);
+    }
+
+    [Fact]
+    public void MoveInspectionTo_DisableRotAndScaleLock_TranslatesOnly()
+    {
+        var baselineInspection = new RoiModel
+        {
+            Shape = RoiShape.Rectangle,
+            X = 5,
+            Y = 5,
+            Width = 4,
+            Height = 6,
+            AngleDeg = 10
+        };
+
+        var target = baselineInspection.Clone();
+        var anchors = CreateAnchorContext(scaleLock: true, disableRot: true);
+
+        InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
+
+        Assert.Equal(6, target.X, 6);
+        Assert.Equal(7, target.Y, 6);
+        Assert.Equal(4, target.Width, 6);
+        Assert.Equal(6, target.Height, 6);
+        Assert.Equal(10, target.AngleDeg, 6);
+    }
+
+    private static AnchorTransformContext CreateAnchorContext(bool scaleLock, bool disableRot)
+    {
+        var baselineM1 = new Point2d(0, 0);
+        var baselineM2 = new Point2d(10, 0);
+        var detectedM1 = new Point2d(1, 2);
+        var detectedM2 = new Point2d(1, 22);
+
+        return new AnchorTransformContext(
+            baselineM1,
+            baselineM2,
+            detectedM1,
+            detectedM2,
+            0,
+            0,
+            0,
+            0,
+            2.0,
+            Math.PI / 2.0,
+            scaleLock,
+            disableRot);
+    }
+
     private static RoiModel CreateBaselineInspection(RoiShape shape)
     {
         return shape switch

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/MasterLayoutTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/MasterLayoutTests.cs
@@ -37,4 +37,15 @@ public class MasterLayoutTests
         Assert.Equal(25, roundTrip.Inspection.RInner);
         Assert.Equal(60, roundTrip.Inspection.R);
     }
+
+    [Fact]
+    public void AnalyzeDisableRot_DefaultsToFalse_WhenMissing()
+    {
+        const string json = "{\"Analyze\":{\"ScaleLock\":true}}";
+
+        var layout = JsonSerializer.Deserialize<MasterLayout>(json);
+
+        Assert.NotNull(layout);
+        Assert.False(layout!.Analyze.DisableRot);
+    }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -30,13 +30,16 @@ internal static class InspectionAlignmentHelper
         var (baseCx, baseCy) = baselineInspection.GetCenter();
         var vBase = new Point2d(baseCx - pivotBaseline.X, baseCy - pivotBaseline.Y);
 
-        var cosA = Math.Cos(anchors.AngleDeltaGlobal);
-        var sinA = Math.Sin(anchors.AngleDeltaGlobal);
-        var vx = (vBase.X * cosA - vBase.Y * sinA) * anchors.Scale;
-        var vy = (vBase.X * sinA + vBase.Y * cosA) * anchors.Scale;
+        var angleEffective = anchors.DisableRot ? 0.0 : anchors.AngleDeltaGlobal;
+        var scaleEffective = anchors.ScaleLock ? 1.0 : anchors.Scale;
+
+        var cosA = Math.Cos(angleEffective);
+        var sinA = Math.Sin(angleEffective);
+        var vx = (vBase.X * cosA - vBase.Y * sinA) * scaleEffective;
+        var vy = (vBase.X * sinA + vBase.Y * cosA) * scaleEffective;
 
         var roiNewCenter = new Point2d(pivotCurrent.X + vx, pivotCurrent.Y + vy);
-        var roiNewAngleDeg = baselineInspection.AngleDeg + anchors.AngleDeltaGlobal * 180.0 / Math.PI;
+        var roiNewAngleDeg = baselineInspection.AngleDeg + angleEffective * 180.0 / Math.PI;
 
         trace?.Invoke(
             $"[ROI] name={inspectionTarget.Label} anchor={anchor} " +
@@ -47,8 +50,8 @@ internal static class InspectionAlignmentHelper
         {
             case RoiShape.Rectangle:
                 inspectionTarget.Shape = RoiShape.Rectangle;
-                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * anchors.Scale);
-                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * anchors.Scale);
+                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * scaleEffective);
+                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * scaleEffective);
                 inspectionTarget.X = roiNewCenter.X;
                 inspectionTarget.Y = roiNewCenter.Y;
                 inspectionTarget.Left = roiNewCenter.X - inspectionTarget.Width * 0.5;
@@ -61,23 +64,23 @@ internal static class InspectionAlignmentHelper
                 inspectionTarget.Shape = RoiShape.Circle;
                 inspectionTarget.CX = roiNewCenter.X;
                 inspectionTarget.CY = roiNewCenter.Y;
-                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * anchors.Scale);
-                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * anchors.Scale);
+                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * scaleEffective);
+                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * scaleEffective);
                 inspectionTarget.Left = roiNewCenter.X - inspectionTarget.Width * 0.5;
                 inspectionTarget.Top = roiNewCenter.Y - inspectionTarget.Height * 0.5;
-                inspectionTarget.R = Math.Max(1, baselineInspection.R * anchors.Scale);
+                inspectionTarget.R = Math.Max(1, baselineInspection.R * scaleEffective);
                 inspectionTarget.AngleDeg = roiNewAngleDeg;
                 break;
             case RoiShape.Annulus:
                 inspectionTarget.Shape = RoiShape.Annulus;
                 inspectionTarget.CX = roiNewCenter.X;
                 inspectionTarget.CY = roiNewCenter.Y;
-                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * anchors.Scale);
-                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * anchors.Scale);
+                inspectionTarget.Width = Math.Max(1, baselineInspection.Width * scaleEffective);
+                inspectionTarget.Height = Math.Max(1, baselineInspection.Height * scaleEffective);
                 inspectionTarget.Left = roiNewCenter.X - inspectionTarget.Width * 0.5;
                 inspectionTarget.Top = roiNewCenter.Y - inspectionTarget.Height * 0.5;
-                inspectionTarget.R = Math.Max(1, baselineInspection.R * anchors.Scale);
-                inspectionTarget.RInner = Math.Max(0, baselineInspection.RInner * anchors.Scale);
+                inspectionTarget.R = Math.Max(1, baselineInspection.R * scaleEffective);
+                inspectionTarget.RInner = Math.Max(0, baselineInspection.RInner * scaleEffective);
                 if (inspectionTarget.RInner >= inspectionTarget.R)
                 {
                     inspectionTarget.RInner = Math.Max(0, inspectionTarget.R - 1);
@@ -98,4 +101,6 @@ internal readonly record struct AnchorTransformContext(
     double M1DetectedAngleDeg,
     double M2DetectedAngleDeg,
     double Scale,
-    double AngleDeltaGlobal);
+    double AngleDeltaGlobal,
+    bool ScaleLock,
+    bool DisableRot);

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -237,6 +237,10 @@
                     <CheckBox x:Name="ChkScaleLock"
                               Content="Lock scale"
                               IsChecked="{Binding ScaleLock, Mode=TwoWay}"/>
+                    <CheckBox x:Name="ChkDisableRot"
+                              Content="Disable rot"
+                              Margin="8,0,0,0"
+                              IsChecked="{Binding DisableRot, Mode=TwoWay}"/>
                     <CheckBox x:Name="ChkUseLocalMatcher"
                               Content="Use local matcher"
                               Margin="8,0,0,0"

--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -64,6 +64,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     PosTolPx = Analyze?.PosTolPx ?? new AnalyzeOptions().PosTolPx,
                     AngTolDeg = Analyze?.AngTolDeg ?? new AnalyzeOptions().AngTolDeg,
                     ScaleLock = Analyze?.ScaleLock ?? new AnalyzeOptions().ScaleLock,
+                    DisableRot = Analyze?.DisableRot ?? new AnalyzeOptions().DisableRot,
                     UseLocalMatcher = Analyze?.UseLocalMatcher ?? new AnalyzeOptions().UseLocalMatcher,
                     FeatureM1 = Analyze?.FeatureM1 ?? new AnalyzeOptions().FeatureM1,
                     FeatureM2 = Analyze?.FeatureM2 ?? new AnalyzeOptions().FeatureM2,
@@ -106,6 +107,7 @@ namespace BrakeDiscInspector_GUI_ROI
         public double PosTolPx { get; set; } = 1.0;
         public double AngTolDeg { get; set; } = 0.5;
         public bool ScaleLock { get; set; } = true;
+        public bool DisableRot { get; set; } = false;
         public bool UseLocalMatcher { get; set; } = true;
         public string FeatureM1 { get; set; } = "auto";
         public int ThrM1 { get; set; } = 85;

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -5358,6 +5358,10 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             var angCurr = Math.Atan2(vCurr.Y, vCurr.X);
             var angleDeltaGlobal = angCurr - angBase;
 
+            var analyzeOpts = _layoutOriginal.Analyze ?? new AnalyzeOptions();
+            bool scaleLock = analyzeOpts.ScaleLock;
+            bool disableRot = analyzeOpts.DisableRot;
+
             if (logSummary)
             {
                 _trace?.Invoke(FormattableString.Invariant($"[ANCHORS] scale={scale:F3} angleDeltaGlobal={angleDeltaGlobal * 180.0 / Math.PI:F1}deg"));
@@ -5373,7 +5377,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 _m1Detection.AngleDeg,
                 _m2Detection.AngleDeg,
                 scale,
-                angleDeltaGlobal);
+                angleDeltaGlobal,
+                scaleLock,
+                disableRot);
 
             return true;
         }


### PR DESCRIPTION
## Summary
- add a persisted Analyze option and UI checkbox to disable global rotation when repositioning inspection ROIs
- honor both disable-rotation and scale-lock flags in ROI relocation logic, including batch anchor transforms
- extend layout defaults and unit tests to cover rotation/scale combinations and missing-fields compatibility

## Testing
- `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c76f20e5c832ebc3b86313b97d184)