### PR TITLE
Fix anchor master binding and persistence for inspection ROIs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -6782,6 +6782,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 RoiDiag($"[save-slot] idx={index} configId={config.Id} shape={config.Shape} base=({config.BaseImgW}x{config.BaseImgH}) name='{config.Name}'");
             }
 
+            var anchorMaster = config?.AnchorMaster ?? MasterAnchorChoice.Master1;
+            GuiLog.Info(FormattableString.Invariant($"[ALIGN][SAVE] roi_index={index} saved_anchor_master={(int)anchorMaster}"));
+
             GuiLog.Info($"[inspection] save slot={index} roi={roiModel.Label ?? roiModel.Id} shape={roiModel.Shape}");
 
             RoiDiag($"[save-slot] idx={index} persist base=({roiModel.BaseImgW}x{roiModel.BaseImgH})");

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -155,10 +155,12 @@
                                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                                             <TextBlock Text="Anchor master:" VerticalAlignment="Center" Margin="0,0,8,0"/>
                                             <ComboBox Width="90"
-                                                      SelectedValuePath="Content"
+                                                      SelectedValuePath="Tag"
                                                       SelectedValue="{Binding AnchorMaster, Mode=TwoWay}">
-                                                <ComboBoxItem Content="Master1" />
-                                                <ComboBoxItem Content="Master2" />
+                                                <ComboBoxItem Content="Master1"
+                                                              Tag="{x:Static m:MasterAnchorChoice.Master1}" />
+                                                <ComboBoxItem Content="Master2"
+                                                              Tag="{x:Static m:MasterAnchorChoice.Master2}" />
                                             </ComboBox>
                                         </StackPanel>
                                     </StackPanel>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -2552,6 +2552,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
         private void InspectionRoiPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
+            if (e.PropertyName == nameof(InspectionRoiConfig.AnchorMaster) && sender is InspectionRoiConfig anchorChanged)
+            {
+                LogAlign(FormattableString.Invariant(
+                    $"[UI] roi_index={anchorChanged.Index} anchor_master_changed_to={(int)anchorChanged.AnchorMaster}"));
+            }
+
             if (e.PropertyName == nameof(InspectionRoiConfig.Enabled))
             {
                 EvaluateAllRoisCommand.RaiseCanExecuteChanged();
@@ -5464,6 +5470,16 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                 var baseline = EnsureBaselineForRoi(rcfg, roi, "reposition");
                 var baselineModel = BuildBaselineModel(roi, baseline);
+                var pivotBase = rcfg.AnchorMaster == MasterAnchorChoice.Master1
+                    ? anchorContext.M1BaselineCenter
+                    : anchorContext.M2BaselineCenter;
+                var pivotDet = rcfg.AnchorMaster == MasterAnchorChoice.Master1
+                    ? anchorContext.M1DetectedCenter
+                    : anchorContext.M2DetectedCenter;
+
+                LogAlign(FormattableString.Invariant(
+                    $"[APPLY] roi_index={rcfg.Index} using_anchor_master={(int)rcfg.AnchorMaster} pivot_base=({pivotBase.X:0.###},{pivotBase.Y:0.###}) pivot_det=({pivotDet.X:0.###},{pivotDet.Y:0.###})"));
+
                 InspectionAlignmentHelper.MoveInspectionTo(roi, baselineModel, rcfg.AnchorMaster, anchorContext, _trace);
             }
         }


### PR DESCRIPTION
## Summary
- bind the anchor master selector to enum values so selections persist correctly
- add alignment logging for UI changes, apply operations, and ROI saves to trace anchor usage
- ensure saved inspection slots capture the current anchor master alongside geometry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c96a02df0832e9ef3be2392695a4a)