### PR TITLE
UI: Split ROI Management into Master/Inspection panels + center text content

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/RoiPanelModeToVisibilityConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/RoiPanelModeToVisibilityConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace BrakeDiscInspector_GUI_ROI.Converters
+{
+    public sealed class RoiPanelModeToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not Enum)
+            {
+                return Visibility.Collapsed;
+            }
+
+            if (parameter is null)
+            {
+                return Visibility.Collapsed;
+            }
+
+            var parameterText = parameter.ToString();
+            if (string.IsNullOrWhiteSpace(parameterText))
+            {
+                return Visibility.Collapsed;
+            }
+
+            if (!Enum.TryParse(value.GetType(), parameterText, out var parameterValue))
+            {
+                return Visibility.Collapsed;
+            }
+
+            return Equals(value, parameterValue) ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -23,6 +23,7 @@
         <conv:BoolToEditSaveTextConverter x:Key="BoolToEditSaveText" />
         <conv:BoolToBrushConverter x:Key="BoolToBrush" />
         <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
+        <conv:RoiPanelModeToVisibilityConverter x:Key="RoiPanelModeToVisibility" />
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
 
         <Style x:Key="TitleTextStyle" TargetType="TextBlock">
@@ -70,11 +71,13 @@
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ControlText}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
         <Style TargetType="ComboBox">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ControlText}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
         <Style TargetType="CheckBox">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
@@ -533,362 +536,410 @@
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
+            </StackPanel>
             </ScrollViewer>
 
             <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
