### PR TITLE
Move RoiPanelMode enum to Models and remove nested enum to fix XAML binding errors

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -145,13 +145,6 @@ namespace BrakeDiscInspector_GUI_ROI
             Comms
         }
 
-        private enum RoiPanelMode
-        {
-            Selector,
-            Master,
-            Inspection
-        }
-
         private int _freezeRoiRepositionCounter;
         private RoiPanelMode _roiPanelMode = RoiPanelMode.Selector;
         private bool _pendingActiveInspectionSync;

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/RoiPanelMode.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/RoiPanelMode.cs
@@ -1,0 +1,9 @@
+namespace BrakeDiscInspector_GUI_ROI.Models
+{
+    public enum RoiPanelMode
+    {
+        Selector,
+        Master,
+        Inspection
+    }
+}


### PR DESCRIPTION
### Motivation
- Resolve CS0102/CS0053 caused by a nested `RoiPanelMode` type colliding with the `RoiPanelMode` property in `MainWindow` and blocking XAML designer type resolution.
- Ensure the XAML binding `RoiPanelMode` and `RoiPanelModeToVisibilityConverter` can access a public enum type with members `Selector`, `Master`, and `Inspection`.

### Description
- Added `gui/BrakeDiscInspector_GUI_ROI/Models/RoiPanelMode.cs` containing `public enum RoiPanelMode { Selector, Master, Inspection }`.
- Removed the private nested `RoiPanelMode` enum from `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` so there is a single public enum type used by the existing property.
- Preserved the existing public property `public RoiPanelMode RoiPanelMode` in `MainWindow` so XAML bindings remain functional.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956dd083200832ea4dab98489d7416e)