### PR TITLE
Fix inspection ROI repositioning drift in Analyze Master

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/InspectionAlignmentHelper.cs
@@ -73,7 +73,8 @@ internal static class InspectionAlignmentHelper
         // ROI scaling is disabled globally: ROIs must keep fixed size/offset across images.
         // Keep anchors.Scale only for logging/diagnostics.
         var scaleRequested = anchors.Scale;
-        var scaleEffective = 1.0;
+        var scaleEffective = anchors.ScaleLock ? 1.0 : anchors.Scale;
+        var angleDeltaDeg = anchors.AngleDeltaGlobal * 180.0 / Math.PI;
 
         var cosA = Math.Cos(rotForCenter);
         var sinA = Math.Sin(rotForCenter);
@@ -132,6 +133,15 @@ internal static class InspectionAlignmentHelper
                 scaleEffective,
                 tx,
                 ty,
+                anchors.ScaleLock,
+                anchors.DisableRot));
+        LogAlign(trace,
+            FormattableStringFactory.Create(
+                "[BATCH][ROI] roi={0} angle_delta_deg={1:0.###} scale_req={2:0.####} scale_eff={3:0.####} scaleLock={4} disableRot={5}",
+                inspectionTarget.Label ?? inspectionTarget.Id,
+                angleDeltaDeg,
+                scaleRequested,
+                scaleEffective,
                 anchors.ScaleLock,
                 anchors.DisableRot));
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -1,8 +1,11 @@
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using System.Windows.Threading;
+using BrakeDiscInspector_GUI_ROI.Util;
 
 
 namespace BrakeDiscInspector_GUI_ROI
@@ -18,10 +21,14 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (ViewModel != null)
             {
+                VisConfLog.AnalyzeMaster(FormattableStringFactory.Create(
+                    "[VISCONF][ANALYZE_MASTER][BACKEND] image='{0}'",
+                    _currentImagePathWin));
                 await ViewModel.RepositionMastersAsync(_currentImagePathWin);
+                await ViewModel.RepositionInspectionRoisAsync(_currentImagePathWin);
             }
 
-            RedrawOverlay();
+            await Dispatcher.InvokeAsync(() => RedrawOverlay(), DispatcherPriority.Render);
         }
 
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2236,6 +2236,12 @@ namespace BrakeDiscInspector_GUI_ROI
                     continue;
 
                 var (beforeCx, beforeCy) = GetCenterShapeAware(baseline);
+                VisConfLog.AnalyzeMaster(FormattableStringFactory.Create(
+                    "[VISCONF][INSP_BASE] key='{0}' file='{1}' roi='{2}' baseline={3}",
+                    visImageKey,
+                    visFileName,
+                    target.Label ?? target.Id ?? "<null>",
+                    DescribeRoi(baseline)));
                 ApplyRoiTransform(target, baseline, pivotOld.X, pivotOld.Y, pivotNew.X, pivotNew.Y, scaleFactor, angleDelta);
                 if (_imgW > 0 && _imgH > 0)
                 {
@@ -2243,6 +2249,12 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
 
                 var (afterCx, afterCy) = GetCenterShapeAware(target);
+                VisConfLog.AnalyzeMaster(FormattableStringFactory.Create(
+                    "[VISCONF][INSP_APPLIED] key='{0}' file='{1}' roi='{2}' applied={3}",
+                    visImageKey,
+                    visFileName,
+                    target.Label ?? target.Id ?? "<null>",
+                    DescribeRoi(target)));
 
                 moved++;
                 firstBefore ??= new SWPoint(beforeCx, beforeCy);


### PR DESCRIPTION
### Motivation
- Inspection ROIs drift when `Analyze Master` is run multiple times because transforms were applied on top of already-mutated ROIs instead of a stable baseline.
- The alignment helper forced `scaleEffective = 1.0` which ignored legitimate scale changes reported by the matcher when `ScaleLock` is not enabled.
- Repositioning and redraw must run on the UI thread and emit focused logs to verify baseline vs applied transforms.
- Changes should be minimal and keep existing baseline semantics (fixed vs rolling) intact.

### Description
- Respect layout snapshot baselines by preferring the original layout ROI when seeding baselines via `GetLayoutBaselineRoi` and using `EnsureLayoutOriginalSnapshot()` to preserve stable baselines during repositioning.
- Update `EnsureBaselineForRoi` to use the layout snapshot baseline when available so transforms are always computed from an immutable baseline model rather than the current ROI state.
- Add `RepositionInspectionRoisAsync(string)` to `WorkflowViewModel` that computes anchor context and invokes `RepositionInspectionRois` on the UI thread, and call it from `AnalyzeMastersViaBackend` so inspection ROIs are repositioned after masters are updated.
- Fix scaling in `InspectionAlignmentHelper.MoveInspectionTo(...)` by using `var scaleEffective = anchors.ScaleLock ? 1.0 : anchors.Scale;` and add focused `VisConfLog`/alignment logs (`AnalyzeMaster` + per-ROI `INSP_BASE`/`INSP_APPLIED`) to verify requested vs applied scale/angle and baseline/applied ROI geometry.

### Testing
- No automated tests were executed as part of this change (no test run requested).
- Existing unit tests to exercise alignment behavior include `InspectionAlignmentHelperTests`; please run the test suite (`dotnet test` / IDE) to verify no regressions after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69505885f1cc832ea5735e7f93527211)