### PR TITLE
Use Wpf.Ui 3.4.2.7 and enum-based icons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
@@ -18,7 +18,8 @@
                 <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
                 <PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
                 <PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.11.0.20250507" />
-<PackageReference Include="S7netplus" Version="0.20.0" />
+                <PackageReference Include="Wpf.Ui" Version="3.4.2.7" />
+                <PackageReference Include="S7netplus" Version="0.20.0" />
                 <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
         </ItemGroup>
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -62,7 +62,7 @@
                          ToolTip="Open an image"
                          Click="BtnLoadImage_Click">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                  <ui:SymbolIcon Symbol="Image" Margin="0,0,8,0"/>
+                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Image24}" Margin="0,0,8,0"/>
                   <TextBlock Text="Load Picture" VerticalAlignment="Center"/>
                 </StackPanel>
               </ui:Button>
@@ -71,7 +71,7 @@
                          MinWidth="120"
                          Click="BtnLoadLayout_Click">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                  <ui:SymbolIcon Symbol="Folder" Margin="0,0,8,0"/>
+                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Folder24}" Margin="0,0,8,0"/>
                   <TextBlock Text="Load Layout" VerticalAlignment="Center"/>
                 </StackPanel>
               </ui:Button>
@@ -79,7 +79,7 @@
                          MinWidth="120"
                          Click="BtnSaveLayout_Click">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                   <TextBlock Text="Save Layout" VerticalAlignment="Center"/>
                 </StackPanel>
               </ui:Button>
@@ -113,27 +113,27 @@
                   <ui:Button Command="{Binding LayoutProfiles.RefreshCommand}"
                              Margin="0,0,4,0">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="ArrowClockwise" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowClockwise24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Refresh" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
                   <ui:Button Command="{Binding LayoutProfiles.LoadSelectedCommand}"
                              Margin="0,0,4,0">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="ArrowRight" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowRight24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Load Selected" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
                   <ui:Button Margin="0,0,4,0"
                              Click="SaveCurrentLayoutAs_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Save Current as" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
                   <ui:Button Command="{Binding LayoutProfiles.DeleteSelectedCommand}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -141,7 +141,7 @@
                              Command="{Binding BlankDatasetCommand}"
                              ToolTip="Create a blank dataset for the current layout">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Blank Dataset" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -187,7 +187,7 @@
                                Padding="8,4"
                                Click="BtnM1_Create_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Create" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -197,7 +197,7 @@
                                Margin="4,0,0,0"
                                Click="BtnEditM1_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Edit Master 1" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -207,7 +207,7 @@
                                Margin="4,0,0,0"
                                Click="BtnM1_Remove_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Remove" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -242,7 +242,7 @@
                                Padding="8,4"
                                Click="BtnM2_Create_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Add" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Create" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -252,7 +252,7 @@
                                Margin="4,0,0,0"
                                Click="BtnEditM2_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Edit Master 2" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -262,7 +262,7 @@
                                Margin="4,0,0,0"
                                Click="BtnM2_Remove_Click">
                       <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Remove" VerticalAlignment="Center"/>
                       </StackPanel>
                     </ui:Button>
@@ -275,7 +275,7 @@
               <ui:Button x:Name="BtnClearCanvas"
                          Click="BtnClearCanvas_Click">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                  <ui:SymbolIcon Symbol="Eraser" Margin="0,0,8,0"/>
+                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0"/>
                   <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
                 </StackPanel>
               </ui:Button>
@@ -317,7 +317,7 @@
                              Margin="0,8,0,0"
                              Click="BtnAnalyzeMaster_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="Target" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -386,7 +386,7 @@
                     <WrapPanel>
                       <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                          <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                          <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                           <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
                         </StackPanel>
                       </ui:Button>
@@ -413,7 +413,7 @@
                              Tag="1"
                              Click="BtnCreateInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Create ROI 1" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -429,7 +429,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                               <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -445,7 +445,7 @@
                             <Setter Property="Content">
                               <Setter.Value>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                                   <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
                                 </StackPanel>
                               </Setter.Value>