-                    <GroupBox x:Name="MasterRoiGroup"
-                              Header="Master ROI"
-                              Margin="10,0,0,0" Height="202" ScrollViewer.VerticalScrollBarVisibility="Disabled" Width="441" HorizontalAlignment="Left">
-                        <Grid Margin="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="10*"/>
-                                <ColumnDefinition Width="179*"/>
-                                <ColumnDefinition Width="204*"/>
-                            </Grid.ColumnDefinitions>
-
-                            <StackPanel Grid.Column="0" Grid.ColumnSpan="2">
-                                <TextBlock Text="Master 1" FontWeight="SemiBold" Margin="0,0,0,6" FontSize="18" Width="165" HorizontalAlignment="Left"/>
-                                <Grid Width="218" HorizontalAlignment="Left">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" MinWidth="49"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Shape:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                    <ComboBox x:Name="ComboMasterRoiShape" Grid.Column="1" Height="37" HorizontalAlignment="Left" Width="135" Margin="1,0,0,0">
-                                        <ComboBoxItem Content="Rectangle"/>
-                                        <ComboBoxItem Content="Circle"/>
-                                        <ComboBoxItem Content="Annulus"/>
-                                    </ComboBox>
-                                </Grid>
-                                <Grid Margin="0,0,0,6" Width="216" HorizontalAlignment="Left">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" MinWidth="50"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                    <ComboBox x:Name="ComboMasterRoiRole" Grid.Column="1" RenderTransformOrigin="0.521,0.527" HorizontalAlignment="Left" Width="135" Height="37"/>
-                                </Grid>
-                                <WrapPanel Width="112" RenderTransformOrigin="0.515,0.547" HorizontalAlignment="Left" Margin="65,0,0,0">
-                                    <ui:Button x:Name="BtnEditM1"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               ToolTip="Edit Master 1"
-                                               Click="BtnEditM1_Click" Height="37" Width="37" HorizontalAlignment="Center">
-                                        <ui:SymbolIcon x:Name="IconEditM1" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
-                                    </ui:Button>
-                                    <ui:Button x:Name="BtnM1_Remove"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               Click="BtnM1_Remove_Click" Width="37" Height="37" VerticalAlignment="Stretch" HorizontalAlignment="Left">
-                                        <StackPanel Orientation="Horizontal" Height="22" HorizontalAlignment="Left" RenderTransformOrigin="1,0.521" Width="17">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
-                                        </StackPanel>
-                                    </ui:Button>
-                                    <ui:Button x:Name="BtnM1_Create"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               Click="BtnM1_Create_Click" Width="37" Height="37" HorizontalAlignment="Left">
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Height="18" Width="15">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
-                                        </StackPanel>
-                                    </ui:Button>
-                                </WrapPanel>
-                            </StackPanel>
-
-                            <StackPanel Grid.Column="2" HorizontalAlignment="Left" Width="188" Margin="10,0,0,0">
-                                <TextBlock Text="Master 2" FontWeight="SemiBold" FontSize="18" Width="146" HorizontalAlignment="Left" Margin="0,0,0,6"/>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto"/>
-                                        <ColumnDefinition Width="*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Shape:" VerticalAlignment="Top" Margin="0,10,8,0"/>
-                                    <ComboBox x:Name="ComboM2Shape" Grid.Column="1" HorizontalAlignment="Center" Width="135" VerticalAlignment="Center" Height="35">
-                                        <ComboBoxItem Content="Rectangle"/>
-                                        <ComboBoxItem Content="Circle"/>
-                                        <ComboBoxItem Content="Annulus"/>
-                                    </ComboBox>
-                                </Grid>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" MinWidth="40"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                    <ComboBox x:Name="ComboM2Role" Grid.Column="1" Margin="10,0,0,0" Height="37" HorizontalAlignment="Left" Width="135"/>
-                                </Grid>
-                                <WrapPanel Width="118" HorizontalAlignment="Left" Margin="60,7,0,0">
-                                    <ui:Button x:Name="BtnEditM2"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               Margin="4,0,0,0"
-                                               ToolTip="Edit Master 2"
-                                               Click="BtnEditM2_Click" Width="37" Height="37">
-                                        <ui:SymbolIcon x:Name="IconEditM2" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
-                                    </ui:Button>
-                                    <ui:Button x:Name="BtnM2_Remove"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               Click="BtnM2_Remove_Click" Width="37" HorizontalAlignment="Center" Height="37">
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
-                                        </StackPanel>
-                                    </ui:Button>
-                                    <ui:Button x:Name="BtnM2_Create"
-                                               MinHeight="26"
-                                               Padding="8,4"
-                                               Click="BtnM2_Create_Click" RenderTransformOrigin="4.067,0.5" HorizontalAlignment="Center" Width="37" Height="37">
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
-                                        </StackPanel>
-                                    </ui:Button>
-                                </WrapPanel>
-                            </StackPanel>
-                        </Grid>
-                    </GroupBox>
-
-                    <WrapPanel Margin="0,12,0,12">
-                        <ui:Button x:Name="BtnClearCanvas"
-                                   Click="BtnClearCanvas_Click" Margin="10,0,0,0">
+                    <StackPanel x:Name="RoiManagementSelector"
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">
+                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
+                        <ui:Button Height="43"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   Click="RoiManagementSelectMaster_Click">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0" FontSize="16"/>
-                                <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
+                                <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
-                    </WrapPanel>
-
-                    <Grid Margin="0,12,0,0">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" MinWidth="221"/>
-                            <ColumnDefinition Width="9"/>
-                            <ColumnDefinition Width="Auto" MinWidth="228"/>
-                        </Grid.ColumnDefinitions>
-                        <GroupBox Header="Analyze Options M1"
-                                  UseLayoutRounding="False"
-                                  Grid.Column="0"
-                                  Margin="10,0,10,11"
-                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                            <StackPanel Margin="0,4,0,0">
-                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Width="195">
-                                    <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0" HorizontalAlignment="Left"/>
-                                    <ComboBox x:Name="ComboFeature" Width="138"
-                                              SelectedValuePath="Content"
-                                              SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}" Height="37">
-                                        <ComboBoxItem Content="auto"/>
-                                        <ComboBoxItem Content="sift"/>
-                                        <ComboBoxItem Content="orb"/>
-                                        <ComboBoxItem Content="tm_rot"/>
-                                        <ComboBoxItem Content="edges"/>
-                                    </ComboBox>
-                                </StackPanel>
-
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="191" HorizontalAlignment="Left">
-                                    <TextBlock Text="Threshold" VerticalAlignment="Center" Margin="0,0,1,0"/>
-                                    <TextBox x:Name="TxtThr" Width="128"
-                                             Margin="4,0,0,0"
-                                             Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
-                                </StackPanel>
+                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
+                        <ui:Button Height="43"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   Click="RoiManagementSelectInspection_Click">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
+                                <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
                             </StackPanel>
