### PR TITLE
Persist Setup GUI configuration to local JSON and restore at startup

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
@@ -1,6 +1,9 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Windows;
+using BrakeDiscInspector_GUI_ROI.Services;
+using BrakeDiscInspector_GUI_ROI.Properties;
 
 namespace BrakeDiscInspector_GUI_ROI
 {
@@ -12,7 +15,69 @@ namespace BrakeDiscInspector_GUI_ROI
         protected override void OnStartup(StartupEventArgs e)
         {
             ResetLogsOnStartup();
+            var guiSettings = GuiSetupSettingsService.LoadOrDefault();
+            GuiSetupSettingsService.Apply(guiSettings);
+            ApplyThemePreference(guiSettings.Theme);
             base.OnStartup(e);
+        }
+
+        private static void ApplyThemePreference(string? preference)
+        {
+            if (string.IsNullOrWhiteSpace(preference))
+            {
+                return;
+            }
+
+            var themeValue = preference.Equals("Auto", StringComparison.OrdinalIgnoreCase)
+                ? "Light"
+                : preference;
+
+            try
+            {
+                var themeDictionary = Application.Current.Resources.MergedDictionaries
+                    .FirstOrDefault(dictionary => dictionary.GetType().Name == "ThemesDictionary");
+                if (themeDictionary == null)
+                {
+                    return;
+                }
+
+                var themeProperty = themeDictionary.GetType().GetProperty("Theme");
+                if (themeProperty == null || !themeProperty.CanWrite)
+                {
+                    return;
+                }
+
+                var targetType = themeProperty.PropertyType;
+                object? resolvedValue = themeValue;
+
+                if (targetType.IsEnum)
+                {
+                    if (Enum.TryParse(targetType, themeValue, true, out var parsed))
+                    {
+                        resolvedValue = parsed;
+                    }
+                    else
+                    {
+                        resolvedValue = null;
+                    }
+                }
+                else if (targetType != typeof(string) && targetType != typeof(object))
+                {
+                    resolvedValue = null;
+                }
+
+                if (resolvedValue != null)
+                {
+                    themeProperty.SetValue(themeDictionary, resolvedValue);
+                }
+
+                Settings.Default.ThemePreference = preference;
+                Settings.Default.Save();
+            }
+            catch
+            {
+                // Swallow theme initialization errors to avoid startup failure.
+            }
         }
 
         private static void ResetLogsOnStartup()
@@ -83,4 +148,3 @@ namespace BrakeDiscInspector_GUI_ROI
         }
     }
 }
-

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -53,6 +53,7 @@ using ROI = BrakeDiscInspector_GUI_ROI.RoiModel;
 using RoiShapeType = BrakeDiscInspector_GUI_ROI.RoiShape;
 using BrakeDiscInspector_GUI_ROI.Models;
 using BrakeDiscInspector_GUI_ROI.Helpers;
+using BrakeDiscInspector_GUI_ROI.Services;
 // --- BEGIN: UI/OCV type aliases ---
 using SW = System.Windows;
 using SWM = System.Windows.Media;
@@ -3438,6 +3439,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     HideSnackVisual();
                 };
 
+                Closing += MainWindow_OnClosing;
+
                 this.SizeChanged += (s, e) =>
                 {
                     try
@@ -3674,6 +3677,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
                 Settings.Default.ThemePreference = desired;
                 Settings.Default.Save();
+                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
             }
             catch (Exception ex)
             {
@@ -3784,6 +3788,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is ComboBox combo && combo.Tag is string key && combo.SelectedItem is string familyName)
             {
                 SetFontFamilyResource(key, familyName);
+                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
             }
         }
 
@@ -3797,6 +3802,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is Slider slider && slider.Tag is string key)
             {
                 SetDoubleResource(key, slider.Value);
+                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
             }
         }
 
@@ -3809,7 +3815,10 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (sender is TextBox textBox && textBox.Tag is string key)
             {
-                TryApplyColorText(textBox, key);
+                if (TryApplyColorText(textBox, key))
+                {
+                    GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+                }
             }
         }
 
@@ -3821,6 +3830,7 @@ namespace BrakeDiscInspector_GUI_ROI
             TryApplyColorText(ButtonHoverBackgroundColorBox, "UI.Brush.ButtonBackgroundHover");
             TryApplyColorText(ButtonForegroundColorBox, "UI.Brush.ButtonForeground");
             TryApplyColorText(GroupHeaderForegroundColorBox, "UI.Brush.GroupHeaderForeground");
+            GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
         }
 
         private void ResetGuiDefaultsButton_Click(object sender, RoutedEventArgs e)
