### PR TITLE
Fix deterministic ROI placement and baseline selection

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiPlacementEngineTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiPlacementEngineTests.cs
@@ -210,4 +210,44 @@ public class RoiPlacementEngineTests
         Assert.Equal(a1.Height, a2.Height, 6);
         Assert.NotEqual(a1.X, outputB.InspectionsPlaced.Single().X, 6);
     }
+
+    [Fact]
+    public void ScaleNeverAppliesToOffsetOrSize()
+    {
+        var baselineMasters = new List<RoiModel>
+        {
+            new RoiModel { Role = RoiRole.Master1Pattern, Shape = RoiShape.Rectangle, X = 0, Y = 0, Width = 10, Height = 10 },
+            new RoiModel { Role = RoiRole.Master2Pattern, Shape = RoiShape.Rectangle, X = 10, Y = 0, Width = 10, Height = 10 }
+        };
+
+        var inspection = new RoiModel
+        {
+            Id = "r1",
+            Shape = RoiShape.Rectangle,
+            X = 4,
+            Y = 2,
+            Width = 6,
+            Height = 8,
+            AngleDeg = 0
+        };
+
+        var input = new RoiPlacementInput(
+            new ImgPoint(0, 0),
+            new ImgPoint(10, 0),
+            new ImgPoint(0, 0),
+            new ImgPoint(20, 0),
+            DisableRot: false,
+            ScaleLock: false,
+            ScaleMode.OffsetOnly,
+            true,
+            new Dictionary<string, MasterAnchorChoice> { ["r1"] = MasterAnchorChoice.Master1 });
+
+        var output = RoiPlacementEngine.Place(input, baselineMasters, new List<RoiModel> { inspection });
+        var placed = output.InspectionsPlaced.Single();
+
+        Assert.Equal(4, placed.X, 6);
+        Assert.Equal(2, placed.Y, 6);
+        Assert.Equal(6, placed.Width, 6);
+        Assert.Equal(8, placed.Height, 6);
+    }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
@@ -35,10 +35,15 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         MasterAnchorChoice Anchor,
         ImgPoint BaselineCenter,
         ImgPoint NewCenter,
+        ImgPoint Delta,
         double BaseWidth,
         double BaseHeight,
         double BaseR,
         double BaseRInner,
+        double NewWidth,
+        double NewHeight,
+        double NewR,
+        double NewRInner,
         double AngleBase,
         double AngleNew);
 
@@ -132,15 +137,14 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     {
                         var vBase = baselineCenter - pivotBase;
                         var vRot = Rotate(vBase, angDelta);
-                        var vFinal = (input.ScaleMode == ScaleMode.OffsetOnly && !input.ScaleLock)
-                            ? vRot * scale
-                            : vRot;
-                        newCenter = pivotDet + vFinal;
+                        newCenter = pivotDet + vRot;
                         newAngle = baseline.AngleDeg + angDeltaDeg;
                     }
 
                     ApplyCenter(placed, newCenter);
                     placed.AngleDeg = newAngle;
+
+                    var deltaCenter = new ImgPoint(newCenter.X - baselineCenter.X, newCenter.Y - baselineCenter.Y);
 
                     inspectionPlaced.Add(placed);
                     debugEntries.Add(new PlacementRoiDebug(
@@ -148,10 +152,15 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                         anchor,
                         baselineCenter,
                         newCenter,
+                        deltaCenter,
                         baseline.Width,
                         baseline.Height,
                         baseline.R,
                         baseline.RInner,
+                        placed.Width,
+                        placed.Height,
+                        placed.R,
+                        placed.RInner,
                         baseline.AngleDeg,
                         newAngle));
                 }


### PR DESCRIPTION
### Motivation
- Prevent non-deterministic drift when re-running "Analyze Master" by enforcing a single source of truth for ROI placement.
- Ensure `ScaleLock` and `DisableRot` behave as strict locks so inspection ROIs always translate with their anchor and never resize or rotate unintentionally.
- Avoid cross-image baseline leaks that cause A→B→A glitches by scoping inspection baselines to the current image key or the canonical layout snapshot.
- Make placement debug-able by adding structured math/logging to verify deltas and sizes are correct at runtime.

### Description
- Consolidated placement so all callers (batch and manual) use `RoiPlacementEngine.Place(...)` as the single source of truth and removed legacy transform application paths and per-image skip shortcuts (e.g., removed `skipIfAnchorsReady` behavior). 
- Updated `RoiPlacementEngine.Place` to: when `DisableRot==true` only apply translation deltas by anchor, and never apply computed `scale` to ROI offsets or geometry; angle is preserved unless rotation is enabled; returned debug records now include per-ROI delta and both base/new size fields. 
- Scoped baseline lookup to the image-specific snapshot or the immutable layout snapshot by changing baseline resolution in `MainWindow` helpers and `GetInspectionBaselineClone(...)` to prefer `InspectionBaselinesByImage[imageKey]` and layout-fixed baselines, avoiding scanning all keys. 
- Removed/neutralized legacy rescale/transform helpers and global batch transform usage so batch placement no longer applies a global scale/rotation to inspection geometry, and added detailed `[PLACE][SUMMARY]` / `[PLACE][ROI]` logging in `WorkflowViewModel` and `MainWindow` for math validation. 
- Added unit test `ScaleNeverAppliesToOffsetOrSize` to assert that computed scale is never applied to ROI center/size, and extended placement debug structures to support assertions and logging.

### Testing
- Added/updated unit tests in `gui/BrakeDiscInspector_GUI_ROI.Tests/RoiPlacementEngineTests.cs` including `ScaleNeverAppliesToOffsetOrSize` and existing determinism/A↔B↔A tests were kept to validate idempotency; tests were prepared in the repo but not executed in CI here. 
- Attempted to run `dotnet build` and `dotnet test` locally but the execution environment does not have the `dotnet` CLI installed so automated tests could not be run (`command not found: dotnet`). 
- Per-change logging has been added to make it straightforward to validate behavior manually or in CI by inspecting `[PLACE][SUMMARY]` and `[PLACE][ROI]` entries that include anchor bases/detections, raw scale/angle, per-ROI dx/dy, and sizes. 
- Please run `dotnet build` and `dotnet test` in a .NET-enabled environment to confirm the unit tests pass (they are expected to pass with the engine-only placement semantics implemented).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695412879970832ebe69ce2896925bde)