### PR TITLE
Add toggleable ROIs Management submenu in left nav

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -542,24 +542,10 @@
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel x:Name="RoiManagementSelector"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">
-                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
-                        <ui:Button Height="43"
-                                   Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="RoiManagementSelectMaster_Click">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
-                                <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ui:Button>
-                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
-                        <ui:Button Height="43"
-                                   Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="RoiManagementSelectInspection_Click">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
-                                <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ui:Button>
+                        <TextBlock Text="Selecciona 'Master ROIs' o 'Inspection ROIs' desde el menú de la izquierda."
+                                   TextWrapping="Wrap"
+                                   Opacity="0.7"
+                                   Margin="4,8,4,0"/>
                     </StackPanel>
 
                     <StackPanel x:Name="MasterRoisPanel"
@@ -1632,6 +1618,27 @@
                         <TextBlock Text="ROIs Management" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
+                <!-- Submenú colapsable: aparece debajo de ROIs Management -->
+                <StackPanel x:Name="RoiNavSubmenu" Visibility="Collapsed" Margin="0">
+                    <!-- 90% de la altura del LeftNavButtonStyle (48 -> 43). -->
+                    <ui:Button Height="43"
+                               Style="{StaticResource LeftNavButtonStyle}"
+                               Click="RoiManagementSelectMaster_Click">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
+                            <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ui:Button>
+
+                    <ui:Button Height="43"
+                               Style="{StaticResource LeftNavButtonStyle}"
+                               Click="RoiManagementSelectInspection_Click">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
+                            <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ui:Button>
+                </StackPanel>
                 <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                            Click="NavBatchInspection_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3658,12 +3658,24 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
+            RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.LayoutSetup);
         }
 
         private void NavRoiManagement_Click(object sender, RoutedEventArgs e)
         {
-            ShowSidePanel(SidePanelMode.RoiManagement);
+            var expand = RoiNavSubmenu.Visibility != Visibility.Visible;
+            RoiNavSubmenu.Visibility = expand ? Visibility.Visible : Visibility.Collapsed;
+
+            if (expand)
+            {
+                ShowSidePanel(SidePanelMode.RoiManagement);
+                RoiPanelMode = RoiPanelMode.Selector;
+            }
+            else
+            {
+                RoiManagementPanel.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
@@ -3683,11 +3695,13 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
+            RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.BatchInspection);
         }
 
         private void NavComms_Click(object sender, RoutedEventArgs e)
         {
+            RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.Comms);
         }
 


### PR DESCRIPTION
### Motivation
- Hide `Master ROIs` and `Inspection ROIs` by default and reveal them via a toggleable submenu under the `ROIs Management` nav entry.
- When expanded, the submenu should push the remainder of the left-nav buttons down using a `StackPanel` layout.
- Preserve and reuse the existing handlers `RoiManagementSelectMaster_Click` and `RoiManagementSelectInspection_Click` without changing their logic.
- Reduce duplication by removing the selector buttons from the right-side `RoiManagementPanel` and replacing them with an instructional message.

### Description
- Add a `StackPanel x:Name="RoiNavSubmenu"` to `MainWindow.xaml` placed directly under the `ROIs Management` button containing two buttons wired to the existing `RoiManagementSelectMaster_Click` and `RoiManagementSelectInspection_Click` handlers.
- Replace the two selector buttons inside the `RoiManagementSelector` block in `MainWindow.xaml` with a `TextBlock` that instructs the user to use the left nav.
- Update `NavRoiManagement_Click` in `MainWindow.xaml.cs` to toggle the `RoiNavSubmenu` visibility and to show/hide the `RoiManagementPanel` consistently while preserving existing navigation behavior via `ShowSidePanel`.
- Ensure the submenu is collapsed when navigating to other sections by collapsing `RoiNavSubmenu` in `NavLayoutSetup_Click`, `NavBatchInspection_Click`, and `NavComms_Click`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956eb2b4aac832bb72b82ac588209a7)