### PR TITLE
Fix extra StackPanel closing tag in LayoutSetupPanel

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -536,7 +536,6 @@
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
-            </StackPanel>
             </ScrollViewer>
 
             <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">


### PR DESCRIPTION
### Motivation
- The `LayoutSetupPanel` section in `MainWindow.xaml` contained an extra closing `</StackPanel>` which broke the XAML XML tree and produced multiple parse/build errors such as XLS0305 and XLS0501.
- Restoring correct tag nesting is necessary so the WPF XAML parser and Visual Studio can correctly interpret the markup and avoid cascading diagnostics.

### Description
- Removed the extra `</StackPanel>` immediately before the `</ScrollViewer>` that closes `LayoutSetupPanel` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` (now the `ScrollViewer` wraps a single correctly-closed `StackPanel`).
- No other files were modified and the change only adjusts the XAML nesting to produce a well-formed document.

### Testing
- No automated builds or tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956c64c4270832eb73d3a7137858101)