+                        </ui:Button>
+                    </StackPanel>
+
+                    <StackPanel x:Name="MasterRoisPanel"
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Master}">
+                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
+                        <ui:Button Height="43"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   Click="RoiManagementBack_Click">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowLeft24}" FontSize="18" Margin="0,0,10,0"/>
+                                <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
+
+                        <GroupBox x:Name="MasterRoiGroup"
+                                  Header="Master ROI"
+                                  Margin="10,0,0,0" Height="202" ScrollViewer.VerticalScrollBarVisibility="Disabled" Width="441" HorizontalAlignment="Left">
+                            <Grid Margin="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="10*"/>
+                                    <ColumnDefinition Width="179*"/>
+                                    <ColumnDefinition Width="204*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <StackPanel Grid.Column="0" Grid.ColumnSpan="2">
+                                    <TextBlock Text="Master 1" FontWeight="SemiBold" Margin="0,0,0,6" FontSize="18" Width="165" HorizontalAlignment="Left"/>
+                                    <Grid Width="218" HorizontalAlignment="Left">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" MinWidth="49"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="Shape:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                        <ComboBox x:Name="ComboMasterRoiShape" Grid.Column="1" Height="37" HorizontalAlignment="Left" Width="135" Margin="1,0,0,0">
+                                            <ComboBoxItem Content="Rectangle"/>
+                                            <ComboBoxItem Content="Circle"/>
+                                            <ComboBoxItem Content="Annulus"/>
+                                        </ComboBox>
+                                    </Grid>
+                                    <Grid Margin="0,0,0,6" Width="216" HorizontalAlignment="Left">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" MinWidth="50"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                        <ComboBox x:Name="ComboMasterRoiRole" Grid.Column="1" RenderTransformOrigin="0.521,0.527" HorizontalAlignment="Left" Width="135" Height="37"/>
+                                    </Grid>
+                                    <WrapPanel Width="112" RenderTransformOrigin="0.515,0.547" HorizontalAlignment="Left" Margin="65,0,0,0">
+                                        <ui:Button x:Name="BtnEditM1"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   ToolTip="Edit Master 1"
+                                                   Click="BtnEditM1_Click" Height="37" Width="37" HorizontalAlignment="Center">
+                                            <ui:SymbolIcon x:Name="IconEditM1" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
+                                        </ui:Button>
+                                        <ui:Button x:Name="BtnM1_Remove"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   Click="BtnM1_Remove_Click" Width="37" Height="37" VerticalAlignment="Stretch" HorizontalAlignment="Left">
+                                            <StackPanel Orientation="Horizontal" Height="22" HorizontalAlignment="Left" RenderTransformOrigin="1,0.521" Width="17">
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button x:Name="BtnM1_Create"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   Click="BtnM1_Create_Click" Width="37" Height="37" HorizontalAlignment="Left">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Height="18" Width="15">
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                    </WrapPanel>
+                                </StackPanel>
+
+                                <StackPanel Grid.Column="2" HorizontalAlignment="Left" Width="188" Margin="10,0,0,0">
+                                    <TextBlock Text="Master 2" FontWeight="SemiBold" FontSize="18" Width="146" HorizontalAlignment="Left" Margin="0,0,0,6"/>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="Shape:" VerticalAlignment="Top" Margin="0,10,8,0"/>
+                                        <ComboBox x:Name="ComboM2Shape" Grid.Column="1" HorizontalAlignment="Center" Width="135" VerticalAlignment="Center" Height="35">
+                                            <ComboBoxItem Content="Rectangle"/>
+                                            <ComboBoxItem Content="Circle"/>
+                                            <ComboBoxItem Content="Annulus"/>
+                                        </ComboBox>
+                                    </Grid>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" MinWidth="40"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                        <ComboBox x:Name="ComboM2Role" Grid.Column="1" Margin="10,0,0,0" Height="37" HorizontalAlignment="Left" Width="135"/>
+                                    </Grid>
+                                    <WrapPanel Width="118" HorizontalAlignment="Left" Margin="60,7,0,0">
+                                        <ui:Button x:Name="BtnEditM2"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   Margin="4,0,0,0"
+                                                   ToolTip="Edit Master 2"
+                                                   Click="BtnEditM2_Click" Width="37" Height="37">
+                                            <ui:SymbolIcon x:Name="IconEditM2" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
+                                        </ui:Button>
+                                        <ui:Button x:Name="BtnM2_Remove"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   Click="BtnM2_Remove_Click" Width="37" HorizontalAlignment="Center" Height="37">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                        <ui:Button x:Name="BtnM2_Create"
+                                                   MinHeight="26"
+                                                   Padding="8,4"
+                                                   Click="BtnM2_Create_Click" RenderTransformOrigin="4.067,0.5" HorizontalAlignment="Center" Width="37" Height="37">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                    </WrapPanel>
+                                </StackPanel>
+                            </Grid>
                         </GroupBox>
