### PR TITLE
Modernize WPF buttons with Wpf.Ui icons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -4,6 +4,11 @@
              xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Theme.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Styles/Controls.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:m="clr-namespace:BrakeDiscInspector_GUI_ROI.Models"
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
+        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         Title="BrakeDiscInspector"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
@@ -19,7 +20,7 @@
     <Style x:Key="ForegroundWhiteStyle" TargetType="{x:Type StackPanel}">
       <Setter Property="TextElement.Foreground" Value="Black"/>
     </Style>
-    <Style x:Key="IconOnlyButton" TargetType="Button">
+    <Style x:Key="IconOnlyButton" TargetType="{x:Type ui:Button}">
       <Setter Property="Width" Value="36"/>
       <Setter Property="Height" Value="36"/>
       <Setter Property="Padding" Value="0"/>
@@ -55,21 +56,33 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
           <StackPanel x:Name="SetupInspectRoot" Margin="8" Orientation="Vertical">
             <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-              <Button x:Name="BtnLoadImage"
-                      Content="Load Picture"
-                      Margin="0,0,8,0"
-                      MinWidth="120"
-                      ToolTip="Open an image"
-                      Click="BtnLoadImage_Click"/>
-              <Button x:Name="BtnLoadLayout"
-                      Content="Load Layout"
-                      Margin="0,0,8,0"
-                      MinWidth="120"
-                      Click="BtnLoadLayout_Click"/>
-              <Button x:Name="BtnSaveLayout"
-                      Content="Save Layout"
-                      MinWidth="120"
-                      Click="BtnSaveLayout_Click"/>
+              <ui:Button x:Name="BtnLoadImage"
+                         Margin="0,0,8,0"
+                         MinWidth="120"
+                         ToolTip="Open an image"
+                         Click="BtnLoadImage_Click">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                  <ui:SymbolIcon Symbol="Image" Margin="0,0,8,0"/>
+                  <TextBlock Text="Load Picture" VerticalAlignment="Center"/>
+                </StackPanel>
+              </ui:Button>
+              <ui:Button x:Name="BtnLoadLayout"
+                         Margin="0,0,8,0"
+                         MinWidth="120"
+                         Click="BtnLoadLayout_Click">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                  <ui:SymbolIcon Symbol="Folder" Margin="0,0,8,0"/>
+                  <TextBlock Text="Load Layout" VerticalAlignment="Center"/>
+                </StackPanel>
+              </ui:Button>
+              <ui:Button x:Name="BtnSaveLayout"
+                         MinWidth="120"
+                         Click="BtnSaveLayout_Click">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                  <TextBlock Text="Save Layout" VerticalAlignment="Center"/>
+                </StackPanel>
+              </ui:Button>
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0"/>
@@ -97,21 +110,41 @@
                 </ListBox>
 
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
-                  <Button Content="Refresh"
-                          Command="{Binding LayoutProfiles.RefreshCommand}"
-                          Margin="0,0,4,0"/>
-                  <Button Content="Load Selected"
-                          Command="{Binding LayoutProfiles.LoadSelectedCommand}"
-                          Margin="0,0,4,0"/>
-                  <Button Content="Save Current as"
-                          Margin="0,0,4,0"
-                          Click="SaveCurrentLayoutAs_Click"/>
-                  <Button Content="Delete Selected"
-                          Command="{Binding LayoutProfiles.DeleteSelectedCommand}"/>
-                  <Button Content="Blank Dataset"
-                          Margin="4,0,0,0"
-                          Command="{Binding BlankDatasetCommand}"
-                          ToolTip="Create a blank dataset for the current layout"/>
+                  <ui:Button Command="{Binding LayoutProfiles.RefreshCommand}"
+                             Margin="0,0,4,0">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="ArrowClockwise" Margin="0,0,8,0"/>
+                      <TextBlock Text="Refresh" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Command="{Binding LayoutProfiles.LoadSelectedCommand}"
+                             Margin="0,0,4,0">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="ArrowRight" Margin="0,0,8,0"/>
+                      <TextBlock Text="Load Selected" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="0,0,4,0"
+                             Click="SaveCurrentLayoutAs_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                      <TextBlock Text="Save Current as" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Command="{Binding LayoutProfiles.DeleteSelectedCommand}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                      <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="4,0,0,0"
+                             Command="{Binding BlankDatasetCommand}"
+                             ToolTip="Create a blank dataset for the current layout">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                      <TextBlock Text="Blank Dataset" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
                 </StackPanel>
 
               </StackPanel>
