### PR TITLE
Fix DynamicResource usage in bindings (DropShadowEffect Color)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -74,7 +74,7 @@
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.35"
-                                              Color="{Binding Color, Source={DynamicResource UI.Brush.Accent}}" />
+                                              Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
                         </Setter.Value>
                     </Setter>
                 </Trigger>

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
@@ -34,7 +34,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={DynamicResource UI.Brush.Accent}}" />
+                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -59,7 +59,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={DynamicResource UI.Brush.Accent}}" />
+                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -86,7 +86,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={DynamicResource UI.Brush.Accent}}" />
+                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>


### PR DESCRIPTION
### Motivation
- The app crashed in `InitializeComponent()` with a `XamlParseException` because `Binding.Source` was being set to a `{DynamicResource ...}` which is invalid since `Binding` is not a `DependencyObject`.
- Replace improper markup to prevent runtime XAML parse failures while preserving runtime theming where possible.
- Keep themeability of UI by using `DynamicResource` only on actual `DependencyProperty` targets (controls/styles).

### Description
- Replaced `Color="{Binding Color, Source={DynamicResource UI.Brush.Accent}}"` with `Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}"` inside `DropShadowEffect` bindings.
- Files modified: `gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml` and `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.
- Only changed `DynamicResource` usage that was inside a `Binding`/`Source`; left `DynamicResource` on control `DependencyProperty` setters untouched so UI remains themeable.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694e7c49d000832b95bd573333dea3c3)