-                        <GroupBox Header="Analyze Options M2"
-                                  Grid.Column="2"
-                                  Margin="0,0,0,12"
-                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                            <StackPanel Margin="8,4,0,0">
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
-                                    <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                    <ComboBox x:Name="ComboFeatureM2" Width="138"
-                                              SelectedValuePath="Content"
-                                              SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}" Height="37">
-                                        <ComboBoxItem Content="auto"/>
-                                        <ComboBoxItem Content="sift"/>
-                                        <ComboBoxItem Content="orb"/>
-                                        <ComboBoxItem Content="tm_rot"/>
-                                        <ComboBoxItem Content="edges"/>
-                                    </ComboBox>
-                                </StackPanel>
 
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="221" HorizontalAlignment="Left">
-                                    <TextBlock Text="Thershold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
-                                    <TextBox x:Name="TxtThrM2" Width="128"
-                                             Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
-                                </StackPanel>
-                            </StackPanel>
-                        </GroupBox>
-                    </Grid>
-                    <GroupBox Header="Analyze Options"
-                              Width="240"
-                              Height="204"
-                              Padding="8,16,8,8"
-                              ScrollViewer.CanContentScroll="True"
-                              DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                        <StackPanel Margin="8,4,0,0">
-                            <StackPanel Height="102" CanVerticallyScroll="True">
-                                <CheckBox x:Name="ChkDisableRot"
-                                          Content="Disable rot"
-                                          IsChecked="{Binding DisableRot, Mode=TwoWay}"/>
-                                <CheckBox x:Name="ChkScaleLock"
-                                          Content="Lock scale"
-                                          IsChecked="{Binding ScaleLock, Mode=TwoWay}"/>
-                                <CheckBox x:Name="ChkUseLocalMatcher"
-                                          Content="Use local matcher"
-                                          ToolTip="Force local matcher"
-                                          IsChecked="True"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,4,0,0"/>
-                            <ui:Button x:Name="BtnAnalyzeMaster"
-                                       Click="BtnAnalyzeMaster_Click">
+                        <WrapPanel Margin="0,12,0,12">
+                            <ui:Button x:Name="BtnClearCanvas"
+                                       Click="BtnClearCanvas_Click" Margin="10,0,0,0">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
-                                    <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
+                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0" FontSize="16"/>
+                                    <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </ui:Button>
-                        </StackPanel>
-                    </GroupBox>
+                        </WrapPanel>
 
