### PR TITLE
Add durable GUI setup logging and ensure persistence on Apply/Theme/Close

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:BrakeDiscInspector_GUI_ROI"
         xmlns:m="clr-namespace:BrakeDiscInspector_GUI_ROI.Models"
+        xmlns:services="clr-namespace:BrakeDiscInspector_GUI_ROI.Services"
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
@@ -436,6 +437,18 @@
                                            Fill="{DynamicResource UI.Brush.GroupHeaderForeground}"
                                            Margin="8,0,0,0"/>
                             </Grid>
+                        </StackPanel>
+
+                        <TextBlock Text="Diagnostics" Style="{StaticResource HeaderTextStyle}" Margin="0,0,0,6"/>
+                        <StackPanel Margin="0,0,0,16">
+                            <TextBlock TextWrapping="Wrap">
+                                <Run Text="Config: "/>
+                                <Run Text="{x:Static services:GuiSetupSettingsService.ConfigPath}"/>
+                            </TextBlock>
+                            <TextBlock TextWrapping="Wrap">
+                                <Run Text="Log: "/>
+                                <Run Text="{x:Static services:GuiSetupSettingsService.GuiSetupLogPath}"/>
+                            </TextBlock>
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3677,7 +3677,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
                 Settings.Default.ThemePreference = desired;
                 Settings.Default.Save();
-                SaveCurrentGuiSetup();
             }
             catch (Exception ex)
             {
@@ -3685,11 +3684,20 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
-        private void SaveCurrentGuiSetup()
+        private void PersistGuiSetup(string reason)
         {
-            var settings = GuiSetupSettingsService.CaptureCurrent(this);
-            App.CurrentGuiSetup = settings;
-            GuiSetupSettingsService.Save(settings);
+            try
+            {
+                var settings = GuiSetupSettingsService.CaptureCurrent(this);
+                App.CurrentGuiSetup = settings;
+                GuiSetupSettingsService.Log($"[Persist] start reason={reason} path={GuiSetupSettingsService.ConfigPath}");
+                GuiSetupSettingsService.Save(settings);
+                GuiSetupSettingsService.Log($"[Persist] ok reason={reason}");
+            }
+            catch (Exception ex)
+            {
+                GuiSetupSettingsService.Log($"[Persist] FAIL reason={reason}", ex);
+            }
         }
 
         private void SetupGuiButton_Click(object sender, RoutedEventArgs e)
@@ -3705,11 +3713,13 @@ namespace BrakeDiscInspector_GUI_ROI
         private void ThemeLightButton_Click(object sender, RoutedEventArgs e)
         {
             ApplyTheme("Light");
+            PersistGuiSetup("ThemeLight");
         }
 
         private void ThemeDarkButton_Click(object sender, RoutedEventArgs e)
         {
             ApplyTheme("Dark");
+            PersistGuiSetup("ThemeDark");
         }
 
         private void InitializeGuiSetupPanel()
@@ -3795,7 +3805,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is ComboBox combo && combo.Tag is string key && combo.SelectedItem is string familyName)
             {
                 SetFontFamilyResource(key, familyName);
-                SaveCurrentGuiSetup();
+                PersistGuiSetup("FontFamilyChanged");
             }
         }
 
@@ -3809,7 +3819,7 @@ namespace BrakeDiscInspector_GUI_ROI
             if (sender is Slider slider && slider.Tag is string key)
             {
                 SetDoubleResource(key, slider.Value);
-                SaveCurrentGuiSetup();
+                PersistGuiSetup("FontSizeChanged");
             }
         }
 
@@ -3824,7 +3834,7 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 if (TryApplyColorText(textBox, key))
                 {
-                    SaveCurrentGuiSetup();
+                    PersistGuiSetup("ColorTextChanged");
                 }
             }
         }
@@ -3837,7 +3847,7 @@ namespace BrakeDiscInspector_GUI_ROI
             TryApplyColorText(ButtonHoverBackgroundColorBox, "UI.Brush.ButtonBackgroundHover");
             TryApplyColorText(ButtonForegroundColorBox, "UI.Brush.ButtonForeground");
             TryApplyColorText(GroupHeaderForegroundColorBox, "UI.Brush.GroupHeaderForeground");
-            SaveCurrentGuiSetup();
+            PersistGuiSetup("ApplyColors");
         }
 
         private void ResetGuiDefaultsButton_Click(object sender, RoutedEventArgs e)
@@ -3993,7 +4003,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void MainWindow_OnClosing(object? sender, CancelEventArgs e)
         {
-            SaveCurrentGuiSetup();
+            PersistGuiSetup("WindowClosing");
         }
 
         private bool TryGetResourceValue<T>(string key, out T? value)


### PR DESCRIPTION
### Motivation
- Make GUI setup persistence observable and reliable by adding durable file logging for save/load errors and snapshots.
- Ensure there is a single canonical config file at `%LOCALAPPDATA%\BrakeDiscInspector\gui_setup.json` and a dedicated log at `%LOCALAPPDATA%\BrakeDiscInspector\logs\gui_setup.log`.
- Guarantee settings are persisted when the user clicks Apply, toggles theme, or closes the main window so UI changes survive restarts.
- Keep the UI non-blocking on errors and provide quick diagnostics in the Setup popup so files can be inspected.

### Description
- Added `LogDirectory`, `GuiSetupLogPath`, `Log(...)`, and `BuildSnapshot(...)` helpers to `GuiSetupSettingsService` and enhanced `LoadOrDefault()` and `Save()` to write detailed log entries including timestamps, snapshots, and exception stacks.
- Made `ConfigPath` canonical using `Environment.SpecialFolder.LocalApplicationData` and ensured `Directory.CreateDirectory(...)` is used before writes.
- Replaced ad-hoc `SaveCurrentGuiSetup()` calls with a new `PersistGuiSetup(string reason)` in `MainWindow.xaml.cs` which captures current settings, calls `GuiSetupSettingsService.Save(...)`, and logs success/failure; this is invoked on theme toggles, font-family/size changes, color edits, Apply button, and window closing.
- Exposed config and log paths in the GUI setup popup by adding a small "Diagnostics" block to `MainWindow.xaml` for quick user inspection.

### Testing
- No automated tests were run against these changes.
- Changes were limited to non-blocking logging and persistence calls to avoid altering existing UI flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f143f24a0832bb784123615bc4e28)