### PR TITLE
Fix EnsureInspectionRoiDefaults visibility

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -18,7 +18,7 @@ namespace BrakeDiscInspector_GUI_ROI
     {
         public MasterLayout()
         {
-            EnsureInspectionRoiDefaults(this);
+            MasterLayoutManager.EnsureInspectionRoiDefaults(this);
         }
 
         public RoiModel? Master1Pattern { get; set; }
@@ -391,7 +391,7 @@ namespace BrakeDiscInspector_GUI_ROI
             prop?.SetValue(roi, index);
         }
 
-        private static InspectionRoiNormalizationResult EnsureInspectionRoiDefaults(MasterLayout layout)
+        internal static InspectionRoiNormalizationResult EnsureInspectionRoiDefaults(MasterLayout layout)
         {
             layout.InspectionRois ??= new ObservableCollection<InspectionRoiConfig>();
             var originalCount = layout.InspectionRois.Count;


### PR DESCRIPTION
## Summary
- call MasterLayoutManager.EnsureInspectionRoiDefaults from the MasterLayout constructor to initialize inspection ROI defaults
- expose EnsureInspectionRoiDefaults so it can be invoked during layout construction

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.sln *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d4fc5d444832ea3ba429f0e41a56d)