### PR TITLE
Add "Advnaced" sub‑submenu and collapsible Advanced panel for Master ROIs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -683,94 +683,101 @@
                             </ui:Button>
                         </WrapPanel>
 
-                        <Grid Margin="0,12,0,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" MinWidth="221"/>
-                                <ColumnDefinition Width="9"/>
-                                <ColumnDefinition Width="Auto" MinWidth="228"/>
-                            </Grid.ColumnDefinitions>
-                            <GroupBox Header="Analyze Options M1"
-                                      UseLayoutRounding="False"
-                                      Grid.Column="0"
-                                      Margin="10,0,10,11"
-                                      DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                                <StackPanel Margin="0,4,0,0">
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Width="195">
-                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0" HorizontalAlignment="Left"/>
-                                        <ComboBox x:Name="ComboFeature" Width="138"
-                                                  SelectedValuePath="Content"
-                                                  SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}" Height="37">
-                                            <ComboBoxItem Content="auto"/>
-                                            <ComboBoxItem Content="sift"/>
-                                            <ComboBoxItem Content="orb"/>
-                                            <ComboBoxItem Content="tm_rot"/>
-                                            <ComboBoxItem Content="edges"/>
-                                        </ComboBox>
-                                    </StackPanel>
+                        <StackPanel x:Name="MasterAdvancedOptionsPanel"
+                                    Visibility="Collapsed"
+                                    Margin="12,0,0,0">
+                            <Grid Margin="0,12,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="221"/>
+                                    <ColumnDefinition Width="9"/>
+                                    <ColumnDefinition Width="Auto" MinWidth="228"/>
+                                </Grid.ColumnDefinitions>
+                                <GroupBox Header="Analyze Options M1"
+                                          UseLayoutRounding="False"
+                                          Grid.Column="0"
+                                          Margin="10,0,10,11"
+                                          DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                    <StackPanel Margin="0,4,0,0">
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Width="195">
+                                            <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0" HorizontalAlignment="Left"/>
+                                            <ComboBox x:Name="ComboFeature" Width="138"
+                                                      SelectedValuePath="Content"
+                                                      SelectedValue="{Binding AnalyzeFeatureM1, Mode=TwoWay}" Height="37">
+                                                <ComboBoxItem Content="auto"/>
+                                                <ComboBoxItem Content="sift"/>
+                                                <ComboBoxItem Content="orb"/>
+                                                <ComboBoxItem Content="tm_rot"/>
+                                                <ComboBoxItem Content="edges"/>
+                                            </ComboBox>
+                                        </StackPanel>
 
-                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="191" HorizontalAlignment="Left">
-                                        <TextBlock Text="Threshold" VerticalAlignment="Center" Margin="0,0,1,0"/>
-                                        <TextBox x:Name="TxtThr" Width="128"
-                                                 Margin="4,0,0,0"
-                                                 Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
+                                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="191" HorizontalAlignment="Left">
+                                            <TextBlock Text="Threshold" VerticalAlignment="Center" Margin="0,0,1,0"/>
+                                            <TextBox x:Name="TxtThr" Width="128"
+                                                     Margin="4,0,0,0"
+                                                     Text="{Binding AnalyzeThrM1, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
+                                        </StackPanel>
                                     </StackPanel>
