### PR TITLE
Fix CS1503: accept string in VisConfLog (FormattableString overloads)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2470,27 +2470,57 @@ namespace BrakeDiscInspector_GUI_ROI
             double score2,
             double posTol)
         {
-            VisConfLog.AnalyzeMaster(FormattableString.Invariant(
-                $"[VISCONF][ANALYZE_MASTER][RAW] key='{imageKey}' file='{fileName}' " +
-                $"M1_base=({baseM1.X:0.###},{baseM1.Y:0.###}) M2_base=({baseM2.X:0.###},{baseM2.Y:0.###}) " +
-                $"M1_raw=({rawM1.X:0.###},{rawM1.Y:0.###}) score1={score1:0.###} " +
-                $"M2_raw=({rawM2.X:0.###},{rawM2.Y:0.###}) score2={score2:0.###} " +
-                $"posTolPx={posTol:0.###}"));
+            var message = FormattableStringFactory.Create(
+                "[VISCONF][ANALYZE_MASTER][RAW] key='{0}' file='{1}' " +
+                "M1_base=({2:0.###},{3:0.###}) M2_base=({4:0.###},{5:0.###}) " +
+                "M1_raw=({6:0.###},{7:0.###}) score1={8:0.###} " +
+                "M2_raw=({9:0.###},{10:0.###}) score2={11:0.###} " +
+                "posTolPx={12:0.###}",
+                imageKey,
+                fileName,
+                baseM1.X,
+                baseM1.Y,
+                baseM2.X,
+                baseM2.Y,
+                rawM1.X,
+                rawM1.Y,
+                score1,
+                rawM2.X,
+                rawM2.Y,
+                score2,
+                posTol);
+            VisConfLog.AnalyzeMaster(message);
         }
 
         private void LogAnalyzeMasterDeltaVisConf(string imageKey, string fileName, SWPoint baseM1, SWPoint baseM2, SWPoint rawM1, SWPoint rawM2)
         {
-            VisConfLog.AnalyzeMaster(FormattableString.Invariant(
-                $"[VISCONF][ANALYZE_MASTER][DELTA] key='{imageKey}' file='{fileName}' " +
-                $"dM1=({rawM1.X - baseM1.X:0.###},{rawM1.Y - baseM1.Y:0.###}) " +
-                $"dM2=({rawM2.X - baseM2.X:0.###},{rawM2.Y - baseM2.Y:0.###})"));
+            var message = FormattableStringFactory.Create(
+                "[VISCONF][ANALYZE_MASTER][DELTA] key='{0}' file='{1}' " +
+                "dM1=({2:0.###},{3:0.###}) " +
+                "dM2=({4:0.###},{5:0.###})",
+                imageKey,
+                fileName,
+                rawM1.X - baseM1.X,
+                rawM1.Y - baseM1.Y,
+                rawM2.X - baseM2.X,
+                rawM2.Y - baseM2.Y);
+            VisConfLog.AnalyzeMaster(message);
         }
 
         private void LogAnalyzeMasterFinalVisConf(string imageKey, string fileName, bool accepted, string reason, SWPoint finalM1, SWPoint finalM2)
         {
-            VisConfLog.AnalyzeMaster(FormattableString.Invariant(
-                $"[VISCONF][ANALYZE_MASTER][FINAL] key='{imageKey}' file='{fileName}' accepted={accepted} reason='{reason}' " +
-                $"M1_final=({finalM1.X:0.###},{finalM1.Y:0.###}) M2_final=({finalM2.X:0.###},{finalM2.Y:0.###})"));
+            var message = FormattableStringFactory.Create(
+                "[VISCONF][ANALYZE_MASTER][FINAL] key='{0}' file='{1}' accepted={2} reason='{3}' " +
+                "M1_final=({4:0.###},{5:0.###}) M2_final=({6:0.###},{7:0.###})",
+                imageKey,
+                fileName,
+                accepted,
+                reason,
+                finalM1.X,
+                finalM1.Y,
+                finalM2.X,
+                finalM2.Y);
+            VisConfLog.AnalyzeMaster(message);
         }
 
         private void LogAnalyzeMasterVisConf(

--- a/gui/BrakeDiscInspector_GUI_ROI/Util/VisConfLog.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Util/VisConfLog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace BrakeDiscInspector_GUI_ROI.Util
@@ -19,15 +20,55 @@ namespace BrakeDiscInspector_GUI_ROI.Util
 
         public static void Gui(string message) => GuiLog.Info(message);
 
+        public static void Gui(FormattableString message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            Gui(message.ToString(CultureInfo.InvariantCulture));
+        }
+
         public static void GuiAndRoi(string message)
         {
             Gui(message);
             Roi(message);
         }
 
+        public static void GuiAndRoi(FormattableString message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            GuiAndRoi(message.ToString(CultureInfo.InvariantCulture));
+        }
+
         public static void Roi(string message) => WriteLine(RoiCoordsPath, message);
 
+        public static void Roi(FormattableString message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            Roi(message.ToString(CultureInfo.InvariantCulture));
+        }
+
         public static void AnalyzeMaster(string message) => WriteLine(AnalyzeMasterPath, message);
+
+        public static void AnalyzeMaster(FormattableString message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            AnalyzeMaster(message.ToString(CultureInfo.InvariantCulture));
+        }
 
         private static void WriteLine(string path, string message)
         {


### PR DESCRIPTION
### Motivation
- The build failed with CS1503 when calling `VisConfLog.AnalyzeMaster(...)` with plain `string` because the helper only accepted `FormattableString` at some call sites. 
- The intent is to allow logging helpers to accept both `FormattableString` and `string` with minimal, low-risk changes. 
- Keep existing log messages and formatting behavior (invariant culture) while removing the need for call-site changes. 

### Description
- Added `FormattableString` overloads to `gui/BrakeDiscInspector_GUI_ROI/Util/VisConfLog.cs` for `Gui`, `GuiAndRoi`, `Roi`, and `AnalyzeMaster` that forward to the `string` variants using `CultureInfo.InvariantCulture`. 
- Updated the three problematic `VisConfLog.AnalyzeMaster(...)` call sites in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` to build `FormattableString` values via `FormattableStringFactory.Create(...)` and invoke `VisConfLog.AnalyzeMaster(...)` to preserve formatting and avoid conversion errors. 
- Added the required `using System.Globalization;` where needed and kept the log text/formatting unchanged. 

### Testing
- Attempted to run `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` but `dotnet` was not available in the environment so a full build could not be executed. 
- Ran automated repository searches (`rg`) to identify all `VisConfLog` and `FormattableString` usages and confirmed the modified call sites were covered by the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694ffc0fe3c0832b97c628c25fdd2c9f)