### PR TITLE
Fix invariant log formatting for placement traces

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2080,20 +2080,12 @@ namespace BrakeDiscInspector_GUI_ROI
         private void LogPlacement(RoiPlacementOutput output, string imageKey, RoiPlacementInput input)
         {
             AppendLog(FormattableString.Invariant(
-                $"[PLACE][SUMMARY] key={imageKey} " +
-                $"M1_base=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) M1_det=({input.DetM1.X:0.###},{input.DetM1.Y:0.###}) " +
-                $"M2_base=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) M2_det=({input.DetM2.X:0.###},{input.DetM2.Y:0.###}) " +
-                $"rawScale={output.Debug.Scale:0.####} rawAngleDeg={output.Debug.AngleDeltaDeg:0.###} disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
-                $"distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
+                $"[PLACE][SUMMARY] key={imageKey} M1_base=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) M1_det=({input.DetM1.X:0.###},{input.DetM1.Y:0.###}) M2_base=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) M2_det=({input.DetM2.X:0.###},{input.DetM2.Y:0.###}) rawScale={output.Debug.Scale:0.####} rawAngleDeg={output.Debug.AngleDeltaDeg:0.###} disableRot={input.DisableRot} scaleLock={input.ScaleLock} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
 
             foreach (var detail in output.Debug.RoiDetails)
             {
                 AppendLog(FormattableString.Invariant(
-                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) " +
-                    $"new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dx={detail.Delta.X:0.###} dy={detail.Delta.Y:0.###} " +
-                    $"sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +
-                    $"sizeNew=({detail.NewWidth:0.###},{detail.NewHeight:0.###},{detail.NewR:0.###},{detail.NewRInner:0.###}) " +
-                    $"angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
+                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dx={detail.Delta.X:0.###} dy={detail.Delta.Y:0.###} sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) sizeNew=({detail.NewWidth:0.###},{detail.NewHeight:0.###},{detail.NewR:0.###},{detail.NewRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
             }
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -5539,11 +5539,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             var key = Path.GetFileName(CurrentImagePath ?? string.Empty);
             LogAlign(FormattableString.Invariant(
-                $"[PLACE][SUMMARY] key='{key}' " +
-                $"M1_base=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) M1_det=({input.DetM1.X:0.###},{input.DetM1.Y:0.###}) " +
-                $"M2_base=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) M2_det=({input.DetM2.X:0.###},{input.DetM2.Y:0.###}) " +
-                $"rawScale={output.Debug.Scale:0.####} rawAngleDeg={output.Debug.AngleDeltaDeg:0.###} disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
-                $"distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
+                $"[PLACE][SUMMARY] key='{key}' M1_base=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) M1_det=({input.DetM1.X:0.###},{input.DetM1.Y:0.###}) M2_base=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) M2_det=({input.DetM2.X:0.###},{input.DetM2.Y:0.###}) rawScale={output.Debug.Scale:0.####} rawAngleDeg={output.Debug.AngleDeltaDeg:0.###} disableRot={input.DisableRot} scaleLock={input.ScaleLock} distBase={output.Debug.DistBase:0.###} distDet={output.Debug.DistDet:0.###}"));
 
             if (output.Debug.RoiDetails == null)
             {
@@ -5553,11 +5549,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             foreach (var detail in output.Debug.RoiDetails)
             {
                 LogAlign(FormattableString.Invariant(
-                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) " +
-                    $"new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dx={detail.Delta.X:0.###} dy={detail.Delta.Y:0.###} " +
-                    $"sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +
-                    $"sizeNew=({detail.NewWidth:0.###},{detail.NewHeight:0.###},{detail.NewR:0.###},{detail.NewRInner:0.###}) " +
-                    $"angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
+                    $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} base=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) new=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dx={detail.Delta.X:0.###} dy={detail.Delta.Y:0.###} sizeBase=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) sizeNew=({detail.NewWidth:0.###},{detail.NewHeight:0.###},{detail.NewR:0.###},{detail.NewRInner:0.###}) angleBase={detail.AngleBase:0.###} angleNew={detail.AngleNew:0.###}"));
             }
         }
 


### PR DESCRIPTION
### Motivation
- The compiler raised `CS1503` errors because `FormattableString.Invariant` was being passed a `string` produced by concatenating interpolated fragments.
- Placement summary and per-ROI detail logs used multi-part concatenation which prevented producing a `FormattableString` directly.
- The intent is to restore correct invariant-culture logging while eliminating the build-time type mismatch.

### Description
- Collapse concatenated interpolated fragments into single interpolated strings so `FormattableString.Invariant` receives a `FormattableString` instead of `string`.
- Updated placement logging in `LogPlacement` inside `MainWindow.xaml.cs` and `LogBatchPlacement` inside `Workflow/WorkflowViewModel.cs` to use single interpolations for summary and ROI detail lines.
- No runtime behavior or log content semantics were changed aside from formatting the invocation into one interpolated expression.

### Testing
- No automated tests or CI jobs were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695416ccb7e8832e96ed492b56c641dc)