### PR TITLE
Fix WPF UI theme defaults and replace unsupported XAML properties

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -9,7 +9,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Strings.xaml" />
                 <ResourceDictionary Source="Styles/Controls.xaml" />
-                <ui:ThemesDictionary Theme="Auto" />
+                <ui:ThemesDictionary Theme="Light" />
                 <ui:ControlsDictionary />
             </ResourceDictionary.MergedDictionaries>
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -44,16 +44,17 @@
         <!-- ===== Top bar ===== -->
         <Border Grid.Row="0" Grid.ColumnSpan="4" Padding="16,10" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,0,0,1">
             <DockPanel>
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left" Spacing="12">
-                    <TextBlock Text="BrakeDiscInspector" FontWeight="Bold" FontSize="18" />
-                    <TextBlock Text="|" Opacity="0.6" />
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left">
+                    <TextBlock Text="BrakeDiscInspector" FontWeight="Bold" FontSize="18" Margin="0,0,12,0" />
+                    <TextBlock Text="|" Opacity="0.6" Margin="0,0,12,0" />
                     <TextBlock Text="{DynamicResource PrimaryActions}" FontWeight="SemiBold" />
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" Spacing="8" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <ComboBox x:Name="ThemeSelector"
                               Width="140"
                               SelectionChanged="ThemeSelector_OnSelectionChanged"
-                              ToolTip="Toggle light/dark/auto theme">
+                              ToolTip="Toggle light/dark/auto theme"
+                              Margin="0,0,8,0">
                         <ComboBoxItem Content="{DynamicResource ThemeAuto}" />
                         <ComboBoxItem Content="{DynamicResource ThemeLight}" />
                         <ComboBoxItem Content="{DynamicResource ThemeDark}" />
@@ -73,7 +74,7 @@
             <TabItem x:Name="TabSetupInspect" Header="Setup &amp; Inspection">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel x:Name="SetupInspectRoot" Margin="8" Orientation="Vertical">
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12" Spacing="8">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                             <ui:Button x:Name="BtnLoadImage"
                                        Style="{StaticResource IconTextButtonStyle}"
                                        MinWidth="140"
@@ -1464,18 +1465,18 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <StackPanel Orientation="Horizontal" Grid.Column="0" Spacing="6" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Center">
                     <TextBlock Text="{DynamicResource StatusBackend}" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding DataContext.HealthSummary, ElementName=WorkflowHost}" />
+                    <TextBlock Text="{Binding DataContext.HealthSummary, ElementName=WorkflowHost}" Margin="6,0,0,0" />
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Grid.Column="1" Spacing="6" VerticalAlignment="Center">
+                <StackPanel Orientation="Horizontal" Grid.Column="1" VerticalAlignment="Center">
                     <TextBlock Text="{DynamicResource StatusMode}" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding ModeStatusText, RelativeSource={RelativeSource AncestorType=Window}}" />
+                    <TextBlock Text="{Binding ModeStatusText, RelativeSource={RelativeSource AncestorType=Window}}" Margin="6,0,0,0" />
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Grid.Column="2" HorizontalAlignment="Right" Spacing="8" VerticalAlignment="Center">
-                    <ui:ProgressRing Width="18" Height="18" IsActive="{Binding DataContext.IsBusy, ElementName=WorkflowHost}" />
+                <StackPanel Orientation="Horizontal" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <ui:ProgressRing Width="18" Height="18" IsIndeterminate="{Binding DataContext.IsBusy, ElementName=WorkflowHost}" Margin="0,0,8,0" />
                     <TextBlock Text="{Binding BusyStatusText, RelativeSource={RelativeSource AncestorType=Window}}" />
                 </StackPanel>
             </Grid>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3607,12 +3607,15 @@ namespace BrakeDiscInspector_GUI_ROI
         private void ApplyTheme(string? preference)
         {
             var desired = string.IsNullOrWhiteSpace(preference) ? "Auto" : preference;
+            var themeValue = desired.Equals("Auto", StringComparison.OrdinalIgnoreCase)
+                ? "Light"
+                : desired;
             try
             {
                 var themeDictionary = Application.Current.Resources.MergedDictionaries.OfType<ThemesDictionary>().FirstOrDefault();
                 if (themeDictionary != null)
                 {
-                    themeDictionary.Theme = desired;
+                    themeDictionary.Theme = themeValue;
                 }
                 Settings.Default.ThemePreference = desired;
                 Settings.Default.Save();


### PR DESCRIPTION
### Motivation
- Fix XAML/designer errors caused by an unsupported theme value and framework properties reported in the project.  
- Remove uses of `StackPanel.Spacing` which is not available on the target WPF framework and replace with explicit margins to avoid build/designer failures.  
- Use a supported property on the `ProgressRing` control to avoid invalid member errors in XAML.  
- Ensure runtime theme application maps `Auto` to a valid theme to prevent the theme dictionary from being set to an invalid value.

### Description
- Set the default theme in `App.xaml` to `Light` by changing `<ui:ThemesDictionary Theme="Auto" />` to `<ui:ThemesDictionary Theme="Light" />`.  
- Update `MainWindow.xaml.cs` `ApplyTheme` to map an `Auto` preference to a supported theme (`Light`) before assigning to the theme dictionary.  
- Remove unsupported `StackPanel Spacing` attributes in `MainWindow.xaml` and replace layout spacing with explicit `Margin` values on child elements to preserve visual spacing.  
- Replace the unsupported `ProgressRing.IsActive` binding with `IsIndeterminate` and add small layout margins for spacing in `MainWindow.xaml`.

### Testing
- No automated tests were executed for this change.  
- Changes were limited to XAML/C# UI resources and validated by inspecting the modified XAML to remove unsupported attributes and adjust bindings.  
- Local grep/inspection verified removal of `Spacing=` occurrences in `MainWindow.xaml` and the theme mapping logic was added to `ApplyTheme`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694bfd5c50cc832b9e5160faec4a59a7)