### PR TITLE
Remove ROI Management back buttons and increase side panel title font size

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -459,7 +459,7 @@
             <TextBlock x:Name="SidePanelTitle"
                        Grid.Row="0"
                        Style="{StaticResource HeaderTextStyle}"
-                       FontSize="16"
+                       FontSize="20"
                        Margin="8,8,8,4"
                        Visibility="Collapsed"/>
 
@@ -562,16 +562,6 @@
 
                     <StackPanel x:Name="MasterRoisPanel"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Master}">
-                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
-                        <ui:Button Height="43"
-                                   Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="RoiManagementBack_Click">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowLeft24}" FontSize="18" Margin="0,0,10,0"/>
-                                <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ui:Button>
-
                         <GroupBox x:Name="MasterRoiGroup"
                                   Header="Master ROI"
                                   Margin="10,0,0,0" Height="202" ScrollViewer.VerticalScrollBarVisibility="Disabled" Width="441" HorizontalAlignment="Left">
@@ -808,16 +798,6 @@
 
                     <StackPanel x:Name="InspectionRoisPanel"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Inspection}">
-                        <!-- 90% of LeftNavButtonStyle Height (48 -> 43). -->
-                        <ui:Button Height="43"
-                                   Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="RoiManagementBack_Click">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.ArrowLeft24}" FontSize="18" Margin="0,0,10,0"/>
-                                <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ui:Button>
-
                         <GroupBox x:Name="InspectionRoisGroup" Header="Inspection ROIs" Margin="0,12,0,0">
                             <StackPanel Margin="8,4,0,0">
                                 <StackPanel Orientation="Horizontal" Margin="0,0,0,4" VerticalAlignment="Center">

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3707,11 +3707,6 @@ namespace BrakeDiscInspector_GUI_ROI
             SetSidePanelTitle("ROI Management -> ROI Inspection");
         }
 
-        private void RoiManagementBack_Click(object sender, RoutedEventArgs e)
-        {
-            RoiPanelMode = RoiPanelMode.Selector;
-        }
-
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;


### PR DESCRIPTION
### Motivation
- Simplify the ROI Management UI by removing redundant "Back" buttons inside the Master and Inspection panels.
- Ensure the dynamic side panel title is more prominent by increasing its font size.
- Remove unused event handler code to avoid dead code and potential maintenance confusion.
- Preserve existing navigation flow where `NavRoiManagement_Click` controls expansion and selector state.

### Description
- Deleted the left-arrow "Back" buttons inside `MasterRoisPanel` and `InspectionRoisPanel` in `MainWindow.xaml`.
- Increased the `SidePanelTitle` `FontSize` from `16` to `20` in `MainWindow.xaml`.
- Removed the unused handler method `RoiManagementBack_Click` from `MainWindow.xaml.cs`.
- Left `NavRoiManagement_Click` behavior intact so expanding/collapsing ROI Management still sets `RoiPanelMode = RoiPanelMode.Selector` and updates the side title.

### Testing
- Ran a repository-wide search for `RoiManagementBack_Click` to confirm no remaining references and the search returned no matches.
- No automated unit or UI tests were executed for this UI-only change.
- Manual inspection of the edited XAML/CS files was performed to verify the deleted blocks and handler removal.
- No build or runtime tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695803114bd8832eb0bdec8d84e6a283)