### PR TITLE
Fix GUI setup persistence and centralize settings path to LocalAppData

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
@@ -12,10 +12,13 @@ namespace BrakeDiscInspector_GUI_ROI
     /// </summary>
     public partial class App : Application
     {
+        public static GuiSetupSettings CurrentGuiSetup { get; set; } = new();
+
         protected override void OnStartup(StartupEventArgs e)
         {
             ResetLogsOnStartup();
             var guiSettings = GuiSetupSettingsService.LoadOrDefault();
+            CurrentGuiSetup = guiSettings;
             GuiSetupSettingsService.Apply(guiSettings);
             ApplyThemePreference(guiSettings.Theme);
             base.OnStartup(e);

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3677,12 +3677,19 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
                 Settings.Default.ThemePreference = desired;
                 Settings.Default.Save();
-                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+                SaveCurrentGuiSetup();
             }
             catch (Exception ex)
             {
                 GuiLog.Error($"[theme] failed to set theme {desired}", ex); // CODEX: string interpolation compatibility.
             }
+        }
+
+        private void SaveCurrentGuiSetup()
+        {
+            var settings = GuiSetupSettingsService.CaptureCurrent(this);
+            App.CurrentGuiSetup = settings;
+            GuiSetupSettingsService.Save(settings);
         }
 
         private void SetupGuiButton_Click(object sender, RoutedEventArgs e)
@@ -3788,7 +3795,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is ComboBox combo && combo.Tag is string key && combo.SelectedItem is string familyName)
             {
                 SetFontFamilyResource(key, familyName);
-                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+                SaveCurrentGuiSetup();
             }
         }
 
@@ -3802,7 +3809,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is Slider slider && slider.Tag is string key)
             {
                 SetDoubleResource(key, slider.Value);
-                GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+                SaveCurrentGuiSetup();
             }
         }
 
@@ -3817,7 +3824,7 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 if (TryApplyColorText(textBox, key))
                 {
-                    GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+                    SaveCurrentGuiSetup();
                 }
             }
         }
@@ -3830,7 +3837,7 @@ namespace BrakeDiscInspector_GUI_ROI
             TryApplyColorText(ButtonHoverBackgroundColorBox, "UI.Brush.ButtonBackgroundHover");
             TryApplyColorText(ButtonForegroundColorBox, "UI.Brush.ButtonForeground");
             TryApplyColorText(GroupHeaderForegroundColorBox, "UI.Brush.GroupHeaderForeground");
-            GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+            SaveCurrentGuiSetup();
         }
 
         private void ResetGuiDefaultsButton_Click(object sender, RoutedEventArgs e)
@@ -3986,7 +3993,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void MainWindow_OnClosing(object? sender, CancelEventArgs e)
         {
-            GuiSetupSettingsService.Save(GuiSetupSettingsService.CaptureCurrent(this));
+            SaveCurrentGuiSetup();
         }
 
         private bool TryGetResourceValue<T>(string key, out T? value)

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
 using System.Windows;
@@ -40,11 +41,13 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             "UI.Brush.GroupHeaderForeground"
         };
 
+        // Stored at %LOCALAPPDATA%\BrakeDiscInspector\gui_setup.json for easy diagnostics.
         public static string ConfigPath => Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "BrakeDiscInspector",
-            "gui",
             "gui_setup.json");
+
+        public static string GetSettingsPath() => ConfigPath;
 
         public static GuiSetupSettings LoadOrDefault()
         {
@@ -63,8 +66,9 @@ namespace BrakeDiscInspector_GUI_ROI.Services
 
                 return settings ?? new GuiSetupSettings();
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[gui-setup] Failed to load settings from '{ConfigPath}': {ex}");
                 return new GuiSetupSettings();
             }
         }
@@ -91,9 +95,9 @@ namespace BrakeDiscInspector_GUI_ROI.Services
 
                 File.WriteAllText(ConfigPath, json);
             }
-            catch
+            catch (Exception ex)
             {
-                // Best-effort persistence; ignore failures.
+                Debug.WriteLine($"[gui-setup] Failed to save settings to '{ConfigPath}': {ex}");
             }
         }
 


### PR DESCRIPTION
### Motivation
- Ensure the "Setup GUI" customization (fonts, sizes, colors, theme) is reliably persisted to disk and re-applied on startup.  
- Eliminate mismatches between load and save paths by using a single canonical settings file under LocalAppData.  
- Keep a single in-memory source of truth for GUI settings so saves reflect the current UI state.  
- Add lightweight diagnostics so load/save failures are logged rather than silently swallowed.  

### Description
- Changed the settings file location to `%LOCALAPPDATA%\BrakeDiscInspector\gui_setup.json` and exposed it via `GuiSetupSettingsService.ConfigPath` and `GetSettingsPath()`.  
- Added `Debug.WriteLine` logging for exceptions in `GuiSetupSettingsService.LoadOrDefault()` and `Save()` so failures include the full path and exception text.  
- Introduced `App.CurrentGuiSetup` and set it on startup from `GuiSetupSettingsService.LoadOrDefault()` so there is one canonical current settings object.  
- Consolidated per-control save calls into a single `SaveCurrentGuiSetup()` helper in `MainWindow.xaml.cs` that captures current resources, updates `App.CurrentGuiSetup`, and calls `GuiSetupSettingsService.Save()`, and wired this helper to theme changes, control events, and window closing.  

### Testing
- No automated tests were executed as part of this change.  
- Changes are limited to wiring, path selection, and logging and were applied across `App.xaml.cs`, `MainWindow.xaml.cs`, and `GuiSetupSettingsService.cs` to preserve existing behavior while fixing persistence.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f0e0f20bc832ba5c1464a91409fca)