### PR TITLE
Remove invalid Wpf.Ui controls resource dictionary

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -7,7 +7,6 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Accents/Blue.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>


### PR DESCRIPTION
## Summary
- remove the missing Wpf.Ui Controls.xaml resource dictionary that caused startup failures
- keep the light theme and blue accent resources intact

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941bd45247c832bb894e5bd02fe7042)