### PR TITLE
Add dynamic side panel title

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -451,7 +451,19 @@
 
         <!-- ===== Side Panel Host ===== -->
         <Grid Grid.Row="1" Grid.Column="1" x:Name="SidePanelHost">
-            <ScrollViewer x:Name="LayoutSetupPanel" VerticalScrollBarVisibility="Auto" d:Visibility="Collapsed">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock x:Name="SidePanelTitle"
+                       Grid.Row="0"
+                       Style="{StaticResource HeaderTextStyle}"
+                       FontSize="16"
+                       Margin="8,8,8,4"
+                       Visibility="Collapsed"/>
+
+            <ScrollViewer x:Name="LayoutSetupPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" d:Visibility="Collapsed">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <ui:Button x:Name="BtnLoadImage"
@@ -538,7 +550,7 @@
                 </StackPanel>
         </ScrollViewer>
 
-            <ScrollViewer x:Name="RoiManagementPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
+            <ScrollViewer x:Name="RoiManagementPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel x:Name="RoiManagementSelector"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">
@@ -1287,7 +1299,7 @@
         </StackPanel>
     </ScrollViewer>
 
-            <ScrollViewer x:Name="BatchInspectionPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" DataContext="{Binding DataContext, ElementName=WorkflowHost}">
+            <ScrollViewer x:Name="BatchInspectionPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" DataContext="{Binding DataContext, ElementName=WorkflowHost}">
                 <Grid Margin="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -1452,7 +1464,7 @@
                 </Grid>
             </ScrollViewer>
 
-            <ScrollViewer x:Name="CommsPanel" VerticalScrollBarVisibility="Auto" Visibility="Collapsed">
+            <ScrollViewer x:Name="CommsPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed">
                 <Grid Margin="8" x:Name="CommsRoot">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3656,10 +3656,25 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
+        private void SetSidePanelTitle(string? title)
+        {
+            if (SidePanelTitle == null)
+            {
+                return;
+            }
+
+            var trimmed = title?.Trim();
+            SidePanelTitle.Text = trimmed ?? string.Empty;
+            SidePanelTitle.Visibility = string.IsNullOrEmpty(trimmed)
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        }
+
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.LayoutSetup);
+            SetSidePanelTitle("Layout Setup");
         }
 
         private void NavRoiManagement_Click(object sender, RoutedEventArgs e)
@@ -3671,21 +3686,25 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 ShowSidePanel(SidePanelMode.RoiManagement);
                 RoiPanelMode = RoiPanelMode.Selector;
+                SetSidePanelTitle("ROI Management");
             }
             else
             {
                 RoiManagementPanel.Visibility = Visibility.Collapsed;
+                SetSidePanelTitle(string.Empty);
             }
         }
 
         private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
         {
             RoiPanelMode = RoiPanelMode.Master;
+            SetSidePanelTitle("ROI Management -> ROI Master");
         }
 
         private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
         {
             RoiPanelMode = RoiPanelMode.Inspection;
+            SetSidePanelTitle("ROI Management -> ROI Inspection");
         }
 
         private void RoiManagementBack_Click(object sender, RoutedEventArgs e)
@@ -3697,12 +3716,14 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.BatchInspection);
+            SetSidePanelTitle("Batch Inspection");
         }
 
         private void NavComms_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.Comms);
+            SetSidePanelTitle("Comms");
         }
 
         private void PanelSplitter_OnDragCompleted(object sender, DragCompletedEventArgs e)


### PR DESCRIPTION
### Motivation
- Provide a single dynamic title for the side panel that becomes visible when navigating to a panel and is hidden at startup.
- Keep existing layout and handlers intact while surfacing the active menu name in the side panel header.
- Enforce a consistent title font size of `16` and reuse the current header style.
- Avoid breaking existing bindings or logic by keeping changes localized to layout and brief calls in nav handlers.

### Description
- Add a header row to `SidePanelHost` with a `TextBlock` named `SidePanelTitle` and `FontSize="16"`, initially `Visibility="Collapsed"` in `MainWindow.xaml`.
- Move existing top-level `ScrollViewer` panels to `Grid.Row="1"` and add a `Grid.RowDefinitions` block so the title occupies `Row 0` and content `Row 1`.
- Add `SetSidePanelTitle(string?)` helper in `MainWindow.xaml.cs` that updates `SidePanelTitle.Text` and toggles its `Visibility` based on content.
- Call `SetSidePanelTitle(...)` from navigation handlers such as `NavLayoutSetup_Click`, `NavBatchInspection_Click`, `NavComms_Click`, `NavRoiManagement_Click`, `RoiManagementSelectInspection_Click`, and `RoiManagementSelectMaster_Click` with the appropriate menu strings.

### Testing
- No automated tests were executed as part of this change.
- The code changes are limited to `MainWindow.xaml` and `MainWindow.xaml.cs` and are designed to be non-invasive to existing logic.
- Manual UI verification is recommended to confirm the title appears/disappears for `Layout Setup`, `ROI Management` (and sub-pages), `Batch Inspection`, and `Comms`.
- Ensure `SidePanelTitle` remains `Collapsed` at startup and displays text at `16px` when panels are shown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695800627de8832e9f4bbfd2fc63a7c4)