-                                </StackPanel>
-                            </GroupBox>
-                            <GroupBox Header="Analyze Options M2"
-                                      Grid.Column="2"
-                                      Margin="0,0,0,12"
+                                </GroupBox>
+                                <GroupBox Header="Analyze Options M2"
+                                          Grid.Column="2"
+                                          Margin="0,0,0,12"
+                                          DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                    <StackPanel Margin="8,4,0,0">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                            <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                            <ComboBox x:Name="ComboFeatureM2" Width="138"
+                                                      SelectedValuePath="Content"
+                                                      SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}" Height="37">
+                                                <ComboBoxItem Content="auto"/>
+                                                <ComboBoxItem Content="sift"/>
+                                                <ComboBoxItem Content="orb"/>
+                                                <ComboBoxItem Content="tm_rot"/>
+                                                <ComboBoxItem Content="edges"/>
+                                            </ComboBox>
+                                        </StackPanel>
+
+                                        <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="221" HorizontalAlignment="Left">
+                                            <TextBlock Text="Thershold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
+                                            <TextBox x:Name="TxtThrM2" Width="128"
+                                                     Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
+                                        </StackPanel>
+                                    </StackPanel>
+                                </GroupBox>
+                            </Grid>
+                            <GroupBox Header="Analyze Options"
+                                      Width="240"
+                                      Height="204"
+                                      Padding="8,16,8,8"
+                                      ScrollViewer.CanContentScroll="True"
                                       DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
                                 <StackPanel Margin="8,4,0,0">
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
-                                        <TextBlock Text="Feature:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-                                        <ComboBox x:Name="ComboFeatureM2" Width="138"
-                                                  SelectedValuePath="Content"
-                                                  SelectedValue="{Binding AnalyzeFeatureM2, Mode=TwoWay}" Height="37">
-                                            <ComboBoxItem Content="auto"/>
-                                            <ComboBoxItem Content="sift"/>
-                                            <ComboBoxItem Content="orb"/>
-                                            <ComboBoxItem Content="tm_rot"/>
-                                            <ComboBoxItem Content="edges"/>
-                                        </ComboBox>
+                                    <StackPanel Height="102" CanVerticallyScroll="True">
+                                        <CheckBox x:Name="ChkDisableRot"
+                                                  Content="Disable rot"
+                                                  IsChecked="{Binding DisableRot, Mode=TwoWay}"/>
+                                        <CheckBox x:Name="ChkScaleLock"
+                                                  Content="Lock scale"
+                                                  IsChecked="{Binding ScaleLock, Mode=TwoWay}"/>
+                                        <CheckBox x:Name="ChkUseLocalMatcher"
+                                                  Content="Use local matcher"
+                                                  ToolTip="Force local matcher"
+                                                  IsChecked="True"/>
                                     </StackPanel>
-
-                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="221" HorizontalAlignment="Left">
-                                        <TextBlock Text="Thershold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
-                                        <TextBox x:Name="TxtThrM2" Width="128"
-                                                 Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
-                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0"/>
                                 </StackPanel>
                             </GroupBox>
-                        </Grid>
-                        <GroupBox Header="Analyze Options"
-                                  Width="240"
-                                  Height="204"
-                                  Padding="8,16,8,8"
-                                  ScrollViewer.CanContentScroll="True"
-                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                            <StackPanel Margin="8,4,0,0">
-                                <StackPanel Height="102" CanVerticallyScroll="True">
-                                    <CheckBox x:Name="ChkDisableRot"
-                                              Content="Disable rot"
-                                              IsChecked="{Binding DisableRot, Mode=TwoWay}"/>
-                                    <CheckBox x:Name="ChkScaleLock"
-                                              Content="Lock scale"
-                                              IsChecked="{Binding ScaleLock, Mode=TwoWay}"/>
-                                    <CheckBox x:Name="ChkUseLocalMatcher"
-                                              Content="Use local matcher"
-                                              ToolTip="Force local matcher"
-                                              IsChecked="True"/>
-                                </StackPanel>
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,0"/>
-                                <ui:Button x:Name="BtnAnalyzeMaster"
-                                           Click="BtnAnalyzeMaster_Click">
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
-                                        <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
-                                    </StackPanel>
-                                </ui:Button>
+                        </StackPanel>
+
+                        <!-- Acción siempre visible (no dentro de Advanced) -->
+                        <ui:Button x:Name="BtnAnalyzeMaster"
+                                   Click="BtnAnalyzeMaster_Click"
+                                   Margin="0,8,0,0">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
+                                <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
                             </StackPanel>