@@ -149,23 +182,35 @@
                     </ComboBox>
                   </Grid>
                   <WrapPanel>
-                    <Button x:Name="BtnM1_Create"
-                            Content="Create"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Click="BtnM1_Create_Click"/>
-                    <Button x:Name="BtnEditM1"
-                            Content="Edit Master 1"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Margin="4,0,0,0"
-                            Click="BtnEditM1_Click"/>
-                    <Button x:Name="BtnM1_Remove"
-                            Content="Remove"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Margin="4,0,0,0"
-                            Click="BtnM1_Remove_Click"/>
+                    <ui:Button x:Name="BtnM1_Create"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Click="BtnM1_Create_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                        <TextBlock Text="Create" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
+                    <ui:Button x:Name="BtnEditM1"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Margin="4,0,0,0"
+                               Click="BtnEditM1_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                        <TextBlock Text="Edit Master 1" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
+                    <ui:Button x:Name="BtnM1_Remove"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Margin="4,0,0,0"
+                               Click="BtnM1_Remove_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                        <TextBlock Text="Remove" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
                   </WrapPanel>
                 </StackPanel>
 
@@ -192,32 +237,48 @@
                     </ComboBox>
                   </Grid>
                   <WrapPanel>
-                    <Button x:Name="BtnM2_Create"
-                            Content="Create"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Click="BtnM2_Create_Click"/>
-                    <Button x:Name="BtnEditM2"
-                            Content="Edit Master 2"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Margin="4,0,0,0"
-                            Click="BtnEditM2_Click"/>
-                    <Button x:Name="BtnM2_Remove"
-                            Content="Remove"
-                            MinHeight="26"
-                            Padding="8,4"
-                            Margin="4,0,0,0"
-                            Click="BtnM2_Remove_Click"/>
+                    <ui:Button x:Name="BtnM2_Create"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Click="BtnM2_Create_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                        <TextBlock Text="Create" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
+                    <ui:Button x:Name="BtnEditM2"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Margin="4,0,0,0"
+                               Click="BtnEditM2_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                        <TextBlock Text="Edit Master 2" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
+                    <ui:Button x:Name="BtnM2_Remove"
+                               MinHeight="26"
+                               Padding="8,4"
+                               Margin="4,0,0,0"
+                               Click="BtnM2_Remove_Click">
+                      <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                        <TextBlock Text="Remove" VerticalAlignment="Center"/>
+                      </StackPanel>
+                    </ui:Button>
                   </WrapPanel>
                 </StackPanel>
               </Grid>
             </GroupBox>
 
             <WrapPanel Margin="0,12,0,12">
-              <Button x:Name="BtnClearCanvas"
-                      Content="Clear Canvas"
-                      Click="BtnClearCanvas_Click"/>
+              <ui:Button x:Name="BtnClearCanvas"
+                         Click="BtnClearCanvas_Click">
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                  <ui:SymbolIcon Symbol="Eraser" Margin="0,0,8,0"/>
+                  <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
+                </StackPanel>
+              </ui:Button>
             </WrapPanel>
 
             <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
@@ -252,10 +313,14 @@
                     <TextBox Width="70"
                              Text="{Binding AnalyzeAngToleranceDeg, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:F2}}"/>
                   </StackPanel>
