### PR TITLE
Add default SymbolIcon font size to prevent startup crash

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -14,17 +14,20 @@
         Loaded="MainWindow_Loaded">
 
   <Window.Resources>
-    <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
-    <conv:BoolToBrushConverter x:Key="BoolToBrush" />
-    <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
-    <Style x:Key="ForegroundWhiteStyle" TargetType="{x:Type StackPanel}">
-      <Setter Property="TextElement.Foreground" Value="Black"/>
-    </Style>
-    <Style x:Key="IconOnlyButton" TargetType="{x:Type ui:Button}">
-      <Setter Property="Width" Value="36"/>
-      <Setter Property="Height" Value="36"/>
-      <Setter Property="Padding" Value="0"/>
-      <Setter Property="FontSize" Value="14"/>
+      <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
+      <conv:BoolToBrushConverter x:Key="BoolToBrush" />
+      <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
+      <Style x:Key="ForegroundWhiteStyle" TargetType="{x:Type StackPanel}">
+        <Setter Property="TextElement.Foreground" Value="Black"/>
+      </Style>
+      <Style TargetType="{x:Type ui:SymbolIcon}">
+        <Setter Property="FontSize" Value="16"/>
+      </Style>
+      <Style x:Key="IconOnlyButton" TargetType="{x:Type ui:Button}">
+        <Setter Property="Width" Value="36"/>
+        <Setter Property="Height" Value="36"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="FontSize" Value="14"/>
       <Setter Property="Margin" Value="8,0,0,0"/>
       <Setter Property="ToolTipService.ShowDuration" Value="30000"/>
     </Style>


### PR DESCRIPTION
## Summary
- add a global SymbolIcon style in MainWindow.xaml to ensure a safe default FontSize and avoid parse failures when icons inherit an empty value

## Testing
- dotnet build (fails: dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941c53c7f9c832b8cade6666bc136e9)