@@ -466,7 +466,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -493,7 +493,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -519,7 +519,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Remove 1" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -549,7 +549,7 @@
                              Tag="2"
                              Click="BtnCreateInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Create ROI 2" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -565,7 +565,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                               <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -581,7 +581,7 @@
                             <Setter Property="Content">
                               <Setter.Value>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                                   <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
                                 </StackPanel>
                               </Setter.Value>
@@ -602,7 +602,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -629,7 +629,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -655,7 +655,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Remove 2" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -685,7 +685,7 @@
                              Tag="3"
                              Click="BtnCreateInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Create ROI 3" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -701,7 +701,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                               <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -717,7 +717,7 @@
                             <Setter Property="Content">
                               <Setter.Value>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                                   <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
                                 </StackPanel>
                               </Setter.Value>
@@ -738,7 +738,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -765,7 +765,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -791,7 +791,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Remove 3" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -821,7 +821,7 @@
                              Tag="4"
                              Click="BtnCreateInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                      <ui:SymbolIcon Symbol="AddSquare" Margin="0,0,8,0"/>
+                      <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" Margin="0,0,8,0"/>
                       <TextBlock Text="Create ROI 4" VerticalAlignment="Center"/>
                     </StackPanel>
                   </ui:Button>
@@ -837,7 +837,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                               <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -853,7 +853,7 @@
                             <Setter Property="Content">
                               <Setter.Value>
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                  <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                  <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                                   <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
                                 </StackPanel>
                               </Setter.Value>
@@ -874,7 +874,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="CheckmarkCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to OK" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -901,7 +901,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="DismissCircle" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Add to NG" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -927,7 +927,7 @@
                         <Setter Property="Content">
                           <Setter.Value>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                              <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                               <TextBlock Text="Remove 4" VerticalAlignment="Center"/>
                             </StackPanel>
                           </Setter.Value>
@@ -969,7 +969,7 @@
                        Padding="12,4"
                        Command="{Binding BrowseBatchFolderCommand}">
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <ui:SymbolIcon Symbol="FolderOpen" Margin="0,0,8,0"/>
+                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0"/>
                 <TextBlock Text="Browse" VerticalAlignment="Center"/>
               </StackPanel>
             </ui:Button>
@@ -979,7 +979,7 @@
                        ToolTip="Play / Start or Resume"
                        AutomationProperties.Name="Play"
                        Command="{Binding StartBatchCommand}">
-              <ui:SymbolIcon Symbol="Play"/>
+              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Play24}"/>
             </ui:Button>
 
             <!-- ⏸ Pause -->
@@ -987,7 +987,7 @@
                        ToolTip="Pause"
                        AutomationProperties.Name="Pause"
                        Command="{Binding PauseBatchCommand}">
-              <ui:SymbolIcon Symbol="Pause"/>
+              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Pause24}"/>
             </ui:Button>
 
             <!-- ■ Stop -->
@@ -995,7 +995,7 @@
                        ToolTip="Stop"
                        AutomationProperties.Name="Stop"
                        Command="{Binding StopBatchCommand}">
-              <ui:SymbolIcon Symbol="Stop"/>
+              <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Stop24}"/>
             </ui:Button>
 
             <TextBlock Margin="12,0,0,0"
@@ -1137,7 +1137,7 @@
                        Padding="10,3"
                        Command="{Binding ConnectCommand}">
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <ui:SymbolIcon Symbol="PlugConnected" Margin="0,0,8,0"/>
+                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}" Margin="0,0,8,0"/>
                 <TextBlock Text="Connect" VerticalAlignment="Center"/>
               </StackPanel>
             </ui:Button>
@@ -1146,7 +1146,7 @@
                        Padding="10,3"
                        Command="{Binding DisconnectCommand}">
               <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                <ui:SymbolIcon Symbol="PlugDisconnected" Margin="0,0,8,0"/>
+                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugDisconnected24}" Margin="0,0,8,0"/>
                 <TextBlock Text="Disconnect" VerticalAlignment="Center"/>
               </StackPanel>
             </ui:Button>