-                    <GroupBox Header="Match Options"
-                              Width="260"
-                              DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                        <StackPanel Margin="8,4,0,0">
-                            <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
-                                <TextBlock Text="RotRange:" VerticalAlignment="Center"/>
-                                <TextBox x:Name="TxtRot" Width="60" Margin="4,0,8,0" Text="10"/>
-                                <TextBlock Text="ScaleMin:" VerticalAlignment="Center"/>
-                                <TextBox x:Name="TxtSMin" Width="60" Margin="4,0,8,0" Text="0.95"/>
-                                <TextBlock Text="ScaleMax:" VerticalAlignment="Center"/>
-                                <TextBox x:Name="TxtSMax" Width="60" Margin="4,0,0,0" Text="1.05"/>
-                            </StackPanel>
-                            <WrapPanel>
-                                <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
+                        <Grid Margin="0,12,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" MinWidth="221"/>
+                                <ColumnDefinition Width="9"/>
+                                <ColumnDefinition Width="Auto" MinWidth="228"/>
+                            </Grid.ColumnDefinitions>
+                            <GroupBox Header="Analyze Options M1"
+                                      UseLayoutRounding="False"
+                                      Grid.Column="0"
+                                      Margin="10,0,10,11"
+                                      DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                <StackPanel Margin="0,4,0,0">
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Width="195">
+                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0" HorizontalAlignment="Left"/>
+                                        <ComboBox x:Name="ComboFeature" Width="138"
+                                                  SelectedValuePath="Content"
+                                                  SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}" Height="37">
+                                            <ComboBoxItem Content="auto"/>
+                                            <ComboBoxItem Content="sift"/>
+                                            <ComboBoxItem Content="orb"/>
+                                            <ComboBoxItem Content="tm_rot"/>
+                                            <ComboBoxItem Content="edges"/>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="191" HorizontalAlignment="Left">
+                                        <TextBlock Text="Threshold" VerticalAlignment="Center" Margin="0,0,1,0"/>
+                                        <TextBox x:Name="TxtThr" Width="128"
+                                                 Margin="4,0,0,0"
+                                                 Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </GroupBox>
+                            <GroupBox Header="Analyze Options M2"
+                                      Grid.Column="2"
+                                      Margin="0,0,0,12"
+                                      DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                <StackPanel Margin="8,4,0,0">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                        <ComboBox x:Name="ComboFeatureM2" Width="138"
+                                                  SelectedValuePath="Content"
+                                                  SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}" Height="37">
+                                            <ComboBoxItem Content="auto"/>
+                                            <ComboBoxItem Content="sift"/>
+                                            <ComboBoxItem Content="orb"/>
+                                            <ComboBoxItem Content="tm_rot"/>
+                                            <ComboBoxItem Content="edges"/>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="221" HorizontalAlignment="Left">
+                                        <TextBlock Text="Thershold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
+                                        <TextBox x:Name="TxtThrM2" Width="128"
+                                                 Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
+                                    </StackPanel>
+                                </StackPanel>
+                            </GroupBox>
+                        </Grid>
+                        <GroupBox Header="Analyze Options"
+                                  Width="240"
+                                  Height="204"
+                                  Padding="8,16,8,8"
+                                  ScrollViewer.CanContentScroll="True"
+                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                            <StackPanel Margin="8,4,0,0">
+                                <StackPanel Height="102" CanVerticallyScroll="True">
+                                    <CheckBox x:Name="ChkDisableRot"
+                                              Content="Disable rot"
+                                              IsChecked="{Binding DisableRot, Mode=TwoWay}"/>
+                                    <CheckBox x:Name="ChkScaleLock"
+                                              Content="Lock scale"
+                                              IsChecked="{Binding ScaleLock, Mode=TwoWay}"/>
+                                    <CheckBox x:Name="ChkUseLocalMatcher"
+                                              Content="Use local matcher"
+                                              ToolTip="Force local matcher"
+                                              IsChecked="True"/>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0"/>
+                                <ui:Button x:Name="BtnAnalyzeMaster"
+                                           Click="BtnAnalyzeMaster_Click">
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0" FontSize="16"/>
-                                        <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
+                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
+                                        <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ui:Button>
-                            </WrapPanel>
-                        </StackPanel>
-                    </GroupBox>
-
-                    <GroupBox x:Name="InspectionRoisGroup" Header="Inspection ROIs" Margin="0,12,0,0">
-                        <StackPanel Margin="8,4,0,0">
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,4" VerticalAlignment="Center">
-                                <TextBlock Text="Inspection 1" Width="80" VerticalAlignment="Center"/>
-                                <ComboBox x:Name="CmbShapeInspection1"
-                                          Width="80"
-                                          Tag="1"
-                                          ItemsSource="{Binding AvailableShapes}"
-                                          SelectedItem="{Binding DataContext.InspectionRois[0].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
-                                          SelectionChanged="InspectionShape_SelectionChanged"/>
-                                <ui:Button x:Name="BtnCreateInspection1"
-                                           Margin="4,0,0,0"
-                                           Style="{StaticResource IconOnlyButton}"
-                                           ToolTip="Create ROI 1"
-                                           Tag="1"
-                                           Click="BtnCreateInspection_Click">
-                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" FontSize="16"/>
-                                </ui:Button>
-                                <ui:Button Margin="4,0,0,0"
-                                           DataContext="{Binding DataContext.InspectionRois[0], ElementName=WorkflowHost}"
-                                           Click="BtnToggleEdit_Click"
-                                           IsEnabled="{Binding Enabled}">
-                                    <ui:Button.Style>
-                                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
-                                            <Setter Property="IsEnabled" Value="True"/>
-                                            <Setter Property="Content">
-                                                <Setter.Value>
-                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Setter Property="ToolTip" Value="Edit ROI 1"/>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding IsEditable}" Value="True">
-                                                    <Setter Property="Content">
-                                                        <Setter.Value>
-                                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" FontSize="16"/>
-                                                        </Setter.Value>
-                                                    </Setter>
-                                                    <Setter Property="ToolTip" Value="Save ROI 1"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:Button.Style>
-                                </ui:Button>
-                                <ui:Button x:Name="BtnAddOkInspection1"
-                                           Margin="4,0,0,0"
-                                           ToolTip="Add ROI 1 to OK"
-                                           Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
-                                           CommandParameter="{Binding Inspection1}">
-                                    <ui:Button.Style>
-                                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
-                                            <Setter Property="IsEnabled" Value="True"/>
-                                            <Setter Property="Content">
-                                                <Setter.Value>
-                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" FontSize="16"/>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:Button.Style>
-                                </ui:Button>
-                                <ui:Button x:Name="BtnAddNgInspection1"
-                                           Margin="4,0,0,0"
-                                           ToolTip="Add ROI 1 to NG"
-                                           Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
-                                           CommandParameter="{Binding Inspection1}">
-                                    <ui:Button.Style>
-                                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
-                                            <Setter Property="IsEnabled" Value="True"/>
-                                            <Setter Property="Content">
-                                                <Setter.Value>
-                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" FontSize="16"/>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:Button.Style>
-                                </ui:Button>
-                                <ui:Button x:Name="BtnRemoveInspection1"
-                                           Margin="4,0,0,0"
-                                           ToolTip="Remove ROI 1"
-                                           Click="BtnRemoveInspection1_Click">
-                                    <ui:Button.Style>
-                                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
-                                            <Setter Property="IsEnabled" Value="True"/>
-                                            <Setter Property="Content">
-                                                <Setter.Value>
-                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" FontSize="16"/>
-                                                </Setter.Value>
-                                            </Setter>
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
-                                                    <Setter Property="IsEnabled" Value="False"/>
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:Button.Style>
-                                </ui:Button>
                             </StackPanel>
