### PR TITLE
Use FormattableStringFactory for AnalyzeMaster visconf logging

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2514,12 +2514,26 @@ namespace BrakeDiscInspector_GUI_ROI
             double posTol,
             double angTol)
         {
-            VisConfLog.AnalyzeMaster(FormattableString.Invariant(
-                $"[VISCONF][ANALYZE_MASTER][START] key='{imageKey}' file='{fileName}' path='{imagePath}' " +
-                $"imgSize={imageWidth}x{imageHeight} templateKey='{templateKey}' " +
-                $"templateM1Path='{templateM1Path ?? string.Empty}' templateM2Path='{templateM2Path ?? string.Empty}' " +
-                $"templateM1Size={templateM1Size} templateM2Size={templateM2Size} " +
-                $"posTol={posTol:0.###} angTol={angTol:0.###} layout='{GetCurrentLayoutName()}'"));
+            var message = FormattableStringFactory.Create(
+                "[VISCONF][ANALYZE_MASTER][START] key='{0}' file='{1}' path='{2}' " +
+                "imgSize={3}x{4} templateKey='{5}' " +
+                "templateM1Path='{6}' templateM2Path='{7}' " +
+                "templateM1Size={8} templateM2Size={9} " +
+                "posTol={10:0.###} angTol={11:0.###} layout='{12}'",
+                imageKey,
+                fileName,
+                imagePath,
+                imageWidth,
+                imageHeight,
+                templateKey,
+                templateM1Path ?? string.Empty,
+                templateM2Path ?? string.Empty,
+                templateM1Size,
+                templateM2Size,
+                posTol,
+                angTol,
+                GetCurrentLayoutName());
+            VisConfLog.AnalyzeMaster(message);
         }
 
         private void LogAnalyzeMasterMatchVisConf(


### PR DESCRIPTION
### Motivation
- Fix a CS1503-style mismatch by avoiding passing a plain `string` where a `FormattableString` overload is expected in VisConf logging.
- Keep changes minimal and robust by constructing a `FormattableString` rather than editing many call sites.

### Description
- Replace the concatenated interpolated call to `FormattableString.Invariant(...)` with a `FormattableStringFactory.Create(...)` invocation and pass the resulting `FormattableString` to `VisConfLog.AnalyzeMaster`.
- Change was applied in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` around line ~2517 in the `LogAnalyzeMasterStartVisConf` method.
- The new code assigns `var message = FormattableStringFactory.Create(...)` and then calls `VisConfLog.AnalyzeMaster(message);` to ensure correct overload resolution.
- No other call sites were modified.

### Testing
- Attempted to build with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, but `dotnet` is not available in the execution environment so the build could not be run (failed).
- Verified edits with a repository-wide search to ensure only the intended logging call was changed and committed the file update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69504d0d44cc832ba9cb81738c1d9280)