### PR TITLE
Ensure SymbolIcon font size uses global fallback

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -20,9 +20,6 @@
       <Style x:Key="ForegroundWhiteStyle" TargetType="{x:Type StackPanel}">
         <Setter Property="TextElement.Foreground" Value="Black"/>
       </Style>
-      <Style TargetType="{x:Type ui:SymbolIcon}">
-        <Setter Property="FontSize" Value="16"/>
-      </Style>
       <Style x:Key="IconOnlyButton" TargetType="{x:Type ui:Button}">
         <Setter Property="Width" Value="36"/>
         <Setter Property="Height" Value="36"/>


### PR DESCRIPTION
## Summary
- rely on the application-wide SymbolIcon style to enforce a numeric FontSize and remove a duplicate per-window style

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941cc7669d4832bbbdd1c201eb45727)