### PR TITLE
Make ROI submenu buttons inherit nav style and add indentation

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1618,35 +1618,22 @@
                         <TextBlock Text="ROIs Management" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <!-- Submenú colapsable: aparece debajo de ROIs Management -->
+                <!-- Submenú colapsable: mismo tamaño/estilo que el resto, con tabulación -->
                 <StackPanel x:Name="RoiNavSubmenu" Visibility="Collapsed" Margin="0">
-                    <ui:Button Height="37"
-                               Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectMaster_Click"
-                               HorizontalAlignment="Right"
-                               Margin="18,0,0,0">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}"
-                                           FontSize="15"
-                                           Margin="0,0,8,0"/>
-                            <TextBlock Text="Master ROIs"
-                                       FontSize="12"
-                                       VerticalAlignment="Center"/>
+                    <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                               Click="RoiManagementSelectMaster_Click">
+                        <!-- Tabulación: indentamos SOLO el contenido para mantener mismo ancho/alineación del botón -->
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
+                            <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
 
-                    <ui:Button Height="37"
-                               Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectInspection_Click"
-                               HorizontalAlignment="Right"
-                               Margin="18,0,0,0">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
-                                           FontSize="15"
-                                           Margin="0,0,8,0"/>
-                            <TextBlock Text="Inspection ROIs"
-                                       FontSize="12"
-                                       VerticalAlignment="Center"/>
+                    <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                               Click="RoiManagementSelectInspection_Click">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
+                            <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
                 </StackPanel>


### PR DESCRIPTION
### Motivation
- Ensure “Master ROIs” and “Inspection ROIs” match the visual size and behavior of the main `ROIs Management` button.
- Make the submenu buttons visually indistinguishable in style/hover/press from other left nav buttons by reusing the shared style.
- Present the buttons as children of `ROIs Management` via indentation while preserving existing click handlers. 
- Keep the existing toggle behavior controlled by `NavRoiManagement_Click` (submenu visibility). 

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to replace the submenu button definitions under `RoiNavSubmenu` so they no longer use forced `Height`/`FontSize`/`Width`. 
- Submenu buttons now use the shared `LeftNavButtonStyle` so they inherit the same sizing and interaction visuals as the primary nav buttons. 
- Indentation is implemented by adding an inner `StackPanel` with a left `Margin="22,0,0,0"` so the button width/alignment is preserved while the content appears tabbed. 
- Preserved existing click handlers: `RoiManagementSelectMaster_Click`, `RoiManagementSelectInspection_Click`, and the submenu toggle `NavRoiManagement_Click` remains unchanged. 

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6957de12b24c832e909b433c58b72406)