+                        </GroupBox>
+
+                        <GroupBox Header="Match Options"
+                                  Width="260"
+                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                            <StackPanel Margin="8,4,0,0">
+                                <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
+                                    <TextBlock Text="RotRange:" VerticalAlignment="Center"/>
+                                    <TextBox x:Name="TxtRot" Width="60" Margin="4,0,8,0" Text="10"/>
+                                    <TextBlock Text="ScaleMin:" VerticalAlignment="Center"/>
+                                    <TextBox x:Name="TxtSMin" Width="60" Margin="4,0,8,0" Text="0.95"/>
+                                    <TextBlock Text="ScaleMax:" VerticalAlignment="Center"/>
+                                    <TextBox x:Name="TxtSMax" Width="60" Margin="4,0,0,0" Text="1.05"/>
+                                </StackPanel>
+                                <WrapPanel>
+                                    <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0" FontSize="16"/>
+                                            <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </ui:Button>
+                                </WrapPanel>
+                            </StackPanel>
+                        </GroupBox>
+                    </StackPanel>
+
+                    <StackPanel x:Name="InspectionRoisPanel"
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Inspection}">
+                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
+                        <ui:Button Height="43"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   Click="RoiManagementBack_Click">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowLeft24}" FontSize="18" Margin="0,0,10,0"/>
+                                <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
+
+                        <GroupBox x:Name="InspectionRoisGroup" Header="Inspection ROIs" Margin="0,12,0,0">
+                            <StackPanel Margin="8,4,0,0">
+                                <StackPanel Orientation="Horizontal" Margin="0,0,0,4" VerticalAlignment="Center">
+                                    <TextBlock Text="Inspection 1" Width="80" VerticalAlignment="Center"/>
+                                    <ComboBox x:Name="CmbShapeInspection1"
+                                              Width="80"
+                                              Tag="1"
+                                              ItemsSource="{Binding AvailableShapes}"
+                                              SelectedItem="{Binding DataContext.InspectionRois[0].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
+                                              SelectionChanged="InspectionShape_SelectionChanged"/>
+                                    <ui:Button x:Name="BtnCreateInspection1"
+                                               Margin="4,0,0,0"
+                                               Style="{StaticResource IconOnlyButton}"
+                                               ToolTip="Create ROI 1"
+                                               Tag="1"
+                                               Click="BtnCreateInspection_Click">
+                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.AddSquare24}" FontSize="16"/>
+                                    </ui:Button>
+                                    <ui:Button Margin="4,0,0,0"
+                                               DataContext="{Binding DataContext.InspectionRois[0], ElementName=WorkflowHost}"
+                                               Click="BtnToggleEdit_Click"
+                                               IsEnabled="{Binding Enabled}">
+                                        <ui:Button.Style>
+                                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
+                                                <Setter Property="IsEnabled" Value="True"/>
+                                                <Setter Property="Content">
+                                                    <Setter.Value>
+                                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
+                                                    </Setter.Value>
+                                                </Setter>
+                                                <Setter Property="ToolTip" Value="Edit ROI 1"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding IsEditable}" Value="True">
+                                                        <Setter Property="Content">
+                                                            <Setter.Value>
+                                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" FontSize="16"/>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                        <Setter Property="ToolTip" Value="Save ROI 1"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:Button.Style>
+                                    </ui:Button>
+                                    <ui:Button x:Name="BtnAddOkInspection1"
+                                               Margin="4,0,0,0"
+                                               ToolTip="Add ROI 1 to OK"
+                                               Command="{Binding DataContext.AddRoiToOkCommand, ElementName=WorkflowHost}"
+                                               CommandParameter="{Binding Inspection1}">
+                                        <ui:Button.Style>
+                                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
+                                                <Setter Property="IsEnabled" Value="True"/>
+                                                <Setter Property="Content">
+                                                    <Setter.Value>
+                                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.CheckmarkCircle24}" FontSize="16"/>
+                                                    </Setter.Value>
+                                                </Setter>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:Button.Style>
+                                    </ui:Button>
+                                    <ui:Button x:Name="BtnAddNgInspection1"
+                                               Margin="4,0,0,0"
+                                               ToolTip="Add ROI 1 to NG"
+                                               Command="{Binding DataContext.AddRoiToNgCommand, ElementName=WorkflowHost}"
+                                               CommandParameter="{Binding Inspection1}">
+                                        <ui:Button.Style>
+                                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
+                                                <Setter Property="IsEnabled" Value="True"/>
+                                                <Setter Property="Content">
+                                                    <Setter.Value>
+                                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.DismissCircle24}" FontSize="16"/>
+                                                    </Setter.Value>
+                                                </Setter>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding DataContext.InspectionRois[0].Enabled, ElementName=WorkflowHost}" Value="False">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:Button.Style>
+                                    </ui:Button>
+                                    <ui:Button x:Name="BtnRemoveInspection1"
+                                               Margin="4,0,0,0"
+                                               ToolTip="Remove ROI 1"
+                                               Click="BtnRemoveInspection1_Click">
+                                        <ui:Button.Style>
+                                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource IconOnlyButtonStyle}">
+                                                <Setter Property="IsEnabled" Value="True"/>
+                                                <Setter Property="Content">
+                                                    <Setter.Value>
+                                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" FontSize="16"/>
+                                                    </Setter.Value>
+                                                </Setter>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DataContext.Inspection1, ElementName=WorkflowHost}" Value="{x:Null}">
+                                                        <Setter Property="IsEnabled" Value="False"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:Button.Style>
+                                    </ui:Button>
+                                </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,4,0,4" VerticalAlignment="Center">
                                 <TextBlock Text="Inspection 2" Width="80" VerticalAlignment="Center"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -145,7 +145,15 @@ namespace BrakeDiscInspector_GUI_ROI
             Comms
         }
 
