### PR TITLE
Seed default inspection ROI slots on layout creation

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -16,6 +16,11 @@ namespace BrakeDiscInspector_GUI_ROI
 {
     public class MasterLayout
     {
+        public MasterLayout()
+        {
+            EnsureInspectionRoiDefaults(this);
+        }
+
         public RoiModel? Master1Pattern { get; set; }
         public string? Master1PatternImagePath { get; set; }
         public RoiModel? Master1Search { get; set; }


### PR DESCRIPTION
## Summary
- initialize default inspection ROI slots when a MasterLayout is constructed so fresh sessions keep four slots available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d421032bc832eabb311ede466894c)