### PR TITLE
Fix CS1503: add string overload for LogAlign in InspectionAlignmentHelper

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -10,6 +10,18 @@ namespace BrakeDiscInspector_GUI_ROI;
 
 internal static class InspectionAlignmentHelper
 {
+    private static void LogAlign(Action<string>? trace, string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        var payload = "[ALIGN]" + message;
+        GuiLog.Info(payload);
+        trace?.Invoke(payload);
+    }
+
     private static void LogAlign(Action<string>? trace, FormattableString message)
     {
         if (message == null)
@@ -17,9 +29,7 @@ internal static class InspectionAlignmentHelper
             return;
         }
 
-        var payload = "[ALIGN]" + message.ToString(CultureInfo.InvariantCulture);
-        GuiLog.Info(payload);
-        trace?.Invoke(payload);
+        LogAlign(trace, message.ToString(CultureInfo.InvariantCulture));
     }
 
     internal static (double Tx, double Ty) ComputeTranslation(


### PR DESCRIPTION
### Motivation
- The build reported CS1503 errors when plain `string` literals were passed to logging helpers that previously only accepted `FormattableString`.
- Make the logging helper accept both `FormattableString` and `string` so callers using plain literals or interpolated strings compile without changes.
- Preserve invariant-culture rendering for structured/interpolated messages to keep log formatting stable.

### Description
- Added a `string` overload for `LogAlign(Action<string>? trace, string message)` in `InspectionAlignmentHelper.cs` and kept a `FormattableString` overload that forwards through `FormattableString.ToString(CultureInfo.InvariantCulture)`.
- The new `string` path guards against empty/whitespace messages and builds the `[ALIGN]` payload before calling `GuiLog.Info` and the optional `trace` delegate.
- This is a minimal, localized change that funnels `FormattableString` rendering into the existing string-based pipeline and preserves existing logging behavior.
- Modified file: `gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695048801468832bb0bdbcad6c4a22e9)