+        private enum RoiPanelMode
+        {
+            Selector,
+            Master,
+            Inspection
+        }
+
         private int _freezeRoiRepositionCounter;
+        private RoiPanelMode _roiPanelMode = RoiPanelMode.Selector;
         private bool _pendingActiveInspectionSync;
         private bool _globalUnlocked = false;
         private bool _editingM1;
@@ -189,6 +197,21 @@ namespace BrakeDiscInspector_GUI_ROI
             private set
             {
                 _busyStatusText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public RoiPanelMode RoiPanelMode
+        {
+            get => _roiPanelMode;
+            set
+            {
+                if (_roiPanelMode == value)
+                {
+                    return;
+                }
+
+                _roiPanelMode = value;
                 OnPropertyChanged();
             }
         }
@@ -3633,6 +3656,11 @@ namespace BrakeDiscInspector_GUI_ROI
             RoiManagementPanel.Visibility = mode == SidePanelMode.RoiManagement ? Visibility.Visible : Visibility.Collapsed;
             BatchInspectionPanel.Visibility = mode == SidePanelMode.BatchInspection ? Visibility.Visible : Visibility.Collapsed;
             CommsPanel.Visibility = mode == SidePanelMode.Comms ? Visibility.Visible : Visibility.Collapsed;
+
+            if (mode == SidePanelMode.RoiManagement)
+            {
+                RoiPanelMode = RoiPanelMode.Selector;
+            }
         }
 
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
@@ -3643,6 +3671,21 @@ namespace BrakeDiscInspector_GUI_ROI
         private void NavRoiManagement_Click(object sender, RoutedEventArgs e)
         {
             ShowSidePanel(SidePanelMode.RoiManagement);
+        }
+
+        private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
+        {
+            RoiPanelMode = RoiPanelMode.Master;
+        }
+
+        private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
+        {
+            RoiPanelMode = RoiPanelMode.Inspection;
+        }
+
+        private void RoiManagementBack_Click(object sender, RoutedEventArgs e)
+        {
+            RoiPanelMode = RoiPanelMode.Selector;
         }
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Motivation
- The ROI Management side panel currently expands all controls at once, making navigation cluttered and overwhelming. 
- Provide a simple selector that shows only two fluent-styled choices (`Master ROIs` / `Inspection ROIs`) and then reveals only the related controls. 
- Keep existing styles, bindings and DataContext intact while avoiding duplicated GroupBox controls. 
- Fix vertical alignment for text input controls so text does not appear top-aligned.

