### PR TITLE
Fix missing IconOnlyButton style reference in batch toolbar

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -953,7 +953,7 @@
                         </ui:Button>
 
                         <!-- ▶ Play = Start/Resume -->
-                        <ui:Button Style="{StaticResource IconOnlyButton}"
+                        <ui:Button Style="{StaticResource IconOnlyButtonStyle}"
                        ToolTip="Play / Start or Resume"
                        AutomationProperties.Name="Play"
                        Command="{Binding StartBatchCommand}">
@@ -961,7 +961,7 @@
                         </ui:Button>
 
                         <!-- ⏸ Pause -->
-                        <ui:Button Style="{StaticResource IconOnlyButton}"
+                        <ui:Button Style="{StaticResource IconOnlyButtonStyle}"
                        ToolTip="Pause"
                        AutomationProperties.Name="Pause"
                        Command="{Binding PauseBatchCommand}">
@@ -969,7 +969,7 @@
                         </ui:Button>
 
                         <!-- ■ Stop -->
-                        <ui:Button Style="{StaticResource IconOnlyButton}"
+                        <ui:Button Style="{StaticResource IconOnlyButtonStyle}"
                        ToolTip="Stop"
                        AutomationProperties.Name="Stop"
                        Command="{Binding StopBatchCommand}">


### PR DESCRIPTION
## Summary
- update batch toolbar buttons to use the existing IconOnlyButtonStyle resource
- prevent XAML parse failures caused by missing IconOnlyButton style key references

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a729a2aa4832eb4e8a109b21d4bd5)