### PR TITLE
Fix master ROI reposition acceptance and add VISCONF diagnostics

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -108,7 +108,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
     public sealed class AnalyzeOptions
     {
-        public double PosTolPx { get; set; } = 1.0;
+        public double PosTolPx { get; set; } = 50.0;
         public double AngTolDeg { get; set; } = 0.5;
         public bool ScaleLock { get; set; } = true;
         public bool DisableRot { get; set; } = false;


### PR DESCRIPTION
### Motivation
- The master reposition flow was effectively clamping/rejecting detected cross shifts due to a tiny `posTol` and acceptance logic that could cap motion instead of using raw detections. 
- We need to accept good matches by score and only use `posTol` as a validation/sanity gate, not as a motion clamp. 
- Improve visibility into what the matcher produced and why a detection was accepted/rejected via structured VISCONF logs. 

### Description
- Changed `AcceptNewDetectionIfDifferent` signature to accept per-master scores (`score1`, `score2`) and updated acceptance logic to prefer `score`-based acceptance while treating `PosTolPx` only as a validation gate (no clamping of deltas); kept fallback to last-accepted/baseline when detection is rejected. 
- Added detailed VISCONF logging helpers and emitted `RAW`, `DELTA`, `FINAL`, and `FAIL` messages around the analyze-master flow using `LogAnalyzeMasterRawVisConf`, `LogAnalyzeMasterDeltaVisConf`, `LogAnalyzeMasterFinalVisConf`, and `LogAnalyzeMasterFailureDetailVisConf`. 
- Ensured UI updates/redraws run on the UI thread by wrapping redraw calls in `UI(() => ...)` when applying reposition and added score info to acceptance logs. 
- Increased the default positional tolerance from `1.0` to `50.0` pixels in both `MainWindow.xaml.cs` (`_analyzePosTolPx`) and `MasterLayout.cs` (`AnalyzeOptions.PosTolPx`) to avoid accidental tiny-tolerance rejections.

### Testing
- No automated tests were executed for this change.
- Manual verification checklist added in code comments and PR notes (run `Analyze Masters` and inspect VISCONF logs for `[RAW]`, `[DELTA]`, and `[FINAL]` entries to confirm raw match vs baseline vs final points).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694ff85a66c4832bb8329b015ae7b8ca)