### PR TITLE
Fix analyze option defaults and logging

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4284,6 +4284,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             var layoutAnalyze = _layout?.Analyze;
             var layoutUi = _layout?.Ui;
+            var defaults = new AnalyzeOptions();
 
             SyncPresetUiFromLayoutAnalyzeOptions();
 
@@ -4296,6 +4297,15 @@ namespace BrakeDiscInspector_GUI_ROI
             int thrM1 = layoutAnalyze?.ThrM1 > 0 ? layoutAnalyze.ThrM1 : 85;
             int thrM2 = layoutAnalyze?.ThrM2 > 0 ? layoutAnalyze.ThrM2 : 85;
             bool useLocalMatcher = layoutAnalyze?.UseLocalMatcher ?? true;
+            int rotRange = layoutAnalyze?.RotRange > 0
+                ? layoutAnalyze.RotRange
+                : (_preset?.RotRange > 0 ? _preset.RotRange : defaults.RotRange);
+            double scaleMin = layoutAnalyze != null && IsPositiveFinite(layoutAnalyze.ScaleMin)
+                ? layoutAnalyze.ScaleMin
+                : (_preset != null && IsPositiveFinite(_preset.ScaleMin) ? _preset.ScaleMin : defaults.ScaleMin);
+            double scaleMax = layoutAnalyze != null && IsPositiveFinite(layoutAnalyze.ScaleMax)
+                ? layoutAnalyze.ScaleMax
+                : (_preset != null && IsPositiveFinite(_preset.ScaleMax) ? _preset.ScaleMax : defaults.ScaleMax);
             double opacity = layoutUi != null && layoutUi.HeatmapOverlayOpacity >= 0
                 ? Math.Max(0.0, Math.Min(1.0, layoutUi.HeatmapOverlayOpacity))
                 : defaultOpacity;
@@ -4310,8 +4320,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             InspLog($"[layout-load] Analyze: featureM1='{featureM1}' thrM1={thrM1} featureM2='{featureM2}' thrM2={thrM2} " +
                     $"posTolPx={posTol:0.###} angTolDeg={angTol:0.###} scaleLock={scaleLock} disableRot={disableRot} useLocalMatcher={useLocalMatcher} " +
-                    $"rotRange={layoutAnalyze?.RotRange ?? _preset?.RotRange ?? 0} scaleMin={layoutAnalyze?.ScaleMin ?? _preset?.ScaleMin ?? 0:0.####} " +
-                    $"scaleMax={layoutAnalyze?.ScaleMax ?? _preset?.ScaleMax ?? 0:0.####}");
+                    $"rotRange={rotRange} scaleMin={scaleMin:0.####} scaleMax={scaleMax:0.####}");
 
             _inspectionBaselinesByImage.Clear();
             if (_layout?.InspectionBaselinesByImage != null)

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
@@ -259,26 +259,30 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
         private static void LogPlacement(RoiPlacementInput input, bool translateOnly, PlacementDebug debug)
         {
-            Util.GuiLog.Info(FormattableString.Invariant(
+            FormattableString summary =
                 $"[PLACE][SUMMARY] imageKey='{input.ImageKey ?? "<none>"}' disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
                 $"translateOnly={translateOnly} baseM1=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) " +
                 $"baseM2=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) " +
                 $"detM1=({input.DetM1.X:0.###},{input.DetM1.Y:0.###}) " +
-                $"detM2=({input.DetM2.X:0.###},{input.DetM2.Y:0.###})"));
-            Util.GuiLog.Info(FormattableString.Invariant(
+                $"detM2=({input.DetM2.X:0.###},{input.DetM2.Y:0.###})";
+            Util.GuiLog.Info(summary);
+
+            FormattableString deltas =
                 $"[PLACE][DELTAS] dM1=({debug.DeltaM1.X:0.###},{debug.DeltaM1.Y:0.###}) " +
                 $"dM2=({debug.DeltaM2.X:0.###},{debug.DeltaM2.Y:0.###}) " +
                 $"dMid=({debug.DeltaMid.X:0.###},{debug.DeltaMid.Y:0.###}) " +
-                $"angDeltaDeg={debug.AngleDeltaDeg:0.###} scale={debug.Scale:0.####}"));
+                $"angDeltaDeg={debug.AngleDeltaDeg:0.###} scale={debug.Scale:0.####}";
+            Util.GuiLog.Info(deltas);
 
             foreach (var detail in debug.RoiDetails)
             {
-                Util.GuiLog.Info(FormattableString.Invariant(
+                FormattableString roiDetail =
                     $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} baseC=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) " +
                     $"newC=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dxdy=({detail.Delta.X:0.###},{detail.Delta.Y:0.###}) " +
                     $"baseSize=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +
                     $"newSize=({detail.NewWidth:0.###},{detail.NewHeight:0.###},{detail.NewR:0.###},{detail.NewRInner:0.###}) " +
-                    $"baseAng={detail.AngleBase:0.###} newAng={detail.AngleNew:0.###}"));
+                    $"baseAng={detail.AngleBase:0.###} newAng={detail.AngleNew:0.###}";
+                Util.GuiLog.Info(roiDetail);
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Prevent runtime/compile errors caused by missing analyze option variables referenced during UI initialization by providing explicit defaults for rotation and scale.
- Ensure placement logging uses the `FormattableString` overloads so invariant-culture structured messages are preserved and avoid overload conversion errors.

### Description

- Initialize `rotRange`, `scaleMin`, and `scaleMax` in `InitializeOptionsFromConfig` using `var defaults = new AnalyzeOptions()` and multi-level fallbacks (`layout`, `_preset`, `defaults`) to avoid undefined references in `MainWindow.xaml.cs`.
- Replace direct `FormattableString.Invariant(...)` / string logging usages in `Workflow/RoiPlacementEngine.cs` with `FormattableString` local variables and call `Util.GuiLog.Info(FormattableString)` to retain invariant formatting and fix `CS1503` overload mismatches.
- Changes touch `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` and `gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs` and keep existing public APIs intact.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6954412e8654832ebe4199a4f01751d6)