### PR TITLE
Fix nullable master center logging in LogAnalyzeApplyState

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -11433,7 +11433,18 @@ namespace BrakeDiscInspector_GUI_ROI
             var m1 = _lastM1CenterPx;
             var m2 = _lastM2CenterPx;
             var mid = _lastMidCenterPx;
-            GuiLog.Info($"[ApplyAnalyzeResult] crosses M1=({m1.X},{m1.Y}) M2=({m2.X},{m2.Y}) MID=({mid.X},{mid.Y})");
+            string FormatCenter(CvPoint? point, string label)
+            {
+                if (point is not CvPoint pt)
+                {
+                    GuiLog.Warn($"[ApplyAnalyzeResult] {label} center is null; skipping.");
+                    return "null";
+                }
+
+                return $"({pt.X},{pt.Y})";
+            }
+
+            GuiLog.Info($"[ApplyAnalyzeResult] crosses M1={FormatCenter(m1, "M1")} M2={FormatCenter(m2, "M2")} MID={FormatCenter(mid, "MID")}");
 
             if (_layout == null)
             {


### PR DESCRIPTION
### Motivation
- Avoid nullable dereference on master center points (`_lastM1CenterPx`, `_lastM2CenterPx`, `_lastMidCenterPx`) that caused errors when any center was null. 
- Prevent runtime exceptions and CS1061-like issues by safely handling `CvPoint?` before accessing `X`/`Y`.
- Keep ROI reposition behavior unchanged while making logging robust.

### Description
- Replaced direct `m1.X/m1.Y` style dereferences with a local `FormatCenter` function that uses pattern matching (`if (point is not CvPoint pt)`) to safely unwrap `CvPoint?` values. 
- The `FormatCenter` function logs a `GuiLog.Warn` when a center is null and returns a `null` marker string, and otherwise formats `({X},{Y})` from the unwrapped point. 
- Updated the `GuiLog.Info` call in `LogAnalyzeApplyState` to use `FormatCenter` for `M1`, `M2`, and `MID` centers. 
- Change is limited to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` and does not alter ROI logic.

### Testing
- No automated tests were executed as part of this change. 
- The change is minimal and compiles by removing unsafe nullable dereferences in logging, but a full build/test is recommended before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694ff14fa840832b9633ddfa8d2a3adf)