### PR TITLE
Fix logging format overload usage

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4374,9 +4374,9 @@ namespace BrakeDiscInspector_GUI_ROI
             SetFeatureSelection(featureM1);
             SetFeatureSelectionM2(featureM2);
 
-            GuiLog.Info(FormattableString.Invariant(
+            GuiLog.Info(
                 $"[LAYOUT-LOAD][ANALYZE] featureM1={featureM1} thrM1={thrM1} featureM2={featureM2} thrM2={thrM2} " +
-                $"scaleLock={scaleLock} disableRot={disableRot} rotRange={rotRange} scaleMin={scaleMin:0.###} scaleMax={scaleMax:0.###}"));
+                $"scaleLock={scaleLock} disableRot={disableRot} rotRange={rotRange} scaleMin={scaleMin:0.###} scaleMax={scaleMax:0.###}");
 
             PersistAnalyzeOptions();
             PersistUiOptions();

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs
@@ -259,7 +259,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
         private static void LogPlacement(RoiPlacementInput input, bool translateOnly, PlacementDebug debug)
         {
-            FormattableString summary =
+            var summary =
                 $"[PLACE][SUMMARY] imageKey='{input.ImageKey ?? "<none>"}' disableRot={input.DisableRot} scaleLock={input.ScaleLock} " +
                 $"translateOnly={translateOnly} baseM1=({input.BaseM1.X:0.###},{input.BaseM1.Y:0.###}) " +
                 $"baseM2=({input.BaseM2.X:0.###},{input.BaseM2.Y:0.###}) " +
@@ -267,7 +267,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 $"detM2=({input.DetM2.X:0.###},{input.DetM2.Y:0.###})";
             Util.GuiLog.Info(summary);
 
-            FormattableString deltas =
+            var deltas =
                 $"[PLACE][DELTAS] dM1=({debug.DeltaM1.X:0.###},{debug.DeltaM1.Y:0.###}) " +
                 $"dM2=({debug.DeltaM2.X:0.###},{debug.DeltaM2.Y:0.###}) " +
                 $"dMid=({debug.DeltaMid.X:0.###},{debug.DeltaMid.Y:0.###}) " +
@@ -276,7 +276,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             foreach (var detail in debug.RoiDetails)
             {
-                FormattableString roiDetail =
+                var roiDetail =
                     $"[PLACE][ROI] id={detail.RoiId} anchor={detail.Anchor} baseC=({detail.BaselineCenter.X:0.###},{detail.BaselineCenter.Y:0.###}) " +
                     $"newC=({detail.NewCenter.X:0.###},{detail.NewCenter.Y:0.###}) dxdy=({detail.Delta.X:0.###},{detail.Delta.Y:0.###}) " +
                     $"baseSize=({detail.BaseWidth:0.###},{detail.BaseHeight:0.###},{detail.BaseR:0.###},{detail.BaseRInner:0.###}) " +


### PR DESCRIPTION
### Motivation
- Calls to logging helpers mixed `FormattableString.Invariant(...)` and `FormattableString`-typed temporaries which produced implicit conversion errors (CS1503 / CS0029).  
- These mismatches caused the compiler to attempt converting `string` to `System.FormattableString` for several logging sites.  
- The change aims to remove the incorrect overload usage and restore correct logging calls without changing runtime logging semantics.  

### Description
- Replaced `FormattableString`-typed temporaries with plain interpolated `string` variables (`summary`, `deltas`, `roiDetail`) in `gui/BrakeDiscInspector_GUI_ROI/Workflow/RoiPlacementEngine.cs`.  
- Removed `FormattableString.Invariant(...)` wrapper and pass the interpolated string directly to `GuiLog.Info` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.  
- Changes are limited to logging statements and do not alter public APIs or application logic.  

### Testing
- No automated tests were executed for this change.  
- The modifications are restricted to logging call sites to address compile-time type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695443f669a8832e89d08d5a13acc69e)