### PR TITLE
Remove duplicate xmlns:d/xmlns:mc declarations in MainWindow.xaml

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
+        x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
         Title="BrakeDiscInspector"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
### Motivation
- Fix XAML parsing/compile errors caused by duplicate `xmlns:d` and `xmlns:mc` attributes reported on the root element in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.
- Preserve the existing UI layout and controls while making the file well-formed XML and valid XAML.

### Description
- Removed the duplicate `xmlns:d` and `xmlns:mc` attributes that were repeated on the same root `<Window>` tag in `MainWindow.xaml`.
- Kept a single `mc:Ignorable="d"` attribute on the root and preserved all other namespace declarations such as `xmlns:x`, `xmlns:local`, and `xmlns:ui`.
- Only the opening `<Window ...>` tag was modified; no other UI elements or layout markup were changed.

### Testing
- No automated tests were run for this change.
- The edited file was updated to remove duplicated namespace attributes so the file is well-formed XML and the duplicate-namespace XAML errors should be resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694dae101028832ba763b382d41a8637)