### PR TITLE
Fix invariant logging format strings

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2211,15 +2211,12 @@ namespace BrakeDiscInspector_GUI_ROI
         private void LogPlacement(RoiPlacementOutput output, string imageKey, RoiPlacementInput input)
         {
             AppendLog(FormattableString.Invariant(
-                $"[PLACE][SUMMARY] key={imageKey} disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
-                $"scale={output.Debug.Scale:0.####} angDelta={output.Debug.AngleDeltaDeg:0.###} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
+                $"[PLACE][SUMMARY] key={imageKey} disableRot={input.DisableRot} scaleLock={input.ScaleLock} scale={output.Debug.Scale:0.####} angDelta={output.Debug.AngleDeltaDeg:0.###} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
 
             foreach (var detail in output.Debug.RoiDetails)
             {
                 AppendLog(FormattableString.Invariant(
-                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) " +
-                    $"sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +
-                    $"sizeNew=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
+                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) sizeNew=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
             }
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -5687,8 +5687,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             var key = Path.GetFileName(CurrentImagePath ?? string.Empty);
             LogAlign(FormattableString.Invariant(
-                $"[PLACE][SUMMARY] key='{key}' disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
-                $"scale={output.Debug.Scale:0.####} angDelta={output.Debug.AngleDeltaDeg:0.###} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
+                $"[PLACE][SUMMARY] key='{key}' disableRot={input.DisableRot} scaleLock={input.ScaleLock} scale={output.Debug.Scale:0.####} angDelta={output.Debug.AngleDeltaDeg:0.###} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
 
             if (output.Debug.RoiDetails == null)
             {
@@ -5698,9 +5697,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             foreach (var detail in output.Debug.RoiDetails)
             {
                 LogAlign(FormattableString.Invariant(
-                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) " +
-                    $"sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +
-                    $"sizeNew=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
+                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) sizeNew=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
             }
         }
 


### PR DESCRIPTION
### Motivation
- Fix CS1503 errors caused by concatenating interpolated string fragments which produced `string` instead of `System.FormattableString` for `FormattableString.Invariant` calls.
- Ensure placement logging compiles and emits invariant-formatted messages in the GUI placement code paths.
- Align logging format between the main window and workflow view model for consistent diagnostics.
- Prevent similar compile-time issues when composing complex interpolated log messages.

### Description
- Replace concatenated interpolated fragments with a single interpolated `FormattableString` passed to `FormattableString.Invariant` for placement logs.
- Updated `AppendLog`/`LogAlign` placement messages in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` and `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs`.
- Consolidated the placement summary and per-ROI detail interpolations so the `scale`, `sizeBase`, and `sizeNew` fields are included in a single interpolated string.
- Changes committed with message `Fix invariant log formatting`.

### Testing
- No automated tests were run for this change.
- Please run `dotnet build` for the WPF solution to validate compilation in CI.
- Recommend executing the repository's CI pipeline to confirm there are no regressions after the logging changes.
- Existing automated tests (if any) should be run in CI to verify runtime behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953089c11c8832bbdb8ccf2748de96f)