### PR TITLE
Add VISCONF logging for image and ROI workflows

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Util/VisConfLog.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Util/VisConfLog.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+
+namespace BrakeDiscInspector_GUI_ROI.Util
+{
+    internal static class VisConfLog
+    {
+        private static readonly object Sync = new();
+        private static readonly string LogDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "BrakeDiscInspector",
+            "logs");
+
+        private static readonly string RoiCoordsPath = Path.Combine(LogDirectory, "roi_load_coords.log");
+        private static readonly string AnalyzeMasterPath = Path.Combine(LogDirectory, "roi_analyze_master.log");
+
+        public static string FileNameOrEmpty(string? path)
+            => string.IsNullOrWhiteSpace(path) ? string.Empty : Path.GetFileName(path);
+
+        public static void Gui(string message) => GuiLog.Info(message);
+
+        public static void GuiAndRoi(string message)
+        {
+            Gui(message);
+            Roi(message);
+        }
+
+        public static void Roi(string message) => WriteLine(RoiCoordsPath, message);
+
+        public static void AnalyzeMaster(string message) => WriteLine(AnalyzeMasterPath, message);
+
+        private static void WriteLine(string path, string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            try
+            {
+                lock (Sync)
+                {
+                    Directory.CreateDirectory(LogDirectory);
+                    var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {message}{Environment.NewLine}";
+                    File.AppendAllText(path, line);
+                }
+            }
+            catch
+            {
+                // Never throw from logging utilities.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared VISCONF logger helpers to include image keys and filenames in GUI and alignment logs
- log VISCONF events for image loads, analyze master runs, ROI saves, and applied reposition transforms with structured metadata
- capture master anchor context and ROI deltas to provide visual confirmation across the inspection workflow

## Testing
- `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj` *(fails: dotnet command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693eacf32e58832e818dc2805f8d5196)