### PR TITLE
Fix WPF Spacing and resolve Wpf.Ui/System.Windows ambiguity

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -67,7 +67,6 @@ using WPoint = System.Windows.Point; // CODEX: alias for WPF points.
 using WInt32Rect = System.Windows.Int32Rect; // CODEX: alias for WPF Int32Rect.
 // --- END: UI/OCV type aliases ---
 using BrakeDiscInspector_GUI_ROI.Properties;
-using Wpf.Ui.Controls;
 
 namespace BrakeDiscInspector_GUI_ROI
 {
@@ -3527,7 +3526,7 @@ namespace BrakeDiscInspector_GUI_ROI
             var label = GetResourceString(_isPanelCollapsed ? "ExpandPanel" : "CollapsePanel", _isPanelCollapsed ? "Expand panel" : "Collapse panel");
             TogglePanelButton.Content = label;
             TogglePanelButton.ToolTip = label;
-            TogglePanelButton.Tag = _isPanelCollapsed ? SymbolRegular.ChevronRight24 : SymbolRegular.ChevronLeft24;
+            TogglePanelButton.Tag = _isPanelCollapsed ? Wpf.Ui.Controls.SymbolRegular.ChevronRight24 : Wpf.Ui.Controls.SymbolRegular.ChevronLeft24;
         }
 
         private void SetPanelCollapsed(bool collapsed, bool updateSettings = true)

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
@@ -14,8 +14,8 @@
         <Setter Property="ContentTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
-                        <ui:SymbolIcon Symbol="{Binding RelativeSource={RelativeSource AncestorType=ui:Button}, Path=Tag}" FontSize="16" />
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="{Binding RelativeSource={RelativeSource AncestorType=ui:Button}, Path=Tag}" FontSize="16" Margin="0,0,8,0" />
                         <TextBlock Text="{Binding}" VerticalAlignment="Center" />
                     </StackPanel>
                 </DataTemplate>


### PR DESCRIPTION
### Motivation
- XAML parsing failed because WPF panels (`StackPanel`) do not support `Spacing`, which prevented generation of `InitializeComponent` and caused cascading compile errors.
- Ambiguous type references between `Wpf.Ui.Controls` and `System.Windows` (e.g., `MessageBox`, `TextBlock`, `Button`, `SymbolRegular`) produced compile-time collisions.
- The goal is to restore successful XAML code-gen and eliminate ambiguous references while keeping ROI overlay/geometry logic unchanged.

### Description
- Replaced `Spacing="8"` on a `StackPanel` in `gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml` by applying `Margin="0,0,8,0"` to the left child (`ui:SymbolIcon`) so the layout is WPF-compatible. (File updated: `Controls.xaml`)
- Removed the direct `using Wpf.Ui.Controls;` and fully qualified the `SymbolRegular` usage in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` to avoid ambiguous symbol resolution (File updated: `MainWindow.xaml.cs`).
- Preserved all ROI adorner/overlay and geometry classes untouched per constraints; no functional changes to ROI behavior.
- Modified files: `gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml`, `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.

### Testing
- Attempted `dotnet clean ./gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj` and `dotnet build ./gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj` but both failed because `dotnet` was not available in the runtime environment.  (commands attempted: `dotnet clean`, `dotnet build`)
- Removed `bin`/`obj` directories for the GUI project prior to build attempt which completed successfully in the workspace environment.  
- No automated build succeeded in this environment due to the missing `dotnet` tool, so compilation verification should be run locally/CI where .NET SDK is available.  
- No automated tests were executed beyond the attempted `dotnet` build due to the environment limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694bfb35e92c832b86d5dae1e8435c91)