### PR TITLE
Fix LayoutSetupPanel StackPanel closure

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -443,9 +443,8 @@
                             <ui:Button Content="Apply" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ApplyColorsButton_Click"/>
                             <ui:Button Content="Reset" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ResetGuiDefaultsButton_Click"/>
                             <ui:Button Content="Close" Style="{StaticResource AppButtonStyle}" Click="CloseGuiSetupButton_Click"/>
-                        </StackPanel>
-                    </StackPanel>
-                </ScrollViewer>
+                </StackPanel>
+            </ScrollViewer>
             </Border>
         </Popup>
 


### PR DESCRIPTION
### Motivation
- Fix XAML parse/build errors in `MainWindow.xaml` that prevented the GUI from loading.
- The root cause was an extra closing `</StackPanel>` inside the `LayoutSetupPanel` `ScrollViewer` which broke the XML tree and produced downstream errors like `XLS0305`, `MC3000`, and `XLS0501`.
- Restore well-formed XAML so the Visual Studio XAML parser and build can succeed.

### Description
- Removed the duplicate `</StackPanel>` immediately before the `</ScrollViewer>` that closes `LayoutSetupPanel` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.
- Rebalanced the `ScrollViewer`/`StackPanel` nesting so tags are correctly matched.
- The change touches a single file: `MainWindow.xaml` and was committed to the repository.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956ce662168832e8f29aeab2de310e6)