-                  <Button x:Name="BtnAnalyzeMaster"
-                          Content="Force Analyze Master"
-                          Margin="0,8,0,0"
-                          Click="BtnAnalyzeMaster_Click"/>
+                  <ui:Button x:Name="BtnAnalyzeMaster"
+                             Margin="0,8,0,0"
+                             Click="BtnAnalyzeMaster_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="Target" Margin="0,0,8,0"/>
+                      <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
                 </StackPanel>
               </GroupBox>
 
@@ -319,7 +384,12 @@
                       <TextBox x:Name="TxtSMax" Width="60" Margin="4,0,0,0" Text="1.05"/>
                     </StackPanel>
                     <WrapPanel>
-                      <Button x:Name="BtnSavePreset" Content="Save Preset" Click="BtnSavePreset_Click" Margin="0,0,8,0"/>
+                      <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                          <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                          <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
+                        </StackPanel>
+                      </ui:Button>
                     </WrapPanel>
                   </StackPanel>
                 </GroupBox>
@@ -336,25 +406,32 @@
                             ItemsSource="{Binding AvailableShapes}"
                             SelectedItem="{Binding DataContext.InspectionRois[0].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                             SelectionChanged="InspectionShape_SelectionChanged"/>
-                  <Button x:Name="BtnCreateInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Tag="1"
-                          Click="BtnCreateInspection_Click"
-                          Content="Create ROI 1"/>
-                  <Button Margin="4,0,0,0"
-                          Padding="12,4"
-                          MinHeight="26"
-                          DataContext="{Binding DataContext.InspectionRois[0], ElementName=WorkflowHost}"
-                          Click="BtnToggleEdit_Click"
-                          IsEnabled="{Binding Enabled}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                  <ui:Button x:Name="BtnCreateInspection1"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             MinHeight="26"
+                             Tag="1"
+                             Click="BtnCreateInspection_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <TextBlock Text="Create ROI 1" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="4,0,0,0"
+                             Padding="12,4"
+                             MinHeight="26"
+                             DataContext="{Binding DataContext.InspectionRois[0], ElementName=WorkflowHost}"
+                             Click="BtnToggleEdit_Click"
+                             IsEnabled="{Binding Enabled}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
                         <Setter Property="Content">
                           <Setter.Value>
-                            <Binding Path="Index" StringFormat="Edit ROI{0}"/>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
+                            </StackPanel>
                           </Setter.Value>
                         </Setter>
                         <Style.Triggers>
@@ -367,23 +444,33 @@
                           <DataTrigger Binding="{Binding IsEditable}" Value="True">
                             <Setter Property="Content">
                               <Setter.Value>
-                                <Binding Path="Index" StringFormat="Save ROI{0}"/>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
+                                </StackPanel>
                               </Setter.Value>
                             </Setter>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddOkInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to OK"
-                          Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection1}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddOkInspection1"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection1}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -393,17 +480,24 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddNgInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to NG"
-                          Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection1}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddNgInspection1"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection1}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -413,24 +507,31 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnRemoveInspection1"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Remove 1"
-                          Click="BtnRemoveInspection1_Click">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnRemoveInspection1"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Click="BtnRemoveInspection1_Click">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <TextBlock Text="Remove 1" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
+                    </ui:Button.Style>
+                  </ui:Button>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,4" VerticalAlignment="Center">
@@ -441,25 +542,32 @@
                             ItemsSource="{Binding AvailableShapes}"
                             SelectedItem="{Binding DataContext.InspectionRois[1].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                             SelectionChanged="InspectionShape_SelectionChanged"/>
-                  <Button x:Name="BtnCreateInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Tag="2"
-                          Click="BtnCreateInspection_Click"
-                          Content="Create ROI 2"/>
-                  <Button Margin="4,0,0,0"
-                          Padding="12,4"
-                          MinHeight="26"
-                          DataContext="{Binding DataContext.InspectionRois[1], ElementName=WorkflowHost}"
-                          Click="BtnToggleEdit_Click"
-                          IsEnabled="{Binding Enabled}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                  <ui:Button x:Name="BtnCreateInspection2"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             MinHeight="26"
+                             Tag="2"
+                             Click="BtnCreateInspection_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <TextBlock Text="Create ROI 2" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="4,0,0,0"
+                             Padding="12,4"
+                             MinHeight="26"
+                             DataContext="{Binding DataContext.InspectionRois[1], ElementName=WorkflowHost}"
+                             Click="BtnToggleEdit_Click"
+                             IsEnabled="{Binding Enabled}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
                         <Setter Property="Content">
                           <Setter.Value>
