### PR TITLE
Add GUI setup popup and light/dark theme toggles with dynamic UI resources

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -8,11 +8,12 @@
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
         Title="BrakeDiscInspector"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
-        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+        Background="{DynamicResource BrushAppBackground}"
         UseLayoutRounding="True"
         Loaded="MainWindow_Loaded"
         mc:Ignorable="d">
@@ -21,7 +22,84 @@
         <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
         <conv:BoolToBrushConverter x:Key="BoolToBrush" />
         <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
-        <Style TargetType="{x:Type GroupBox}" BasedOn="{StaticResource CardGroupBoxStyle}" />
+        <FontFamily x:Key="FontFamilyTitle">Segoe UI</FontFamily>
+        <FontFamily x:Key="FontFamilyHeader">Segoe UI</FontFamily>
+        <FontFamily x:Key="FontFamilyLabel">Segoe UI</FontFamily>
+        <FontFamily x:Key="FontFamilyButton">Segoe UI</FontFamily>
+        <FontFamily x:Key="FontFamilyTextBox">Segoe UI</FontFamily>
+        <FontFamily x:Key="FontFamilyComboBox">Segoe UI</FontFamily>
+
+        <sys:Double x:Key="FontSizeTitle">20</sys:Double>
+        <sys:Double x:Key="FontSizeHeader">16</sys:Double>
+        <sys:Double x:Key="FontSizeLabel">13</sys:Double>
+        <sys:Double x:Key="FontSizeButton">13</sys:Double>
+        <sys:Double x:Key="FontSizeTextBox">13</sys:Double>
+        <sys:Double x:Key="FontSizeComboBox">13</sys:Double>
+
+        <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+        <SolidColorBrush x:Key="BrushAppForeground" Color="Black" />
+        <SolidColorBrush x:Key="BrushButtonBackground" Color="#FFE5E5E5" />
+        <SolidColorBrush x:Key="BrushButtonForeground" Color="Black" />
+
+        <Style x:Key="TitleTextStyle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyTitle}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeTitle}" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushAppForeground}" />
+        </Style>
+        <Style x:Key="HeaderTextStyle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyHeader}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeHeader}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushAppForeground}" />
+        </Style>
+        <Style x:Key="LabelTextStyle" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyLabel}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeLabel}" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushAppForeground}" />
+        </Style>
+        <Style TargetType="TextBlock" BasedOn="{StaticResource LabelTextStyle}" />
+
+        <Style x:Key="AppButtonStyle" TargetType="{x:Type ui:Button}">
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Background" Value="{DynamicResource BrushButtonBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushButtonForeground}" />
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyButton}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeButton}" />
+            <Setter Property="Padding" Value="10,6" />
+            <Setter Property="Effect" Value="{x:Null}" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Effect">
+                        <Setter.Value>
+                            <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.35" />
+                        </Setter.Value>
+                    </Setter>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource AppButtonStyle}" />
+
+        <Style TargetType="TextBox">
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyTextBox}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeTextBox}" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushAppForeground}" />
+        </Style>
+        <Style TargetType="ComboBox">
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamilyComboBox}" />
+            <Setter Property="FontSize" Value="{DynamicResource FontSizeComboBox}" />
+            <Setter Property="Foreground" Value="{DynamicResource BrushAppForeground}" />
+        </Style>
+
+        <Style TargetType="{x:Type GroupBox}" BasedOn="{StaticResource CardGroupBoxStyle}">
+            <Setter Property="HeaderTemplate">
+                <Setter.Value>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding}" Style="{StaticResource HeaderTextStyle}" />
+                    </DataTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
 
     <Window.InputBindings>
@@ -46,32 +124,288 @@
         </Grid.ColumnDefinitions>
 
         <!-- ===== Top bar ===== -->
-        <Border Grid.Row="0" Grid.ColumnSpan="4" Padding="16,10" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,0,0,1">
+        <Border Grid.Row="0" Grid.ColumnSpan="4" Padding="16,10" Background="{DynamicResource BrushAppBackground}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,0,0,1">
             <DockPanel>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left">
