### PR TITLE
Use Wpf.Ui resource dictionaries

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -7,7 +7,8 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/Wpf.Ui;component/Resources/Theme/Light.xaml" />
+                <ui:ThemesDictionary Theme="Light" />
+                <ui:ControlsDictionary />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- Ensure SymbolIcons always have a valid numeric font size -->


### PR DESCRIPTION
## Summary
- use Wpf.Ui ThemesDictionary and ControlsDictionary in App.xaml to load required resources for SymbolIcon

## Testing
- Not run (Windows-only project in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6942bf8fe418832bbb928595852d5a49)