-                            <Binding Path="Index" StringFormat="Edit ROI{0}"/>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
+                            </StackPanel>
                           </Setter.Value>
                         </Setter>
                         <Style.Triggers>
@@ -472,23 +580,33 @@
                           <DataTrigger Binding="{Binding IsEditable}" Value="True">
                             <Setter Property="Content">
                               <Setter.Value>
-                                <Binding Path="Index" StringFormat="Save ROI{0}"/>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
+                                </StackPanel>
                               </Setter.Value>
                             </Setter>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddOkInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to OK"
-                          Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection2}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddOkInspection2"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection2}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection2, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -498,17 +616,24 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddNgInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to NG"
-                          Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection2}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddNgInspection2"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection2}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection2, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -518,24 +643,31 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnRemoveInspection2"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Remove 2"
-                          Click="BtnRemoveInspection2_Click">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnRemoveInspection2"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Click="BtnRemoveInspection2_Click">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <TextBlock Text="Remove 2" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection2, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
+                    </ui:Button.Style>
+                  </ui:Button>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,4" VerticalAlignment="Center">
@@ -546,25 +678,32 @@
                             ItemsSource="{Binding AvailableShapes}"
                             SelectedItem="{Binding DataContext.InspectionRois[2].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                             SelectionChanged="InspectionShape_SelectionChanged"/>
-                  <Button x:Name="BtnCreateInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Tag="3"
-                          Click="BtnCreateInspection_Click"
-                          Content="Create ROI 3"/>
-                  <Button Margin="4,0,0,0"
-                          Padding="12,4"
-                          MinHeight="26"
-                          DataContext="{Binding DataContext.InspectionRois[2], ElementName=WorkflowHost}"
-                          Click="BtnToggleEdit_Click"
-                          IsEnabled="{Binding Enabled}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                  <ui:Button x:Name="BtnCreateInspection3"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             MinHeight="26"
+                             Tag="3"
+                             Click="BtnCreateInspection_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <TextBlock Text="Create ROI 3" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="4,0,0,0"
+                             Padding="12,4"
+                             MinHeight="26"
+                             DataContext="{Binding DataContext.InspectionRois[2], ElementName=WorkflowHost}"
+                             Click="BtnToggleEdit_Click"
+                             IsEnabled="{Binding Enabled}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
                         <Setter Property="Content">
                           <Setter.Value>
-                            <Binding Path="Index" StringFormat="Edit ROI{0}"/>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
+                            </StackPanel>
                           </Setter.Value>
                         </Setter>
                         <Style.Triggers>
@@ -577,23 +716,33 @@
                           <DataTrigger Binding="{Binding IsEditable}" Value="True">
                             <Setter Property="Content">
                               <Setter.Value>
-                                <Binding Path="Index" StringFormat="Save ROI{0}"/>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
+                                </StackPanel>
                               </Setter.Value>
                             </Setter>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddOkInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to OK"
-                          Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection3}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddOkInspection3"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection3}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection3, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -603,17 +752,24 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddNgInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to NG"
-                          Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection3}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddNgInspection3"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection3}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection3, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -623,24 +779,31 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnRemoveInspection3"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Remove 3"
-                          Click="BtnRemoveInspection3_Click">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnRemoveInspection3"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Click="BtnRemoveInspection3_Click">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <TextBlock Text="Remove 3" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection3, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
+                    </ui:Button.Style>
+                  </ui:Button>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Margin="0,4,0,12" VerticalAlignment="Center">
@@ -651,25 +814,32 @@
                             ItemsSource="{Binding AvailableShapes}"
                             SelectedItem="{Binding DataContext.InspectionRois[3].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                             SelectionChanged="InspectionShape_SelectionChanged"/>
