### PR TITLE
UI: Reduce and indent ROI Management submenu buttons (Master/Inspection)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1620,22 +1620,33 @@
                 </ui:Button>
                 <!-- Submenú colapsable: aparece debajo de ROIs Management -->
                 <StackPanel x:Name="RoiNavSubmenu" Visibility="Collapsed" Margin="0">
-                    <!-- 90% de la altura del LeftNavButtonStyle (48 -> 43). -->
-                    <ui:Button Height="43"
+                    <ui:Button Height="37"
                                Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectMaster_Click">
+                               Click="RoiManagementSelectMaster_Click"
+                               HorizontalAlignment="Right"
+                               Margin="18,0,0,0">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
-                            <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}"
+                                           FontSize="15"
+                                           Margin="0,0,8,0"/>
+                            <TextBlock Text="Master ROIs"
+                                       FontSize="12"
+                                       VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
 
-                    <ui:Button Height="43"
+                    <ui:Button Height="37"
                                Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectInspection_Click">
+                               Click="RoiManagementSelectInspection_Click"
+                               HorizontalAlignment="Right"
+                               Margin="18,0,0,0">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
-                            <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
+                                           FontSize="15"
+                                           Margin="0,0,8,0"/>
+                            <TextBlock Text="Inspection ROIs"
+                                       FontSize="12"
+                                       VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
                 </StackPanel>


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy of the "ROIs Management" submenu by making the "Master ROIs" and "Inspection ROIs" buttons ~15% smaller, indented and visually child-like.
- Ensure the submenu items remain in the same left navigation column directly below `ROIs Management` and push the rest of the nav items down.
- Align the right edge of the submenu buttons with the other navigation buttons while preserving `LeftNavButtonStyle` hover/press behavior.
- Preserve existing behavior by not modifying click handlers or bindings for the submenu entries.

### Description
- Replaced the two buttons under `RoiNavSubmenu` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` with compact variants using `Height="37"`, `SymbolIcon FontSize="15"`, and `TextBlock FontSize="12"`.
- Added `HorizontalAlignment="Right"` and `Margin="18,0,0,0"` to create the requested indentation and to reduce the effective button width so the items read as submenu children.
- Kept the original click handlers `RoiManagementSelectMaster_Click` and `RoiManagementSelectInspection_Click` unchanged and made no code-behind edits.
- File modified: `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.

### Testing
- No automated tests were run for this UI-only XAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956efc6620c832b852410a28e15519c)