### PR TITLE
Centralize theme resources and fix accent shadows

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Strings.xaml" />
+                <ResourceDictionary Source="Styles/ThemeResources.xaml" />
                 <ResourceDictionary Source="Styles/Controls.xaml" />
                 <ui:ThemesDictionary Theme="Light" />
                 <ui:ControlsDictionary />

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -35,7 +35,6 @@
 
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
         <SolidColorBrush x:Key="UI.Brush.Foreground" Color="Black" />
-        <SolidColorBrush x:Key="UI.Brush.Accent" Color="#FF4B9EEA" />
         <SolidColorBrush x:Key="UI.Brush.ButtonForeground" Color="Black" />
         <SolidColorBrush x:Key="UI.Brush.ButtonBackground" Color="#FFE5E5E5" />
         <SolidColorBrush x:Key="UI.Brush.ButtonBackgroundHover" Color="#FFD5D5D5" />
@@ -74,7 +73,7 @@
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.35"
-                                              Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
+                                              Color="{DynamicResource UI.Color.Accent}" />
                         </Setter.Value>
                     </Setter>
                 </Trigger>

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
@@ -34,7 +34,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
+                                          Color="{DynamicResource UI.Color.Accent}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -59,7 +59,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
+                                          Color="{DynamicResource UI.Color.Accent}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>
@@ -86,7 +86,7 @@
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
-                                          Color="{Binding Color, Source={StaticResource UI.Brush.Accent}}" />
+                                          Color="{DynamicResource UI.Color.Accent}" />
                     </Setter.Value>
                 </Setter>
             </Trigger>

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/ThemeResources.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/ThemeResources.xaml
@@ -1,0 +1,11 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Accent color (change this key when switching theme if needed) -->
+    <Color x:Key="UI.Color.Accent">#39FF14</Color>
+
+    <!-- Accent brush derived from the accent color -->
+    <SolidColorBrush x:Key="UI.Brush.Accent"
+                     Color="{DynamicResource UI.Color.Accent}" />
+
+</ResourceDictionary>


### PR DESCRIPTION
### Motivation
- Fix a startup `XamlParseException` and fragility caused by binding `DropShadowEffect.Color` to a `Brush` and by theme resources being defined too late.
- Make accent/theme resources robust across merges and light/dark switching so styles keep working without code-behind changes.

### Description
- Create `Styles/ThemeResources.xaml` that defines `UI.Color.Accent` (a `Color`) and `UI.Brush.Accent` (a `SolidColorBrush` using `DynamicResource UI.Color.Accent`).
- Load `Styles/ThemeResources.xaml` from `App.xaml` before `Styles/Controls.xaml` by updating the `ResourceDictionary.MergedDictionaries` order.
- Replace `Binding`-based `DropShadowEffect.Color` usages with `Color="{DynamicResource UI.Color.Accent}"` in `Styles/Controls.xaml` and `MainWindow.xaml` to avoid binding a `Brush` for a `Color`.
- Remove the duplicate local `UI.Brush.Accent` definition from `MainWindow.xaml` so the global `ThemeResources` is used.

### Testing
- No automated build or runtime tests were executed as part of this change.
- Performed a repository search for `DropShadowEffect` occurrences to verify all targeted replacements were applied.
- Committed the changes including `Styles/ThemeResources.xaml`, `App.xaml`, `Styles/Controls.xaml`, and `MainWindow.xaml`.
- Recommend a clean+rebuild and running the app to confirm `InitializeComponent()` no longer throws and hover shadows update when the theme changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694efe56c614832b94b9788776285a8c)