### PR TITLE
Wire left navigation buttons to side panels

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1208,25 +1208,30 @@
             BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
             Background="#F7F7F7">
             <StackPanel Margin="8">
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                           Click="NavLayoutSetup_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
                         <TextBlock Text="Layout Setup" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                           Click="NavRoiManagement_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}" FontSize="18" Margin="0,0,10,0"/>
                         <TextBlock Text="ROIs Management" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}">
+                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                           Click="NavBatchInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}" FontSize="18" Margin="0,0,10,0"/>
                         <TextBlock Text="Batch Inspection" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}" Margin="0">
+                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                           Click="NavComms_Click"
+                           Margin="0">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}" FontSize="18" Margin="0,0,10,0"/>
                         <TextBlock Text="Comms" VerticalAlignment="Center"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3583,6 +3583,7 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             if (LayoutSetupPanel == null || RoiManagementPanel == null || BatchInspectionPanel == null || CommsPanel == null)
             {
+                GuiLog.Warn("[ui] ShowSidePanel skipped: one or more panels are null (check x:Name bindings).");
                 return;
             }
 


### PR DESCRIPTION
### Motivation
- Fix the left navigation buttons so they actually switch the side panels and ensure `LayoutSetupPanel` is the visible default.
- Prevent common causes of non-working navigation such as missing `x:Name` bindings or styles that block hit-testing.
- Improve diagnosability by warning when panel references are unexpectedly null.

### Description
- Add `Click` handlers to the four left navigation buttons in `MainWindow.xaml` to call `NavLayoutSetup_Click`, `NavRoiManagement_Click`, `NavBatchInspection_Click`, and `NavComms_Click`.
- Add a null-check and `GuiLog.Warn` message in `ShowSidePanel` in `MainWindow.xaml.cs` to surface missing `x:Name` bindings at runtime.
- Modifications applied to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` and `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.

### Testing
- No automated unit or CI tests were executed for this change.
- Performed repository scans to verify there are no duplicate `x:Name` entries and inspected `LeftNavButtonStyle` to ensure it does not disable interaction.
- Confirmed the modified files were added and committed; a full build/CI run was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c7fa1a0ec832bbf795a27b41bc58a)