-                  <Button x:Name="BtnCreateInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          MinHeight="26"
-                          Tag="4"
-                          Click="BtnCreateInspection_Click"
-                          Content="Create ROI 4"/>
-                  <Button Margin="4,0,0,0"
-                          Padding="12,4"
-                          MinHeight="26"
-                          DataContext="{Binding DataContext.InspectionRois[3], ElementName=WorkflowHost}"
-                          Click="BtnToggleEdit_Click"
-                          IsEnabled="{Binding Enabled}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                  <ui:Button x:Name="BtnCreateInspection4"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             MinHeight="26"
+                             Tag="4"
+                             Click="BtnCreateInspection_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <TextBlock Text="Create ROI 4" VerticalAlignment="Center"/>
+                    </StackPanel>
+                  </ui:Button>
+                  <ui:Button Margin="4,0,0,0"
+                             Padding="12,4"
+                             MinHeight="26"
+                             DataContext="{Binding DataContext.InspectionRois[3], ElementName=WorkflowHost}"
+                             Click="BtnToggleEdit_Click"
+                             IsEnabled="{Binding Enabled}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
                         <Setter Property="Content">
                           <Setter.Value>
-                            <Binding Path="Index" StringFormat="Edit ROI{0}"/>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
+                            </StackPanel>
                           </Setter.Value>
                         </Setter>
                         <Style.Triggers>
@@ -682,23 +852,33 @@
                           <DataTrigger Binding="{Binding IsEditable}" Value="True">
                             <Setter Property="Content">
                               <Setter.Value>
-                                <Binding Path="Index" StringFormat="Save ROI{0}"/>
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
+                                </StackPanel>
                               </Setter.Value>
                             </Setter>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddOkInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to OK"
-                          Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection4}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddOkInspection4"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection4}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection4, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -708,17 +888,24 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnAddNgInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Add to NG"
-                          Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
-                          CommandParameter="{Binding Inspection4}">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnAddNgInspection4"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
+                             CommandParameter="{Binding Inspection4}">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection4, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
@@ -728,24 +915,31 @@
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
-                  <Button x:Name="BtnRemoveInspection4"
-                          Margin="4,0,0,0"
-                          Padding="4,2"
-                          Content="Remove 4"
-                          Click="BtnRemoveInspection4_Click">
-                    <Button.Style>
-                      <Style TargetType="Button">
+                    </ui:Button.Style>
+                  </ui:Button>
+                  <ui:Button x:Name="BtnRemoveInspection4"
+                             Margin="4,0,0,0"
+                             Padding="4,2"
+                             Click="BtnRemoveInspection4_Click">
+                    <ui:Button.Style>
+                      <Style TargetType="{x:Type ui:Button}">
                         <Setter Property="IsEnabled" Value="True"/>
+                        <Setter Property="Content">
+                          <Setter.Value>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <TextBlock Text="Remove 4" VerticalAlignment="Center"/>
+                            </StackPanel>
+                          </Setter.Value>
+                        </Setter>
                         <Style.Triggers>
                           <DataTrigger Binding="{Binding DataContext.Inspection4, ElementName=WorkflowHost}" Value="{x:Null}">
                             <Setter Property="IsEnabled" Value="False"/>
                           </DataTrigger>
                         </Style.Triggers>
                       </Style>
-                    </Button.Style>
-                  </Button>
+                    </ui:Button.Style>
+                  </ui:Button>
                 </StackPanel>
                 
                 <workflow:WorkflowControl x:Name="WorkflowHost" Margin="0,12,0,0"/>
@@ -771,35 +965,38 @@
                      AcceptsReturn="True"
                      VerticalScrollBarVisibility="Auto"
                      Text="{Binding BatchFolder, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Margin="8,0,0,0"
