### PR TITLE
Increase snackbar display duration

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3167,7 +3167,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private bool _adornerHadDelta;
         private bool _analysisViewActive;
         private DispatcherTimer? _snackTimer;
-        private readonly TimeSpan _snackDuration = TimeSpan.FromSeconds(3);
+        private readonly TimeSpan _snackDuration = TimeSpan.FromSeconds(7);
 
         private void AppendResizeLog(string msg)
         {


### PR DESCRIPTION
## Summary
- extend the snackbar timer duration so notifications stay visible longer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693ea51c7cd0832eb48ab11daf44f00d)