### PR TITLE
Disable ROI scaling in alignment

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/InspectionAlignmentHelperTests.cs
@@ -61,7 +61,7 @@ public class InspectionAlignmentHelperTests
     }
 
     [Fact]
-    public void MoveInspectionTo_AppliesRotationAndScale_WhenNotDisabled()
+    public void MoveInspectionTo_AppliesRotation_WithoutScaling()
     {
         var baselineInspection = new RoiModel
         {
@@ -78,10 +78,10 @@ public class InspectionAlignmentHelperTests
 
         InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
 
-        Assert.Equal(-9, target.X, 6);
-        Assert.Equal(12, target.Y, 6);
-        Assert.Equal(8, target.Width, 6);
-        Assert.Equal(12, target.Height, 6);
+        Assert.Equal(-4, target.X, 6);
+        Assert.Equal(7, target.Y, 6);
+        Assert.Equal(4, target.Width, 6);
+        Assert.Equal(6, target.Height, 6);
         Assert.Equal(100, target.AngleDeg, 6);
     }
 
@@ -103,10 +103,10 @@ public class InspectionAlignmentHelperTests
 
         InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
 
-        Assert.Equal(11, target.X, 6);
-        Assert.Equal(12, target.Y, 6);
-        Assert.Equal(8, target.Width, 6);
-        Assert.Equal(12, target.Height, 6);
+        Assert.Equal(-4, target.X, 6);
+        Assert.Equal(7, target.Y, 6);
+        Assert.Equal(4, target.Width, 6);
+        Assert.Equal(6, target.Height, 6);
         Assert.Equal(10, target.AngleDeg, 6);
     }
 
@@ -153,7 +153,7 @@ public class InspectionAlignmentHelperTests
 
         InspectionAlignmentHelper.MoveInspectionTo(target, baselineInspection, MasterAnchorChoice.Master1, anchors);
 
-        Assert.Equal(6, target.X, 6);
+        Assert.Equal(-4, target.X, 6);
         Assert.Equal(7, target.Y, 6);
         Assert.Equal(4, target.Width, 6);
         Assert.Equal(6, target.Height, 6);
@@ -206,8 +206,8 @@ public class InspectionAlignmentHelperTests
         var cosA = Math.Cos(angleDelta);
         var sinA = Math.Sin(angleDelta);
         var expectedOffset = new Point2d(
-            (baselineOffset.X * cosA - baselineOffset.Y * sinA) * scale,
-            (baselineOffset.X * sinA + baselineOffset.Y * cosA) * scale);
+            (baselineOffset.X * cosA - baselineOffset.Y * sinA),
+            (baselineOffset.X * sinA + baselineOffset.Y * cosA));
 
         var expectedCenter = new Point2d(detectedM2.X + expectedOffset.X, detectedM2.Y + expectedOffset.Y);
         Assert.Equal(expectedCenter.X, target.X, 6);

--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -59,7 +59,11 @@ internal static class InspectionAlignmentHelper
 
         var rotForCenter = anchors.AngleDeltaGlobal;
         var rotForAngle = anchors.DisableRot ? 0.0 : anchors.AngleDeltaGlobal;
-        var scaleEffective = anchors.ScaleLock ? 1.0 : anchors.Scale;
+
+        // ROI scaling is disabled globally: ROIs must keep fixed size/offset across images.
+        // Keep anchors.Scale only for logging/diagnostics.
+        var scaleRequested = anchors.Scale;
+        var scaleEffective = 1.0;
 
         var cosA = Math.Cos(rotForCenter);
         var sinA = Math.Sin(rotForCenter);
@@ -110,10 +114,11 @@ internal static class InspectionAlignmentHelper
                 roiNewCenter.Y - baseCy));
         LogAlign(trace,
             FormattableStringFactory.Create(
-                "[BATCH][ROI] roi={0} applied rot_deg_center={1:0.###} rot_deg_angle={2:0.###} scale={3:0.####} tx={4:0.###} ty={5:0.###} scaleLock={6} disableRot={7}",
+                "[BATCH][ROI] roi={0} applied rot_deg_center={1:0.###} rot_deg_angle={2:0.###} scale_req={3:0.####} scale_applied={4:0.####} tx={5:0.###} ty={6:0.###} scaleLock={7} disableRot={8}",
                 inspectionTarget.Label ?? inspectionTarget.Id,
                 rotForCenter * 180.0 / Math.PI,
                 rotForAngle * 180.0 / Math.PI,
+                scaleRequested,
                 scaleEffective,
                 tx,
                 ty,


### PR DESCRIPTION
## Summary
- force ROI alignment to apply no scaling and keep sizes constant
- log requested versus applied scale for diagnostics
- adjust alignment helper tests to reflect scale-free behavior

## Testing
- Not run (dotnet not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693efe8380a4832eb98b9431c0af080d)