-                    Padding="12,4"
-                    Command="{Binding BrowseBatchFolderCommand}">
+            <ui:Button Margin="8,0,0,0"
+                       Padding="12,4"
+                       Command="{Binding BrowseBatchFolderCommand}">
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <TextBlock Text="&#xE8B7;" FontFamily="Segoe MDL2 Assets" Margin="0,0,6,0"/>
-                <TextBlock Text="Browse"/>
+                <ui:SymbolIcon Symbol="FolderOpen" Margin="0,0,8,0"/>
+                <TextBlock Text="Browse" VerticalAlignment="Center"/>
               </StackPanel>
-            </Button>
+            </ui:Button>
 
             <!-- ▶ Play = Start/Resume -->
-            <Button Style="{StaticResource IconOnlyButton}"
-                    ToolTip="Play / Start or Resume"
-                    Command="{Binding StartBatchCommand}">
-              <TextBlock Text="▶" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            </Button>
+            <ui:Button Style="{StaticResource IconOnlyButton}"
+                       ToolTip="Play / Start or Resume"
+                       AutomationProperties.Name="Play"
+                       Command="{Binding StartBatchCommand}">
+              <ui:SymbolIcon Symbol="Play"/>
+            </ui:Button>
 
             <!-- ⏸ Pause -->
-            <Button Style="{StaticResource IconOnlyButton}"
-                    ToolTip="Pause"
-                    Command="{Binding PauseBatchCommand}">
-              <TextBlock Text="⏸" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            </Button>
+            <ui:Button Style="{StaticResource IconOnlyButton}"
+                       ToolTip="Pause"
+                       AutomationProperties.Name="Pause"
+                       Command="{Binding PauseBatchCommand}">
+              <ui:SymbolIcon Symbol="Pause"/>
+            </ui:Button>
 
             <!-- ■ Stop -->
-            <Button Style="{StaticResource IconOnlyButton}"
-                    ToolTip="Stop"
-                    Command="{Binding StopBatchCommand}">
-              <TextBlock Text="■" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-            </Button>
+            <ui:Button Style="{StaticResource IconOnlyButton}"
+                       ToolTip="Stop"
+                       AutomationProperties.Name="Stop"
+                       Command="{Binding StopBatchCommand}">
+              <ui:SymbolIcon Symbol="Stop"/>
+            </ui:Button>
 
             <TextBlock Margin="12,0,0,0"
                        VerticalAlignment="Center"
@@ -936,15 +1133,23 @@
             <TextBox Width="40"
                      Text="{Binding Slot}" IsReadOnly="True"/>
 
-            <Button Margin="12,0,0,0"
-                    Padding="10,3"
-                    Content="Connect"
-                    Command="{Binding ConnectCommand}"/>
+            <ui:Button Margin="12,0,0,0"
+                       Padding="10,3"
+                       Command="{Binding ConnectCommand}">
+              <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <ui:SymbolIcon Symbol="PlugConnected" Margin="0,0,8,0"/>
+                <TextBlock Text="Connect" VerticalAlignment="Center"/>
+              </StackPanel>
+            </ui:Button>
 
-            <Button Margin="4,0,0,0"
-                    Padding="10,3"
-                    Content="Disconnect"
-                    Command="{Binding DisconnectCommand}"/>
+            <ui:Button Margin="4,0,0,0"
+                       Padding="10,3"
+                       Command="{Binding DisconnectCommand}">
+              <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <ui:SymbolIcon Symbol="PlugDisconnected" Margin="0,0,8,0"/>
+                <TextBlock Text="Disconnect" VerticalAlignment="Center"/>
+              </StackPanel>
+            </ui:Button>
 
             <TextBlock Margin="12,0,0,0"
                        VerticalAlignment="Center"
@@ -968,11 +1173,15 @@
                       <TextBlock Text="{Binding DisplayName}"
                                  VerticalAlignment="Center"
                                  Width="140"/>
