### PR TITLE
Fix Wpf.Ui accent dictionary reference

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -7,7 +7,6 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Accents/Blue.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>


### PR DESCRIPTION
## Summary
- remove the missing Wpf.Ui accent resource from App.xaml so startup no longer references a non-existent dictionary

## Testing
- dotnet build BrakeDiscInspector_GUI_ROI.csproj *(fails: dotnet command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941bfa5b6c0832b8628a44681022d7c)