### PR TITLE
Add design-time visibility overrides for ROI panel

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1,6 +1,8 @@
 <Window x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
         xmlns:m="clr-namespace:BrakeDiscInspector_GUI_ROI.Models"
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
@@ -11,7 +13,8 @@
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
         UseLayoutRounding="True"
-        Loaded="MainWindow_Loaded">
+        Loaded="MainWindow_Loaded"
+        mc:Ignorable="d">
 
     <Window.Resources>
         <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
@@ -71,7 +74,7 @@
 
         <!-- ===== Side Panel Host ===== -->
         <Grid Grid.Row="1" Grid.Column="1" x:Name="SidePanelHost">
-            <ScrollViewer x:Name="LayoutSetupPanel" VerticalScrollBarVisibility="Auto">
+            <ScrollViewer x:Name="LayoutSetupPanel" VerticalScrollBarVisibility="Auto" d:Visibility="Collapsed">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <ui:Button x:Name="BtnLoadImage"
@@ -158,7 +161,7 @@
                 </StackPanel>
             </ScrollViewer>
 
-            <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed">
+            <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <GroupBox x:Name="MasterRoiGroup"
                               Header="Master ROI"


### PR DESCRIPTION
### Motivation
- Designer tools (Visual Studio / Blend) cannot select elements with `Visibility="Collapsed"`, making `RoiManagementPanel` hard to edit in the designer.
- The goal is to make the ROI panel editable in the designer while preserving runtime behavior where `LayoutSetupPanel` is shown and other panels remain collapsed.

### Description
- Added design-time namespaces to the window root: `xmlns:d="http://schemas.microsoft.com/expression/blend/2008"`, `xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` and `mc:Ignorable="d"` in `MainWindow.xaml`.
- Kept runtime `Visibility` settings unchanged and added `d:Visibility="Visible"` to the `RoiManagementPanel` so it appears in the designer while remaining `Visibility="Collapsed"` at runtime.
- Added `d:Visibility="Collapsed"` to `LayoutSetupPanel` so the designer shows the ROI panel by default, without altering runtime behavior.
- Updated file: `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` with only design-time attributes (no runtime logic changes).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694da7ea8fe4832b98aca3a8cca669fa)