### Description
- Reorganized the ROI Management XAML by adding a selector `StackPanel` (`RoiManagementSelector`) and two subpanels `MasterRoisPanel` and `InspectionRoisPanel`, moving existing GroupBox blocks into the appropriate subpanel and adding a fluent-styled Back button in each subpanel. 
- Introduced a single source-of-truth enum property `RoiPanelMode` in `MainWindow.xaml.cs` with click handlers (`RoiManagementSelectMaster_Click`, `RoiManagementSelectInspection_Click`, `RoiManagementBack_Click`) to toggle modes and reset to the selector when the side panel opens. 
- Added `RoiPanelModeToVisibilityConverter` in `Converters/RoiPanelModeToVisibilityConverter.cs` and registered it in `Window.Resources` to bind subpanel `Visibility` to `RoiPanelMode` (no duplication of GroupBoxes). 
- Updated global styles in `MainWindow.xaml` to set `VerticalContentAlignment="Center"` for `TextBox` and `ComboBox`, and sized the selector/back buttons to 90% of the left nav button height with an explanatory comment (`48 -> 43`).

### Testing
- No automated tests were executed for this UI-only change. 
- Changes are limited to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`, `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`, and a new converter `gui/BrakeDiscInspector_GUI_ROI/Converters/RoiPanelModeToVisibilityConverter.cs` and preserve existing `x:Name` and bindings. 
- Recommend manual UI verification: click `ROIs Management` → see selector, open each subpanel and use Back to return, and confirm text in `TextBox`/`ComboBox` is vertically centered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6955bb3c0ef8832ead0c089c99b19f06)