### PR TITLE
Fix accessibility of inspection ROI defaults

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -340,7 +340,7 @@ namespace BrakeDiscInspector_GUI_ROI
             return match.Success ? $"inspection-{match.Groups[1].Value}" : key.Trim();
         }
 
-        private sealed record InspectionRoiNormalizationResult(int OriginalCount, int NormalizedCount, bool DuplicatesRemoved);
+        public sealed record InspectionRoiNormalizationResult(int OriginalCount, int NormalizedCount, bool DuplicatesRemoved);
 
         private static int TryParseInspectionIndex(string? key)
         {
@@ -391,7 +391,7 @@ namespace BrakeDiscInspector_GUI_ROI
             prop?.SetValue(roi, index);
         }
 
-        internal static InspectionRoiNormalizationResult EnsureInspectionRoiDefaults(MasterLayout layout)
+        public static InspectionRoiNormalizationResult EnsureInspectionRoiDefaults(MasterLayout layout)
         {
             layout.InspectionRois ??= new ObservableCollection<InspectionRoiConfig>();
             var originalCount = layout.InspectionRois.Count;


### PR DESCRIPTION
## Summary
- expose `InspectionRoiNormalizationResult` so callers can access normalization details
- make `EnsureInspectionRoiDefaults` public to resolve protection level errors when constructing `MasterLayout`

## Testing
- Not run (dotnet SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d50797f20832ea3a19a5ce7cb87d6)