### PR TITLE
Make left nav buttons fluent with icons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -25,19 +25,27 @@
         <Setter Property="Height" Value="36"/>
         <Setter Property="Padding" Value="0"/>
         <Setter Property="FontSize" Value="14"/>
-      <Setter Property="Margin" Value="8,0,0,0"/>
-      <Setter Property="ToolTipService.ShowDuration" Value="30000"/>
-    </Style>
-    <Style TargetType="GroupBox">
-      <Setter Property="BorderThickness" Value="1"/>
-      <Setter Property="BorderBrush" Value="#CCCCCC"/>
-      <Setter Property="Background" Value="#F5F5F5"/>
-      <Setter Property="Padding" Value="8"/>
-      <Setter Property="Foreground" Value="Black"/>
-      <Setter Property="FontWeight" Value="Normal"/>
-      <Setter Property="FontSize" Value="12"/>
-      <Setter Property="Margin" Value="0,0,0,12"/>
-    </Style>
+        <Setter Property="Margin" Value="8,0,0,0"/>
+        <Setter Property="ToolTipService.ShowDuration" Value="30000"/>
+      </Style>
+      <Style x:Key="LeftNavButtonStyle" TargetType="{x:Type ui:Button}">
+        <Setter Property="Appearance" Value="Secondary"/>
+        <Setter Property="FontSize" Value="20"/>
+        <Setter Property="Height" Value="52"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="Padding" Value="12,8"/>
+        <Setter Property="Margin" Value="0,0,0,8"/>
+      </Style>
+      <Style TargetType="GroupBox">
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderBrush" Value="#CCCCCC"/>
+        <Setter Property="Background" Value="#F5F5F5"/>
+        <Setter Property="Padding" Value="8"/>
+        <Setter Property="Foreground" Value="Black"/>
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Margin" Value="0,0,0,12"/>
+      </Style>
   </Window.Resources>
 
   <Grid x:Name="RootGrid">
@@ -1223,10 +1231,30 @@
             BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
             Background="#F7F7F7">
       <StackPanel Margin="8">
-        <ui:Button Content="Layout Setup" FontSize="20" Margin="0,0,0,8"/>
-        <ui:Button Content="ROIs Management" FontSize="20" Margin="0,0,0,8"/>
-        <ui:Button Content="Batch Inspection" FontSize="20" Margin="0,0,0,8"/>
-        <ui:Button Content="Comms" FontSize="20"/>
+        <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
+            <TextBlock Text="Layout Setup" VerticalAlignment="Center"/>
+          </StackPanel>
+        </ui:Button>
+        <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}" FontSize="18" Margin="0,0,10,0"/>
+            <TextBlock Text="ROIs Management" VerticalAlignment="Center"/>
+          </StackPanel>
+        </ui:Button>
+        <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}" FontSize="18" Margin="0,0,10,0"/>
+            <TextBlock Text="Batch Inspection" VerticalAlignment="Center"/>
+          </StackPanel>
+        </ui:Button>
+        <ui:Button Style="{StaticResource LeftNavButtonStyle}" Margin="0">
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}" FontSize="18" Margin="0,0,10,0"/>
+            <TextBlock Text="Comms" VerticalAlignment="Center"/>
+          </StackPanel>
+        </ui:Button>
       </StackPanel>
     </Border>
 


### PR DESCRIPTION
## Summary
- add a shared LeftNavButtonStyle that aligns the left navigation buttons with the app's Wpf.Ui look
- update the four left navigation buttons to include Fluent icons with text using the shared style

## Testing
- dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln *(fails: `dotnet` is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6943fe51bd84832b987a8c20262cdba8)