-                        </GroupBox>
+                        </ui:Button>
 
                         <GroupBox Header="Match Options"
                                   Width="260"
@@ -1620,6 +1627,18 @@
                             <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
+
+                    <!-- Sub-submenú: visible solo cuando se selecciona Master ROIs -->
+                    <StackPanel x:Name="MasterRoiSubmenu" Visibility="Collapsed" Margin="0">
+                        <ui:Button Style="{StaticResource LeftNavButtonStyle}"
+                                   Click="NavMasterAdvanced_Click">
+                            <!-- tabulación para subnivel -->
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
+                                <TextBlock Text="Advnaced" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
+                    </StackPanel>
 
                     <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                                Click="RoiManagementSelectInspection_Click">

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3673,6 +3673,8 @@ namespace BrakeDiscInspector_GUI_ROI
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
+            MasterRoiSubmenu.Visibility = Visibility.Collapsed;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.LayoutSetup);
             SetSidePanelTitle("Layout Setup");
         }
@@ -3681,6 +3683,8 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             var expand = RoiNavSubmenu.Visibility != Visibility.Visible;
             RoiNavSubmenu.Visibility = expand ? Visibility.Visible : Visibility.Collapsed;
+            MasterRoiSubmenu.Visibility = Visibility.Collapsed;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
 
             if (expand)
             {
@@ -3699,17 +3703,29 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             RoiPanelMode = RoiPanelMode.Master;
             SetSidePanelTitle("ROI Management -> ROI Master");
+            MasterRoiSubmenu.Visibility = Visibility.Visible;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
         }
 
         private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
         {
             RoiPanelMode = RoiPanelMode.Inspection;
             SetSidePanelTitle("ROI Management -> ROI Inspection");
+            MasterRoiSubmenu.Visibility = Visibility.Collapsed;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+        }
+
+        private void NavMasterAdvanced_Click(object sender, RoutedEventArgs e)
+        {
+            var show = MasterAdvancedOptionsPanel.Visibility != Visibility.Visible;
+            MasterAdvancedOptionsPanel.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
+            MasterRoiSubmenu.Visibility = Visibility.Collapsed;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.BatchInspection);
             SetSidePanelTitle("Batch Inspection");
         }
@@ -3717,6 +3733,8 @@ namespace BrakeDiscInspector_GUI_ROI
         private void NavComms_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
+            MasterRoiSubmenu.Visibility = Visibility.Collapsed;
+            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
             ShowSidePanel(SidePanelMode.Comms);
             SetSidePanelTitle("Comms");
         }


### PR DESCRIPTION
### Motivation
- Add a tabbed sub‑menu entry under Master ROIs named `Advnaced` that is hidden until `Master ROIs` is selected.  
- Provide a collapsible container for the more detailed analyze controls so the main ROI Master panel remains uncluttered.  
- Preserve existing UI size/style and keep `Force Analyze Master` and `Match Options` always visible.  

### Description
- Updated `MainWindow.xaml` to add `MasterRoiSubmenu` (the `Advnaced` button) and a `MasterAdvancedOptionsPanel` that contains the `Analyze Options M1`, `Analyze Options M2` and `Analyze Options` GroupBoxes.  
- Moved the `BtnAnalyzeMaster` control out of the `Analyze Options` GroupBox so it remains always visible and left the `Match Options` GroupBox unchanged.  
- Updated `MainWindow.xaml.cs` to add the `NavMasterAdvanced_Click` handler and to toggle/reset `MasterRoiSubmenu` and `MasterAdvancedOptionsPanel` visibility from existing navigation handlers such as `RoiManagementSelectMaster_Click` and `RoiManagementSelectInspection_Click`.  
- Preserved existing handlers and bindings (no existing click handlers were modified or removed).  

### Testing
- No automated tests were executed for this change.  
- Changes were limited to XAML and code‑behind visibility logic and should be covered by UI/manual validation steps configured by the QA plan.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69584b29158c832b97d03acbdb32618a)