### PR TITLE
Fix missing StackPanel closing tag in MainWindow.xaml (ROI panel)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -536,7 +536,8 @@
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
-            </ScrollViewer>
+            </StackPanel>
+        </ScrollViewer>
 
             <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">


### PR DESCRIPTION
### Motivation
- XAML parsing errors showed a missing closing tag for `<StackPanel>` in the ROI management area which caused tag mismatch diagnostics (`XLS0305`, `XDG0000`, `MC3000`).
- The left-hand ROI management `ScrollViewer` block contained one unclosed `StackPanel`, leaving the file structurally invalid.

### Description
- Added the missing closing `</StackPanel>` directly before the `</ScrollViewer>` to properly close the ROI management content in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.
- This change resolves the XML tag mismatch around the ROI management `ScrollViewer` and restores well-formed XAML for that region.

### Testing
- No automated tests were executed for this change (XAML structural fix only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956c6e49af4832ebeb5e91b63121145)