### PR TITLE
Align Master 1/2 Analyze GroupBoxes side-by-side

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -308,52 +308,59 @@
                                 </ui:Button>
                             </StackPanel>
                         </GroupBox>
-                        <GroupBox Header="Master 1 Analyze" Width="260" UseLayoutRounding="False">
-                            <StackPanel Margin="8,4,0,0">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                    <ComboBox x:Name="ComboFeature" Width="110"
-                                SelectedValuePath="Content"
-                                SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}">
-                                        <ComboBoxItem Content="auto"/>
-                                        <ComboBoxItem Content="sift"/>
-                                        <ComboBoxItem Content="orb"/>
-                                        <ComboBoxItem Content="tm_rot"/>
-                                        <ComboBoxItem Content="edges"/>
-                                    </ComboBox>
-                                </StackPanel>
+                        <Grid Margin="0,0,0,8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="16"/>
+                                <ColumnDefinition Width="Auto"/>
+                            </Grid.ColumnDefinitions>
+                            <GroupBox Grid.Column="0" Header="Master 1 Analyze" Width="260" UseLayoutRounding="False">
+                                <StackPanel Margin="8,4,0,0">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                        <ComboBox x:Name="ComboFeature" Width="110"
+                                    SelectedValuePath="Content"
+                                    SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}">
+                                            <ComboBoxItem Content="auto"/>
+                                            <ComboBoxItem Content="sift"/>
+                                            <ComboBoxItem Content="orb"/>
+                                            <ComboBoxItem Content="tm_rot"/>
+                                            <ComboBoxItem Content="edges"/>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                    <TextBlock Text="Thr:" VerticalAlignment="Center"/>
-                                    <TextBox x:Name="TxtThr" Width="40"
-                               Margin="4,0,0,0"
-                               Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                        <TextBlock Text="Thr:" VerticalAlignment="Center"/>
+                                        <TextBox x:Name="TxtThr" Width="40"
+                                   Margin="4,0,0,0"
+                                   Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    </StackPanel>
                                 </StackPanel>
-                            </StackPanel>
-                        </GroupBox>
-                        <GroupBox Header="Master 2 Analyze" Width="260">
-                            <StackPanel Margin="8,4,0,0">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                    <ComboBox x:Name="ComboFeatureM2" Width="110"
-                                SelectedValuePath="Content"
-                                SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}">
-                                        <ComboBoxItem Content="auto"/>
-                                        <ComboBoxItem Content="sift"/>
-                                        <ComboBoxItem Content="orb"/>
-                                        <ComboBoxItem Content="tm_rot"/>
-                                        <ComboBoxItem Content="edges"/>
-                                    </ComboBox>
-                                </StackPanel>
+                            </GroupBox>
+                            <GroupBox Grid.Column="2" Header="Master 2 Analyze" Width="260">
+                                <StackPanel Margin="8,4,0,0">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                        <ComboBox x:Name="ComboFeatureM2" Width="110"
+                                    SelectedValuePath="Content"
+                                    SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}">
+                                            <ComboBoxItem Content="auto"/>
+                                            <ComboBoxItem Content="sift"/>
+                                            <ComboBoxItem Content="orb"/>
+                                            <ComboBoxItem Content="tm_rot"/>
+                                            <ComboBoxItem Content="edges"/>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
-                                    <TextBlock Text="Thr:" VerticalAlignment="Center"/>
-                                    <TextBox x:Name="TxtThrM2" Width="40"
-                               Margin="4,0,0,0"
-                               Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                                        <TextBlock Text="Thr:" VerticalAlignment="Center"/>
+                                        <TextBox x:Name="TxtThrM2" Width="40"
+                                   Margin="4,0,0,0"
+                                   Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    </StackPanel>
                                 </StackPanel>
-                            </StackPanel>
-                        </GroupBox>
+                            </GroupBox>
+                        </Grid>
                         <GroupBox Header="Match Options" Width="260">
                             <StackPanel Margin="8,4,0,0">
                                 <StackPanel Orientation="Horizontal" Margin="0,4,0,8">


### PR DESCRIPTION
### Motivation
- Render the "Master 1 Analyze" and "Master 2 Analyze" GroupBoxes on the same horizontal row for a more compact UI layout.
- Preserve all existing control names, bindings, and event handlers to avoid functional changes.
- Only modify layout containers/attributes and avoid any logic or behavior changes.
- Apply the change in the area of the analyze controls to keep related UI elements together.

### Description
- Replaced the two sequential `GroupBox` elements with a containing `Grid` using three columns (`Auto`, `16`, `Auto`) and `Margin="0,0,0,8"` to create a fixed spacer between them.
- Placed `GroupBox Header="Master 1 Analyze"` into `Grid.Column="0"` and `GroupBox Header="Master 2 Analyze"` into `Grid.Column="2"` while keeping their inner content identical.
- Preserved `x:Name` values, bindings (e.g. `AnalyzeFeatureM1`, `AnalyzeFeatureM2`, `AnalyzeThrM1`, `AnalyzeThrM2`), and control widths (e.g. `Width="260"`).
- Change applied in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` near the existing `Master 1 Analyze` section.

### Testing
- No automated tests were run for this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c15dd04b0832e8d5834a03dc633ed)