### PR TITLE
Fix startup GUI setup persistence and flush on close

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -16,6 +16,7 @@
         Background="{DynamicResource BrushAppBackground}"
         UseLayoutRounding="True"
         Loaded="MainWindow_Loaded"
+        Closing="MainWindow_Closing"
         mc:Ignorable="d">
 
     <Window.Resources>

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
@@ -296,7 +296,7 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             Log($"[APPLY] dictionary=Application keys=[{summary}]");
         }
 
-        private static bool TryGetEffectiveResource(Window? window, string key, out object? value, out string source)
+        public static bool TryGetEffectiveResource(Window? window, string key, out object? value, out string source)
         {
             value = null;
             source = "fallback";
@@ -407,6 +407,11 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             {
                 // swallow logging failures
             }
+        }
+
+        public static void LogError(string message, Exception ex)
+        {
+            Log(message, ex);
         }
 
         private static void LogCapture(string key, string source, object? value)


### PR DESCRIPTION
### Motivation
- Users reported `gui_setup.json` being overwritten by default/minimum values during startup because Setup GUI controls fired change events while the window was initializing.
- Prevent Setup GUI control events from applying/persisting resources during startup and when the popup is closed to avoid unintended saves.
- Ensure settings are flushed to disk on app exit so the debounce timer cannot drop the final state.

### Description
- Added two flags `_isGuiSetupSyncingControls` and `_isGuiSetupInitialized` and set them during `MainWindow` construction to control event handling during startup.
- Implemented `SyncSetupGuiControlsFromResources()` which reads effective resources via `GuiSetupSettingsService.TryGetEffectiveResource(...)`, updates sliders/combos/color textboxes while ` _isGuiSetupSyncingControls` is true, and logs start/end without calling persist.
- Updated all Setup GUI handlers (`FontFamilyCombo_SelectionChanged`, `FontSizeSlider_ValueChanged`, `ColorTextBox_LostFocus`) to early-return when not initialized, while syncing, or when `GuiSetupPopup` is closed, and emit debug logs for ignored events.
- Added a `Closing=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f1d966228832bbe76ad14c43b11e2)