-                    <TextBlock Text="BrakeDiscInspector" FontWeight="Bold" FontSize="18" Margin="0,0,12,0" />
-                    <TextBlock Text="|" Opacity="0.6" Margin="0,0,12,0" />
-                    <TextBlock Text="{DynamicResource PrimaryActions}" FontWeight="SemiBold" />
+                    <TextBlock Text="BrakeDiscInspector" Style="{StaticResource TitleTextStyle}" Margin="0,0,12,0" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center">
-                    <ComboBox x:Name="ThemeSelector"
-                              Width="140"
-                              SelectionChanged="ThemeSelector_OnSelectionChanged"
-                              ToolTip="Toggle light/dark/auto theme"
-                              Margin="0,0,8,0">
-                        <ComboBoxItem Content="{DynamicResource ThemeAuto}" />
-                        <ComboBoxItem Content="{DynamicResource ThemeLight}" />
-                        <ComboBoxItem Content="{DynamicResource ThemeDark}" />
-                    </ComboBox>
-                    <ui:Button x:Name="TogglePanelButton"
-                               Style="{StaticResource IconTextButtonStyle}"
-                               Click="TogglePanelButton_OnClick"
-                               Tag="{x:Static ui:SymbolRegular.ChevronLeft24}"
-                               ToolTip="{DynamicResource CollapsePanel}"
-                               Content="{DynamicResource CollapsePanel}" />
+                    <ui:Button x:Name="SetupGuiButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="SetupGuiButton_Click"
+                               Margin="0,0,8,0"
+                               ToolTip="Open GUI setup">
+                        <StackPanel Orientation="Horizontal">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" Margin="0,0,6,0" FontSize="16"/>
+                            <TextBlock Text="Setup GUI" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ui:Button>
+                    <ui:Button x:Name="ThemeLightButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeLightButton_Click"
+                               Margin="0,0,6,0"
+                               ToolTip="Light theme">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherSunny24}" FontSize="18"/>
+                    </ui:Button>
+                    <ui:Button x:Name="ThemeDarkButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeDarkButton_Click"
+                               ToolTip="Dark theme">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
+                    </ui:Button>
                 </StackPanel>
             </DockPanel>
         </Border>
+
+        <Popup x:Name="GuiSetupPopup"
+               PlacementTarget="{Binding ElementName=SetupGuiButton}"
+               Placement="Bottom"
+               StaysOpen="False"
+               AllowsTransparency="True"
+               PopupAnimation="Fade">
+            <Border Background="{DynamicResource BrushAppBackground}"
+                    BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                    BorderThickness="1"
+                    CornerRadius="8"
+                    Padding="16"
+                    Width="560">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" MaxHeight="520">
+                    <StackPanel>
+                        <TextBlock Text="GUI Setup" Style="{StaticResource TitleTextStyle}" Margin="0,0,0,12"/>
+
+                        <TextBlock Text="Typography" Style="{StaticResource HeaderTextStyle}" Margin="0,0,0,8"/>
+                        <StackPanel Margin="0,0,0,16">
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Title font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="TitleFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyTitle"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="TitleFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeTitle"
+                                        Minimum="10"
+                                        Maximum="28"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=TitleFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Header font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="HeaderFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyHeader"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="HeaderFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeHeader"
+                                        Minimum="10"
+                                        Maximum="26"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=HeaderFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Label font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="LabelFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyLabel"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="LabelFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeLabel"
+                                        Minimum="10"
+                                        Maximum="22"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=LabelFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Button font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="ButtonFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyButton"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="ButtonFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeButton"
+                                        Minimum="10"
+                                        Maximum="22"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=ButtonFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="TextBox font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="TextBoxFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyTextBox"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="TextBoxFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeTextBox"
+                                        Minimum="10"
+                                        Maximum="22"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=TextBoxFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="70"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="ComboBox font" VerticalAlignment="Center"/>
+                                <ComboBox x:Name="ComboBoxFontFamilyCombo"
+                                          Grid.Column="1"
+                                          Tag="FontFamilyComboBox"
+                                          Margin="8,0"
+                                          SelectionChanged="FontFamilyCombo_SelectionChanged"/>
+                                <Slider x:Name="ComboBoxFontSizeSlider"
+                                        Grid.Column="2"
+                                        Tag="FontSizeComboBox"
+                                        Minimum="10"
+                                        Maximum="22"
+                                        ValueChanged="FontSizeSlider_ValueChanged"/>
+                                <TextBox Grid.Column="3"
+                                         IsReadOnly="True"
+                                         TextAlignment="Center"
+                                         Text="{Binding ElementName=ComboBoxFontSizeSlider, Path=Value, StringFormat=F0}"/>
+                            </Grid>
+                        </StackPanel>
+
+                        <TextBlock Text="Colors" Style="{StaticResource HeaderTextStyle}" Margin="0,0,0,8"/>
+                        <StackPanel Margin="0,0,0,16">
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="180"/>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="40"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Primary text color" VerticalAlignment="Center"/>
+                                <TextBox x:Name="ForegroundColorBox"
+                                         Grid.Column="1"
+                                         Tag="BrushAppForeground"
+                                         LostFocus="ColorTextBox_LostFocus"/>
+                                <Rectangle Grid.Column="2"
+                                           Width="24"
+                                           Height="24"
+                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                                           Fill="{DynamicResource BrushAppForeground}"
+                                           Margin="8,0,0,0"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="180"/>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="40"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Interface background color" VerticalAlignment="Center"/>
+                                <TextBox x:Name="BackgroundColorBox"
+                                         Grid.Column="1"
+                                         Tag="BrushAppBackground"
+                                         LostFocus="ColorTextBox_LostFocus"/>
+                                <Rectangle Grid.Column="2"
+                                           Width="24"
+                                           Height="24"
+                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                                           Fill="{DynamicResource BrushAppBackground}"
+                                           Margin="8,0,0,0"/>
+                            </Grid>
+                            <Grid Margin="0,0,0,8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="180"/>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="40"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Button background color" VerticalAlignment="Center"/>
+                                <TextBox x:Name="ButtonBackgroundColorBox"
+                                         Grid.Column="1"
+                                         Tag="BrushButtonBackground"
+                                         LostFocus="ColorTextBox_LostFocus"/>
+                                <Rectangle Grid.Column="2"
+                                           Width="24"
+                                           Height="24"
+                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                                           Fill="{DynamicResource BrushButtonBackground}"
+                                           Margin="8,0,0,0"/>
+                            </Grid>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="180"/>
+                                    <ColumnDefinition Width="140"/>
+                                    <ColumnDefinition Width="40"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Button foreground color" VerticalAlignment="Center"/>
+                                <TextBox x:Name="ButtonForegroundColorBox"
+                                         Grid.Column="1"
+                                         Tag="BrushButtonForeground"
+                                         LostFocus="ColorTextBox_LostFocus"/>
+                                <Rectangle Grid.Column="2"
+                                           Width="24"
+                                           Height="24"
+                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                                           Fill="{DynamicResource BrushButtonForeground}"
+                                           Margin="8,0,0,0"/>
+                            </Grid>
+                        </StackPanel>
+
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <ui:Button Content="Apply Colors" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ApplyColorsButton_Click"/>
+                            <ui:Button Content="Reset Defaults" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ResetGuiDefaultsButton_Click"/>
+                            <ui:Button Content="Close" Style="{StaticResource AppButtonStyle}" Click="CloseGuiSetupButton_Click"/>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Popup>
 
         <!-- ===== Side Panel Host ===== -->
         <Grid Grid.Row="1" Grid.Column="1" x:Name="SidePanelHost">