-                      <Button Content="Enable"
-                              Margin="8,0,0,0"
-                              Padding="6,2"
-                              Command="{Binding DataContext.ToggleInputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
-                              CommandParameter="{Binding Id}"/>
+                      <ui:Button Margin="8,0,0,0"
+                                 Padding="6,2"
+                                 Command="{Binding DataContext.ToggleInputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                 CommandParameter="{Binding Id}">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                          <ui:SymbolIcon Symbol="Power" Margin="0,0,6,0"/>
+                          <TextBlock Text="Enable" VerticalAlignment="Center"/>
+                        </StackPanel>
+                      </ui:Button>
                     </DockPanel>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -990,11 +1199,15 @@
                       <TextBlock Text="{Binding DisplayName}"
                                  VerticalAlignment="Center"
                                  Width="140"/>
-                      <Button Content="Enable"
-                              Margin="8,0,0,0"
-                              Padding="6,2"
-                              Command="{Binding DataContext.ToggleOutputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
-                              CommandParameter="{Binding Id}"/>
+                      <ui:Button Margin="8,0,0,0"
+                                 Padding="6,2"
+                                 Command="{Binding DataContext.ToggleOutputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
+                                 CommandParameter="{Binding Id}">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                          <ui:SymbolIcon Symbol="Power" Margin="0,0,6,0"/>
+                          <TextBlock Text="Enable" VerticalAlignment="Center"/>
+                        </StackPanel>
+                      </ui:Button>
                     </DockPanel>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -5,6 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:m="clr-namespace:BrakeDiscInspector_GUI_ROI.Models"
              xmlns:w="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              mc:Ignorable="d"
              d:DesignHeight="600"
              d:DesignWidth="480">
@@ -49,8 +50,13 @@
                     <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="8,4,8,0">
                         <TextBox Width="260" Margin="0,0,8,0"
                                  Text="{Binding BackendBaseUrl, UpdateSourceTrigger=PropertyChanged}"/>
-                        <Button Content="Health" Padding="12,4"
-                                Command="{Binding RefreshHealthCommand}"/>
+                        <ui:Button Padding="12,4"
+                                   Command="{Binding RefreshHealthCommand}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="Pulse" Margin="0,0,8,0"/>
+                                <TextBlock Text="Health" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
                     </StackPanel>
 
                     <TextBlock Grid.Row="3" Grid.Column="2" Margin="8,4,0,0"
@@ -89,9 +95,13 @@
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
-                            <Button Content="Infer Enabled"
-                                    Command="{Binding InferEnabledRoisCommand}"
-                                    Padding="12,4"/>
+                            <ui:Button Command="{Binding InferEnabledRoisCommand}"
+                                       Padding="12,4">
+                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                    <ui:SymbolIcon Symbol="Checkmark" Margin="0,0,8,0"/>
+                                    <TextBlock Text="Infer Enabled" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </ui:Button>
                         </StackPanel>
                     </StackPanel>
                     <TabControl ItemsSource="{Binding InspectionRois}"
@@ -120,29 +130,35 @@
                                         <TextBlock Text="Name" Width="70" VerticalAlignment="Center"/>
                                         <TextBox Text="{Binding Name}" Width="200" Margin="0,0,12,0"/>
                                         <CheckBox Content="Enabled" IsChecked="{Binding Enabled}" VerticalAlignment="Center"/>
-                                        <Button Margin="8,0,0,0"
-                                                Padding="12,4"
-                                                Click="BtnToggleEdit_Click"
-                                                IsEnabled="{Binding Enabled}">
-                                            <Button.Style>
-                                                <Style TargetType="Button">
+                                        <ui:Button Margin="8,0,0,0"
+                                                   Padding="12,4"
+                                                   Click="BtnToggleEdit_Click"
+                                                   IsEnabled="{Binding Enabled}">
+                                            <ui:Button.Style>
+                                                <Style TargetType="{x:Type ui:Button}">
                                                     <Setter Property="Content">
                                                         <Setter.Value>
-                                                            <Binding Path="Index" StringFormat="Edit ROI{0}"/>
+                                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                                <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                                                                <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
+                                                            </StackPanel>
                                                         </Setter.Value>
                                                     </Setter>
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsEditable}" Value="True">
                                                             <Setter Property="Content">
                                                                 <Setter.Value>
