### PR TITLE
Add busy progress modal for train and calibrate

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml
@@ -1,0 +1,47 @@
+<Window x:Class="BrakeDiscInspector_GUI_ROI.Views.BusyProgressWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Working"
+        WindowStartupLocation="CenterOwner"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True">
+
+    <Border CornerRadius="12"
+            Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+            Padding="22"
+            SnapsToDevicePixels="True">
+        <Border.Effect>
+            <DropShadowEffect BlurRadius="18" ShadowDepth="0" Opacity="0.25"/>
+        </Border.Effect>
+
+        <StackPanel Width="340">
+            <TextBlock x:Name="TitleText"
+                       FontSize="18"
+                       FontWeight="SemiBold"
+                       Margin="0,0,0,10"
+                       Text="Working"/>
+
+            <ProgressBar x:Name="Progress"
+                         Height="6"
+                         IsIndeterminate="True"
+                         Minimum="0"
+                         Maximum="100"/>
+
+            <TextBlock x:Name="DetailText"
+                       Margin="0,10,0,0"
+                       Opacity="0.75"
+                       TextWrapping="Wrap"/>
+
+            <Button x:Name="CancelButton"
+                    Content="Cancel"
+                    Margin="0,14,0,0"
+                    HorizontalAlignment="Right"
+                    Visibility="Collapsed"/>
+        </StackPanel>
+    </Border>
+</Window>

--- a/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Windows;
+
+namespace BrakeDiscInspector_GUI_ROI.Views
+{
+    public partial class BusyProgressWindow : Window
+    {
+        public BusyProgressWindow()
+        {
+            InitializeComponent();
+        }
+
+        public void SetTitle(string title)
+        {
+            if (title == null)
+            {
+                return;
+            }
+
+            SetState(title, detail: DetailText.Text, percent: Progress.IsIndeterminate ? null : Progress.Value);
+        }
+
+        public void SetDetail(string? detail)
+        {
+            SetState(Title, detail, percent: Progress.IsIndeterminate ? null : Progress.Value);
+        }
+
+        public void SetProgress(double? percent)
+        {
+            SetState(Title, DetailText.Text, percent);
+        }
+
+        public void SetState(string title, string? detail, double? percent)
+        {
+            Title = title;
+            TitleText.Text = title;
+
+            if (percent is null)
+            {
+                Progress.IsIndeterminate = true;
+            }
+            else
+            {
+                Progress.IsIndeterminate = false;
+                var value = Math.Max(0, Math.Min(100, percent.Value));
+                Progress.Value = value;
+
+                if (string.IsNullOrWhiteSpace(detail))
+                {
+                    detail = $"{value:0}%";
+                }
+            }
+
+            DetailText.Text = detail ?? string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Fluent-style busy progress modal window for training and calibration actions
- invoke busy dialog hooks from the workflow view model, updating progress during calibration loops when possible
- wire MainWindow to show, update, and hide the busy dialog when Train or Calibrate run

## Testing
- dotnet build *(fails: `dotnet` is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694982dae478832e9c924c48a08aa313)