@@ -1178,7 +1178,7 @@
                                  Command="{Binding DataContext.ToggleInputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
                                  CommandParameter="{Binding Id}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                          <ui:SymbolIcon Symbol="Power" Margin="0,0,6,0"/>
+                          <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Power24}" Margin="0,0,6,0"/>
                           <TextBlock Text="Enable" VerticalAlignment="Center"/>
                         </StackPanel>
                       </ui:Button>
@@ -1204,7 +1204,7 @@
                                  Command="{Binding DataContext.ToggleOutputCommand, RelativeSource={RelativeSource AncestorType=GroupBox}}"
                                  CommandParameter="{Binding Id}">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                          <ui:SymbolIcon Symbol="Power" Margin="0,0,6,0"/>
+                          <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Power24}" Margin="0,0,6,0"/>
                           <TextBlock Text="Enable" VerticalAlignment="Center"/>
                         </StackPanel>
                       </ui:Button>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -53,7 +53,7 @@
                         <ui:Button Padding="12,4"
                                    Command="{Binding RefreshHealthCommand}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="Pulse" Margin="0,0,8,0"/>
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Pulse24}" Margin="0,0,8,0"/>
                                 <TextBlock Text="Health" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
@@ -98,7 +98,7 @@
                             <ui:Button Command="{Binding InferEnabledRoisCommand}"
                                        Padding="12,4">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <ui:SymbolIcon Symbol="Checkmark" Margin="0,0,8,0"/>
+                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Checkmark24}" Margin="0,0,8,0"/>
                                     <TextBlock Text="Infer Enabled" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </ui:Button>
@@ -139,7 +139,7 @@
                                                     <Setter Property="Content">
                                                         <Setter.Value>
                                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                                <ui:SymbolIcon Symbol="Edit" Margin="0,0,8,0"/>
+                                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
                                                                 <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
                                                             </StackPanel>
                                                         </Setter.Value>
@@ -149,7 +149,7 @@
                                                             <Setter Property="Content">
                                                                 <Setter.Value>
                                                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                                        <ui:SymbolIcon Symbol="Save" Margin="0,0,8,0"/>
+                                                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
                                                                         <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
                                                                     </StackPanel>
                                                                 </Setter.Value>
@@ -194,14 +194,14 @@
                                                    Padding="12,4"
                                                    Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="FolderOpen" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Browse..." VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
                                         <ui:Button Grid.Column="3" Padding="12,4"
                                                    Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="Folder" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Folder24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Open Folder" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
@@ -289,7 +289,7 @@
                                                    Tag="{Binding Index}"
                                                    Click="LoadModelButton_Click">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="ArrowDownload" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowDownload24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Load model" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
@@ -297,7 +297,7 @@
                                                    Margin="0,0,8,0"
                                                    Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="Delete" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
@@ -305,7 +305,7 @@
                                                    Margin="0,0,8,0"
                                                    Command="{Binding DataContext.TrainSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="Rocket" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Rocket24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Train" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
@@ -313,14 +313,14 @@
                                                    Margin="0,0,8,0"
                                                    Command="{Binding DataContext.CalibrateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="Wrench" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Wrench24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Calibrate" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
                                         <ui:Button Padding="12,4"
                                                    Command="{Binding DataContext.EvaluateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType=UserControl}}">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="Search" Margin="0,0,8,0"/>
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Search24}" Margin="0,0,8,0"/>
                                                 <TextBlock Text="Evaluate ROI" VerticalAlignment="Center"/>
                                             </StackPanel>
                                         </ui:Button>
@@ -379,7 +379,7 @@
                 <ui:Button Padding="12,4"
                            Click="ClearCanvasButton_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="Eraser" Margin="0,0,8,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>


### PR DESCRIPTION
## Summary
- update the GUI project to reference Wpf.Ui 3.4.2.7 from NuGet
- adjust SymbolIcon declarations in MainWindow and WorkflowControl to use SymbolRegular enums compatible with the installed package

## Testing
- dotnet restore BrakeDiscInspector_GUI_ROI.csproj *(fails: `dotnet` command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941a85ad64c832ba3a8b4890df05bed)