### PR TITLE
Ensure SymbolIcon font size defaults to numeric

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -1,13 +1,19 @@
 ﻿<Application x:Class="BrakeDiscInspector_GUI_ROI.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
-             StartupUri="MainWindow.xaml">
+              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+              xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
+              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Light.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <!-- Ensure SymbolIcons always have a valid numeric font size -->
+            <Style TargetType="{x:Type ui:SymbolIcon}">
+                <Setter Property="FontSize" Value="18" />
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>


### PR DESCRIPTION
## Summary
- add a global SymbolIcon style to provide a numeric FontSize default
- include Wpf.Ui namespace in App.xaml resources

## Testing
- dotnet build (fails: dotnet command not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941c2a79f08832bb2235b5fca9943f9)