### PR TITLE
Fix XAML tag balance in MainWindow.xaml

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -443,7 +443,8 @@
                             <ui:Button Content="Apply" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ApplyColorsButton_Click"/>
                             <ui:Button Content="Reset" Style="{StaticResource AppButtonStyle}" Margin="0,0,8,0" Click="ResetGuiDefaultsButton_Click"/>
                             <ui:Button Content="Close" Style="{StaticResource AppButtonStyle}" Click="CloseGuiSetupButton_Click"/>
-                </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
             </ScrollViewer>
             </Border>
         </Popup>
@@ -535,7 +536,6 @@
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>
-            </StackPanel>
         </ScrollViewer>
 
             <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
@@ -1294,11 +1294,12 @@
                                 </ui:Button>
                             </StackPanel>
 
-                            <workflow:WorkflowControl x:Name="WorkflowHost" Margin="0,12,0,0"/>
-                        </StackPanel>
-                    </GroupBox>
+                    <workflow:WorkflowControl x:Name="WorkflowHost" Margin="0,12,0,0"/>
                 </StackPanel>
-            </ScrollViewer>
+            </GroupBox>
+        </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
 
             <ScrollViewer x:Name="BatchInspectionPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" DataContext="{Binding DataContext, ElementName=WorkflowHost}">
                 <Grid Margin="0">


### PR DESCRIPTION
### Motivation
- Corregir errores de parseo/compilación XAML en `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` que provocaban múltiples avisos en Visual Studio (`XLS0305`, `MC3000`, `XLS0501`).
- La raíz es un árbol XML roto por tres cierres/missing `</StackPanel>` que desencadenaban errores en cascada y contenido duplicado reportado por el analizador XAML.
- Restaurar la estructura de etiquetas para que el fichero XAML sea bien formado y el editor/compilador deje de informar falsos positivos.

### Description
- Añadido el `</StackPanel>` faltante dentro de `GuiSetupPopup` antes de su `</ScrollViewer>` para cerrar correctamente el StackPanel exterior. 
- Eliminado el cierre `</StackPanel>` extra en `LayoutSetupPanel` para mantener un único cierre coincidente con el `StackPanel Margin="8"`. 
- Insertado el `</StackPanel>` faltante en `RoiManagementPanel` para cerrar el StackPanel exterior `Margin="8"` correctamente. 
- Todos los cambios se hicieron en el archivo `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.

### Testing
- No se ejecutaron pruebas automatizadas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956d0e262e4832eaff91b86b5cd5d55)