### PR TITLE
Fix converters used by MainWindow — normalize text/brush mappings and broaden status mapping

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
@@ -3,16 +3,11 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
-using BrakeDiscInspector_GUI_ROI.Workflow;
 
 namespace BrakeDiscInspector_GUI_ROI.Converters
 {
     public sealed class BatchCellStatusToBrushConverter : IValueConverter
     {
-        public Brush OkBrush { get; set; } = Brushes.LimeGreen;
-        public Brush NokBrush { get; set; } = Brushes.Red;
-        public Brush UnknownBrush { get; set; } = Brushes.Gray;
-
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (targetType != typeof(Brush) && !targetType.IsAssignableFrom(typeof(Brush)))
@@ -20,22 +15,54 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
                 return DependencyProperty.UnsetValue;
             }
 
-            if (value is not BatchCellStatus status)
+            if (value == null || value == DependencyProperty.UnsetValue)
             {
-                return UnknownBrush;
+                return Brushes.Gray;
             }
 
-            return status switch
+            if (value is bool boolValue)
             {
-                BatchCellStatus.Ok => OkBrush,
-                BatchCellStatus.Nok => NokBrush,
-                _ => UnknownBrush,
-            };
+                return boolValue ? Brushes.LimeGreen : Brushes.IndianRed;
+            }
+
+            if (value is string textValue)
+            {
+                return MapStatusText(textValue);
+            }
+
+            if (value is Enum || value is int)
+            {
+                return MapStatusText(value.ToString());
+            }
+
+            return Brushes.Gray;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotSupportedException();
+            return DependencyProperty.UnsetValue;
+        }
+
+        private static Brush MapStatusText(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text) || text.Trim() == "-")
+            {
+                return Brushes.Gray;
+            }
+
+            if (text.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0
+                || text.IndexOf("PASS", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return Brushes.LimeGreen;
+            }
+
+            if (text.IndexOf("NG", StringComparison.OrdinalIgnoreCase) >= 0
+                || text.IndexOf("FAIL", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return Brushes.IndianRed;
+            }
+
+            return Brushes.Gray;
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BoolToBrushConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BoolToBrushConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
@@ -7,18 +8,19 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
 {
     public class BoolToBrushConverter : IValueConverter
     {
-        public Brush OnBrush { get; set; } = Brushes.LimeGreen;
-
-        public Brush OffBrush { get; set; } = Brushes.Gray;
-
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is bool flag && flag)
+            if (value == null || value == DependencyProperty.UnsetValue)
             {
-                return OnBrush;
+                return Brushes.Gray;
             }
 
-            return OffBrush;
+            if (value is bool flag)
+            {
+                return flag ? Brushes.LimeGreen : Brushes.IndianRed;
+            }
+
+            return Brushes.Gray;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BoolToEditSaveTextConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BoolToEditSaveTextConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Windows;
 using System.Windows.Data;
 
 namespace BrakeDiscInspector_GUI_ROI.Converters
@@ -7,9 +8,16 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
     public class BoolToEditSaveTextConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-            => (value is bool b && b) ? "Editar ROI" : "Guardar ROI";
+            => value is bool b && b ? "Save" : "Edit";
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => Binding.DoNothing;
+        {
+            return value switch
+            {
+                string text when string.Equals(text, "Save", StringComparison.OrdinalIgnoreCase) => true,
+                string text when string.Equals(text, "Edit", StringComparison.OrdinalIgnoreCase) => false,
+                _ => DependencyProperty.UnsetValue,
+            };
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Resolve XAML/runtime issues caused by converter behavior and mapping to ensure the workflow UI bindings use predictable values and brushes.  
- Make the converters robust to `null`/`DependencyProperty.UnsetValue` and support multiple input types used in the UI.  
- Provide consistent `ConvertBack` semantics for UI text toggles so the UI/commands can rely on stable values.  
- Avoid touching adorner/overlay or workflow control code; the changes are limited to value converters referenced from XAML resources.  

### Description
- Updated `BoolToEditSaveTextConverter` to emit English labels (`"Save"` / `"Edit"`) and implemented `ConvertBack` to return `true` for `"Save"`, `false` for `"Edit"`, and `DependencyProperty.UnsetValue` as fallback.  
- Reworked `BoolToBrushConverter` to return `Brushes.LimeGreen` when `true`, `Brushes.IndianRed` when `false`, and `Brushes.Gray` for `null`/`Unset`.  
- Broadened `BatchCellStatusToBrushConverter` to handle `bool`, `string`, `Enum`/`int`, and `DependencyProperty.UnsetValue`, mapping common textual forms (`OK`, `PASS`, `NG`, `FAIL`, `-`) to `LimeGreen`/`IndianRed`/`Gray`.  
- Modified only the three files under `gui/BrakeDiscInspector_GUI_ROI/Converters/`: `BoolToEditSaveTextConverter.cs`, `BoolToBrushConverter.cs`, and `BatchCellStatusToBrushConverter.cs` and preserved their namespace `BrakeDiscInspector_GUI_ROI.Converters` so XAML `xmlns:conv` continues to resolve.  

### Testing
- Attempted `dotnet clean` but the command is not available in the execution environment (failed).  
- Attempted `dotnet build` but the command is not available in the execution environment (failed).  
- Performed repository inspections (file listing and XAML search) to verify the converters exist at `gui/BrakeDiscInspector_GUI_ROI/Converters/` and that XAML references (`xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"`) match the namespace (informational checks only).  
- No automated unit tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c6b320e8c832ba736aa984661aa00)