-                                                                    <Binding Path="Index" StringFormat="Save ROI{0}"/>
+                                                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                                        <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                                                        <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
+                                                                    </StackPanel>
                                                                 </Setter.Value>
                                                             </Setter>
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
-                                            </Button.Style>
-                                        </Button>
+                                            </ui:Button.Style>
+                                        </ui:Button>
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,8,0,0">
@@ -174,12 +190,21 @@
                                         </Grid.ColumnDefinitions>
                                         <TextBlock Text="Dataset" VerticalAlignment="Center" Margin="0,0,8,0"/>
                                         <TextBox Grid.Column="1" Text="{Binding DatasetPath}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                                        <Button Grid.Column="2"
-                                                Content="Browse..."
-                                                Padding="12,4"
-                                                Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-                                        <Button Grid.Column="3" Content="Open Folder" Padding="12,4"
-                                                Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                                        <ui:Button Grid.Column="2"
+                                                   Padding="12,4"
+                                                   Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="FolderOpen" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Browse..." VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button Grid.Column="3" Padding="12,4"
+                                                   Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Folder" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Open Folder" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
                                     </Grid>
 
                                     <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,8,0,0">
@@ -259,26 +284,46 @@
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
-                                        <Button Content="Load model"
-                                                Padding="12,4"
-                                                Margin="0,0,8,0"
-                                                Tag="{Binding Index}"
-                                                Click="LoadModelButton_Click"/>
-                                        <Button Content="Delete Selected"
-                                                Padding="12,4"
-                                                Margin="0,0,8,0"
-                                                Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-                                        <Button Content="Train"
-                                                Padding="12,4"
-                                                Margin="0,0,8,0"
-                                                Command="{Binding DataContext.TrainSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-                                        <Button Content="Calibrate"
-                                                Padding="12,4"
-                                                Margin="0,0,8,0"
-                                                Command="{Binding DataContext.CalibrateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-                                        <Button Content="Evaluate ROI"
-                                                Padding="12,4"
-                                                Command="{Binding DataContext.EvaluateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                                        <ui:Button Padding="12,4"
+                                                   Margin="0,0,8,0"
+                                                   Tag="{Binding Index}"
+                                                   Click="LoadModelButton_Click">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="ArrowDownload" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Load model" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button Padding="12,4"
+                                                   Margin="0,0,8,0"
+                                                   Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button Padding="12,4"
+                                                   Margin="0,0,8,0"
+                                                   Command="{Binding DataContext.TrainSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Rocket" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Train" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button Padding="12,4"
+                                                   Margin="0,0,8,0"
+                                                   Command="{Binding DataContext.CalibrateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Wrench" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Calibrate" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button Padding="12,4"
+                                                   Command="{Binding DataContext.EvaluateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="Search" Margin="0,0,8,0"/>
+                                                <TextBlock Text="Evaluate ROI" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
                                     </StackPanel>
 
                                     <StackPanel Grid.Row="8" Orientation="Horizontal" Margin="0,8,0,0">
@@ -331,9 +376,13 @@
             </GroupBox>
 
             <WrapPanel Margin="0,0,0,12">
-                <Button Content="Clear Canvas"
-                        Padding="12,4"
-                        Click="ClearCanvasButton_Click"/>
+                <ui:Button Padding="12,4"
+                           Click="ClearCanvasButton_Click">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="Eraser" Margin="0,0,8,0"/>
+                        <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </ui:Button>
             </WrapPanel>
 
             <GroupBox Header="Regions">


### PR DESCRIPTION
## Summary
- replace legacy buttons in MainWindow and WorkflowControl with Wpf.Ui Fluent buttons and clear icon+text content
- update dynamic edit/save ROI controls and batch/comms actions to use symbol icons while preserving bindings
- merge Wpf.Ui resource dictionaries into the application to apply the Fluent style globally

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69419bf5ab8c832bba6a019332c75386)