### PR DESCRIPTION
### Motivation
- Provide a compact GUI settings panel to let users customize fonts, sizes and interface colors at runtime.
- Replace the existing theme ComboBox with explicit Light/Dark icon toggles in the top bar and remove the side-panel collapse button that interfered with the canvas.
- Make typography and colors configurable via `DynamicResource` keys so changes apply across the UI without hardcoding sizes on controls.
- Fix the `GroupBox` header styling issue by overriding its `HeaderTemplate` so header text follows the dynamic resources.

### Description
- Added dynamic resource keys and defaults in `MainWindow.xaml` for font families (`FontFamily*`), font sizes (`FontSize*`) and brushes (`BrushAppBackground`, `BrushAppForeground`, `BrushButtonBackground`, `BrushButtonForeground`).
- Introduced reusable styles (`TitleTextStyle`, `HeaderTextStyle`, `LabelTextStyle`, `AppButtonStyle`) and updated `GroupBox` style to set `HeaderTemplate` so headers use `HeaderTextStyle`.
- Replaced the top-bar `ThemeSelector` ComboBox and `TogglePanelButton` with a `Setup GUI` button and two icon-only buttons for light/dark (`ThemeLightButton`, `ThemeDarkButton`), and wired `SetupGuiButton_Click`, `ThemeLightButton_Click`, and `ThemeDarkButton_Click` handlers.
- Implemented an in-window `Popup` (`GuiSetupPopup`) anchored to `SetupGuiButton` containing typography and color controls (font-family ComboBoxes, size Sliders, color hex TextBoxes), plus `Apply Colors`, `Reset Defaults` and `Close` actions, and added code-behind helpers in `MainWindow.xaml.cs` to populate controls and update resources live (`SetFontFamilyResource`, `SetDoubleResource`, `SetBrushResource`, `SetResourceValue`, etc.).
- Captured and preserved default GUI resources so `Reset Defaults` restores original values, and populated a short list of available fonts for the dropdowns.
- Removed the old `ThemeSelector` selection-change wiring and the collapse-button logic to avoid altering the canvas and duplicate UI elements; ensured new handlers exist in code-behind and no duplicate XAML xmlns prefixes were introduced (added `sys` once).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694e6c095844832b83d07897acb5da8a)