### PR TITLE
Fix analyze master start log formatting

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -11532,9 +11532,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 effectiveAnalyze.ScaleMin,
                 effectiveAnalyze.ScaleMax);
 
-            AppendLog(FormattableString.Invariant(
+            AppendLog(
                 $"[ANALYZE_MASTER][START] key='{analyzeImageKey}' keyDetail='{_lastImageKeyDetail}' posTol={posTolForLog:0.###} angTol={angTolForLog:0.###} " +
-                $"minScore=({effectiveAnalyze.ThrM1},{effectiveAnalyze.ThrM2}) scaleLock={effectiveAnalyze.ScaleLock} lockRotation={effectiveAnalyze.DisableRot} useLocalMatcher={useLocalMatcher}"));
+                $"minScore=({effectiveAnalyze.ThrM1},{effectiveAnalyze.ThrM2}) scaleLock={effectiveAnalyze.ScaleLock} lockRotation={effectiveAnalyze.DisableRot} useLocalMatcher={useLocalMatcher}");
 
             ViewModel?.TraceManual($"[manual-master] analyze file='{Path.GetFileName(ViewModel?.CurrentManualImagePath ?? string.Empty)}'");
 


### PR DESCRIPTION
### Motivation
- Fix a compilation/logging mismatch in the analyze-master start logging call in `MainWindow.xaml.cs` which led to a `CS1503` conversion error.  
- Ensure logging calls use the expected `string` parameter form for `AppendLog` to avoid overload/type issues.  
- Keep the log message content and formatting intact while resolving the type mismatch.  

### Description
- Replaced the call `AppendLog(FormattableString.Invariant(...))` with a direct interpolated string call `AppendLog($"...")` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.  
- Preserved the original interpolated message contents and concatenation while removing the `FormattableString.Invariant` wrapper.  
- Change is limited to the single logging invocation and does not alter runtime behavior beyond logging.  

### Testing
- No automated tests were executed for this change.  
- No build or CI runs were performed as part of this PR.  
- The change is a minimal source-level fix restricted to `AppendLog` usage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6951a12cc21c832eb4173725ab54b8e3)