### PR TITLE
Fix GUI setup persistence and token resources

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Strings.xaml" />
+                <ResourceDictionary Source="Styles/GuiTokens.xaml" />
                 <ResourceDictionary Source="Styles/ThemeResources.xaml" />
                 <ResourceDictionary Source="Styles/Controls.xaml" />
                 <ui:ThemesDictionary Theme="Light" />

--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
@@ -21,6 +21,7 @@ namespace BrakeDiscInspector_GUI_ROI
             CurrentGuiSetup = guiSettings;
             GuiSetupSettingsService.Apply(guiSettings);
             ApplyThemePreference(guiSettings.Theme);
+            GuiSetupSettingsService.Apply(CurrentGuiSetup);
             base.OnStartup(e);
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -9,7 +9,6 @@
         xmlns:workflow="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-        xmlns:sys="clr-namespace:System;assembly=mscorlib"
         x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
         Title="BrakeDiscInspector"
         WindowState="Maximized"
@@ -23,23 +22,7 @@
         <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
         <conv:BoolToBrushConverter x:Key="BoolToBrush" />
         <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
-        <FontFamily x:Key="UI.FontFamily.Body">Segoe UI</FontFamily>
-        <FontFamily x:Key="UI.FontFamily.Header">Segoe UI</FontFamily>
-
-        <sys:Double x:Key="UI.FontSize.WindowTitle">20</sys:Double>
-        <sys:Double x:Key="UI.FontSize.SectionTitle">16</sys:Double>
-        <sys:Double x:Key="UI.FontSize.GroupHeader">16</sys:Double>
-        <sys:Double x:Key="UI.FontSize.ControlLabel">13</sys:Double>
-        <sys:Double x:Key="UI.FontSize.ControlText">13</sys:Double>
-        <sys:Double x:Key="UI.FontSize.ButtonText">13</sys:Double>
-        <sys:Double x:Key="UI.FontSize.CheckBox">13</sys:Double>
-
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
-        <SolidColorBrush x:Key="UI.Brush.Foreground" Color="Black" />
-        <SolidColorBrush x:Key="UI.Brush.ButtonForeground" Color="Black" />
-        <SolidColorBrush x:Key="UI.Brush.ButtonBackground" Color="#FFE5E5E5" />
-        <SolidColorBrush x:Key="UI.Brush.ButtonBackgroundHover" Color="#FFD5D5D5" />
-        <SolidColorBrush x:Key="UI.Brush.GroupHeaderForeground" Color="Black" />
 
         <Style x:Key="TitleTextStyle" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Header}" />
@@ -161,6 +144,7 @@
                PlacementTarget="{Binding ElementName=SetupGuiButton}"
                Placement="Bottom"
                StaysOpen="False"
+               Closed="GuiSetupPopup_Closed"
                AllowsTransparency="True"
                PopupAnimation="Fade">
             <Border Background="{DynamicResource BrushAppBackground}"

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/GuiTokens.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/GuiTokens.xaml
@@ -1,0 +1,20 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+    <FontFamily x:Key="UI.FontFamily.Body">Segoe UI</FontFamily>
+    <FontFamily x:Key="UI.FontFamily.Header">Segoe UI</FontFamily>
+
+    <sys:Double x:Key="UI.FontSize.WindowTitle">20</sys:Double>
+    <sys:Double x:Key="UI.FontSize.SectionTitle">16</sys:Double>
+    <sys:Double x:Key="UI.FontSize.GroupHeader">16</sys:Double>
+    <sys:Double x:Key="UI.FontSize.ControlLabel">13</sys:Double>
+    <sys:Double x:Key="UI.FontSize.ControlText">13</sys:Double>
+    <sys:Double x:Key="UI.FontSize.ButtonText">13</sys:Double>
+    <sys:Double x:Key="UI.FontSize.CheckBox">13</sys:Double>
+
+    <SolidColorBrush x:Key="UI.Brush.Foreground" Color="Black" />
+    <SolidColorBrush x:Key="UI.Brush.ButtonForeground" Color="Black" />
+    <SolidColorBrush x:Key="UI.Brush.ButtonBackground" Color="#FFE5E5E5" />
+    <SolidColorBrush x:Key="UI.Brush.ButtonBackgroundHover" Color="#FFD5D5D5" />
+    <SolidColorBrush x:Key="UI.Brush.GroupHeaderForeground" Color="Black" />
+</ResourceDictionary>


### PR DESCRIPTION
### Motivation
- Window-level `Window.Resources` were shadowing `Application` resources causing loaded GUI tokens to have no effect on `MainWindow` and captured defaults to be written back.
- Provide a single source-of-truth for UI tokens so user changes persist and are applied after restart.
- Avoid excessive disk writes by debouncing saves and ensure settings are flushed on popup/window close.
- Improve diagnostic logging for load/apply/capture/save operations to aid troubleshooting.

### Description
- Moved token defaults into a new app-scoped resource dictionary `Styles/GuiTokens.xaml` and merged it in `App.xaml` so keys like `UI.FontFamily.*`, `UI.FontSize.*` and `UI.Brush.*` are defined at application scope.
- Reworked `GuiSetupSettingsService` to read effective values via `TryGetEffectiveResource(...)`, to `Log` detailed `[CAPTURE]` and `[APPLY]` entries, and to apply settings into `Application.Current.Resources` with an apply-summary log.
- Updated `MainWindow` to stop writing token keys into `Window.Resources` (all `SetResourceValue` now writes to `Application.Current.Resources`), added a debounced save timer (`_guiSetupSaveTimer`) with `RequestPersistGuiSetup`/`FlushGuiSetupPersistence`, and flush on popup close (`GuiSetupPopup_Closed`) and window closing.
- Ensured settings are re-applied after theme swaps and on startup (`App.OnStartup` and after theme change `ApplyTheme`) so user tokens override theme dictionaries without creating duplicates.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f18666c58832b9a6d87e6bd3adf5f)