### PR TITLE
Add IconOnlyButton style alias for Wpf.Ui buttons

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
@@ -32,6 +32,9 @@
         <Setter Property="ToolTipService.ShowDuration" Value="30000" />
     </Style>
 
+    <Style x:Key="IconOnlyButton" TargetType="{x:Type ui:Button}"
+           BasedOn="{StaticResource IconOnlyButtonStyle}" />
+
     <Style x:Key="LeftNavButtonStyle" TargetType="{x:Type ui:Button}">
         <Setter Property="Appearance" Value="Secondary" />
         <Setter Property="FontSize" Value="18" />


### PR DESCRIPTION
### Motivation
- Fix XDG-0001 build errors caused by `MainWindow.xaml` referencing `IconOnlyButton` while `Controls.xaml` defines `IconOnlyButtonStyle`.
- Keep theme/resource wiring intact and avoid touching ROI/adorners logic per project constraints.
- Make the least-invasive change to satisfy XAML `StaticResource` lookups so the GUI can compile and run.

### Description
- Add a style alias with `x:Key="IconOnlyButton"` that is `BasedOn` the existing `IconOnlyButtonStyle` in `gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml`.
- This provides the missing resource referenced by `MainWindow.xaml` without changing other style definitions or ROI classes.
- No changes were made to any ROI-related classes (`RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`, `RoiOverlay`) and no theme value was altered by this PR.
- Modified file: `gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml`.

### Testing
- Searched the GUI project to confirm `MainWindow.xaml` references `IconOnlyButton` and the new alias exists, which succeeded using the repository search tools.
- Attempted to run `dotnet build ./gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj`, but the `dotnet` CLI was not available in the execution environment so a full build could not be performed.
- No other automated tests were run in this environment due to tooling limits.
- Manual inspection confirms the change is minimal and restricted to XAML resource aliasing to resolve the missing `StaticResource` lookup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c030516f0832b90da04f1ba95d1f2)