@@ -3944,6 +3954,11 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void SetBrushResource(string key, Color color)
         {
+            if (string.Equals(key, "UI.Brush.Accent", StringComparison.OrdinalIgnoreCase))
+            {
+                SetResourceValue("UI.Color.Accent", color);
+            }
+
             var brush = new SolidColorBrush(color);
             if (brush.CanFreeze)
             {
@@ -3967,6 +3982,11 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 Resources[key] = value;
             }
+        }
+
+        private void MainWindow_OnClosing(object? sender, CancelEventArgs e)
+        {
+            GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
         }
 
         private bool TryGetResourceValue<T>(string key, out T? value)

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettings.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettings.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace BrakeDiscInspector_GUI_ROI.Services
+{
+    public sealed class GuiSetupSettings
+    {
+        public string? Theme { get; set; }
+        public Dictionary<string, string>? FontFamilies { get; set; }
+        public Dictionary<string, double>? FontSizes { get; set; }
+        public Dictionary<string, string>? Brushes { get; set; }
+        public string? Accent { get; set; }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Media;
+using BrakeDiscInspector_GUI_ROI.Properties;
+
+namespace BrakeDiscInspector_GUI_ROI.Services
+{
+    public static class GuiSetupSettingsService
+    {
+        private const string AccentBrushKey = "UI.Brush.Accent";
+        private const string AccentColorKey = "UI.Color.Accent";
+
+        private static readonly string[] FontFamilyKeys =
+        {
+            "UI.FontFamily.Body",
+            "UI.FontFamily.Header"
+        };
+
+        private static readonly string[] FontSizeKeys =
+        {
+            "UI.FontSize.WindowTitle",
+            "UI.FontSize.SectionTitle",
+            "UI.FontSize.GroupHeader",
+            "UI.FontSize.ControlLabel",
+            "UI.FontSize.ControlText",
+            "UI.FontSize.ButtonText",
+            "UI.FontSize.CheckBox"
+        };
+
+        private static readonly string[] BrushKeys =
+        {
+            "UI.Brush.Foreground",
+            AccentBrushKey,
+            "UI.Brush.ButtonForeground",
+            "UI.Brush.ButtonBackground",
+            "UI.Brush.ButtonBackgroundHover",
+            "UI.Brush.GroupHeaderForeground"
+        };
+
+        public static string ConfigPath => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "BrakeDiscInspector",
+            "gui",
+            "gui_setup.json");
+
+        public static GuiSetupSettings LoadOrDefault()
+        {
+            try
+            {
+                if (!File.Exists(ConfigPath))
+                {
+                    return new GuiSetupSettings();
+                }
+
+                var json = File.ReadAllText(ConfigPath);
+                var settings = JsonSerializer.Deserialize<GuiSetupSettings>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return settings ?? new GuiSetupSettings();
+            }
+            catch
+            {
+                return new GuiSetupSettings();
+            }
+        }
+
+        public static void Save(GuiSetupSettings settings)
+        {
+            if (settings == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var directory = Path.GetDirectoryName(ConfigPath);
+                if (!string.IsNullOrWhiteSpace(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+
+                File.WriteAllText(ConfigPath, json);
+            }
+            catch
+            {
+                // Best-effort persistence; ignore failures.
+            }
+        }
+
+        public static GuiSetupSettings CaptureCurrent(Window? window)
+        {
+            var settings = new GuiSetupSettings
+            {
+                Theme = Settings.Default.ThemePreference
+            };
+
+            var fontFamilies = new Dictionary<string, string>();
+            foreach (var key in FontFamilyKeys)
+            {
+                if (TryFindResource(window, key, out var value) && value is FontFamily family)
+                {
+                    fontFamilies[key] = family.Source;
+                }
+            }
+
+            if (fontFamilies.Count > 0)
+            {
+                settings.FontFamilies = fontFamilies;
+            }
+
+            var fontSizes = new Dictionary<string, double>();
+            foreach (var key in FontSizeKeys)
+            {
+                if (TryFindResource(window, key, out var value))
+                {
+                    if (value is double size)
+                    {
+                        fontSizes[key] = size;
+                    }
+                    else if (value is float floatSize)
+                    {
+                        fontSizes[key] = floatSize;
+                    }
+                }
+            }
+
+            if (fontSizes.Count > 0)
+            {
+                settings.FontSizes = fontSizes;
+            }
+
+            var brushes = new Dictionary<string, string>();
+            foreach (var key in BrushKeys)
+            {
+                if (TryFindResource(window, key, out var value))
+                {
+                    if (value is SolidColorBrush brush)
+                    {
+                        brushes[key] = brush.Color.ToString();
+                    }
+                    else if (value is Color color)
+                    {
+                        brushes[key] = color.ToString();
+                    }
+                }
+            }
+
+            if (brushes.Count > 0)
+            {
+                settings.Brushes = brushes;
+            }
+
+            if (TryFindResource(window, AccentColorKey, out var accentValue) && accentValue is Color accentColor)
+            {
+                settings.Accent = accentColor.ToString();
+            }
+            else if (TryFindResource(window, AccentBrushKey, out var accentBrush) && accentBrush is SolidColorBrush accent)
+            {
+                settings.Accent = accent.Color.ToString();
+            }
+            else if (settings.Brushes != null && settings.Brushes.TryGetValue(AccentBrushKey, out var accentHex))
+            {
+                settings.Accent = accentHex;
+            }
+
+            return settings;
+        }
+
+        public static void Apply(GuiSetupSettings settings)
+        {
+            if (settings == null || Application.Current == null)
+            {
+                return;
+            }
+
+            if (settings.FontFamilies != null)
+            {
+                foreach (var pair in settings.FontFamilies)
+                {
+                    if (!string.IsNullOrWhiteSpace(pair.Value))
+                    {
+                        SetResourceValue(pair.Key, new FontFamily(pair.Value));
+                    }
+                }
+            }
+
+            if (settings.FontSizes != null)
+            {
+                foreach (var pair in settings.FontSizes)
+                {
+                    SetResourceValue(pair.Key, pair.Value);
+                }
+            }
+
+            if (settings.Brushes != null)
+            {
+                foreach (var pair in settings.Brushes)
+                {
+                    if (TryParseColor(pair.Value, out var color))
+                    {
+                        if (string.Equals(pair.Key, AccentBrushKey, StringComparison.OrdinalIgnoreCase))
+                        {
+                            SetAccentResources(color);
+                        }
+                        else
+                        {
+                            SetBrushResource(pair.Key, color);
+                        }
+                    }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Accent) && TryParseColor(settings.Accent, out var accentColor))
+            {
+                SetAccentResources(accentColor);
+            }
+        }
+
+        private static bool TryFindResource(Window? window, string key, out object? value)
+        {
+            value = null;
+            if (window != null)
+            {
+                var fromWindow = window.TryFindResource(key);
+                if (fromWindow != null)
+                {
+                    value = fromWindow;
+                    return true;
+                }
+            }
+
+            if (Application.Current != null)
+            {
+                var fromApp = Application.Current.TryFindResource(key);
+                if (fromApp != null)
+                {
+                    value = fromApp;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void SetBrushResource(string key, Color color)
+        {
+            var brush = new SolidColorBrush(color);
+            if (brush.CanFreeze)
+            {
+                brush.Freeze();
+            }
+
+            SetResourceValue(key, brush);
+        }
+
+        private static void SetAccentResources(Color color)
+        {
+            SetResourceValue(AccentColorKey, color);
+            SetBrushResource(AccentBrushKey, color);
+        }
+
+        private static void SetResourceValue(string key, object value)
+        {
+            if (Application.Current.Resources.Contains(key))
+            {
+                Application.Current.Resources[key] = value;
+            }
+            else
+            {
+                Application.Current.Resources[key] = value;
+            }
+        }
+
+        private static bool TryParseColor(string value, out Color color)
+        {
+            color = default;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            try
+            {
+                var converted = ColorConverter.ConvertFromString(value);
+                if (converted is Color parsed)
+                {
+                    color = parsed;
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Persist the runtime-configurable Setup GUI (font families, font sizes, brushes, and Light/Dark theme) so user choices survive application restarts. 
- Ensure Accent is applied consistently to both `UI.Color.Accent` and `UI.Brush.Accent` because some controls read the Color key directly.
- Load saved settings before the main window is created to avoid flicker and keep `DynamicResource` behavior intact.
- Save settings whenever the user applies changes or switches theme, and as a safety net on window close.

### Description
- Added a settings model `Services/GuiSetupSettings.cs` and a persistence service `Services/GuiSetupSettingsService.cs` that read/write JSON at `%LOCALAPPDATA%\BrakeDiscInspector\gui\gui_setup.json` using `System.Text.Json`.
- Applied saved settings during startup in `App.xaml.cs` (load + `GuiSetupSettingsService.Apply(...)`) and applied the Wpf.Ui theme preference before `base.OnStartup(...)` to avoid flicker.
- Hooked saves in `MainWindow.xaml.cs`: font family/size changes, color edits (Apply/LostFocus), theme switches, and on `Closing` call `GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this))`.
- When applying Accent, both `UI.Color.Accent` and `UI.Brush.Accent` are updated so Color-based usages (e.g., hover shadow) and brush usages remain consistent, and runtime updates modify `Application.Current.Resources` so `DynamicResource` consumers refresh automatically.

### Testing
- No automated tests were executed as part of this change.
- Persistence is best-effort and IO/parse errors are handled gracefully to fall back to defaults without crashing.
- Manual runtime behavior expected: settings load before window creation, UI updates immediately when applying changes, and settings file is created/updated under the specified LocalAppData path.
- Code uses `System.Text.Json` with indented output for the saved JSON file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f07dd8f70832b94e9391fab01911c)