### PR TITLE
Adjust Advanced navigation indentation and label

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -685,7 +685,7 @@
 
                         <StackPanel x:Name="MasterAdvancedOptionsPanel"
                                     Visibility="Collapsed"
-                                    Margin="12,0,0,0">
+                                    Margin="0,8,0,0">
                             <Grid Margin="0,12,0,0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" MinWidth="221"/>
@@ -1633,9 +1633,9 @@
                         <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                                    Click="NavMasterAdvanced_Click">
                             <!-- tabulación para subnivel -->
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="40,0,0,0">
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
-                                <TextBlock Text="Advnaced" VerticalAlignment="Center"/>
+                                <TextBlock Text="Advanced" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>


### PR DESCRIPTION
### Motivation
- Align the left navigation hierarchy so `Advanced` is visually indented under `Master ROIs` to match the requested tabulation.
- Correct a typographical label (`Advnaced` → `Advanced`) for clarity.
- Adjust the spacing of the master advanced options container to match the UI spacing guidance.
- Keep existing bindings and handlers unchanged (no behavioral changes to event logic).

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to change `MasterAdvancedOptionsPanel` margin from `12,0,0,0` to `0,8,0,0`.
- Increased the submenu indentation by setting the `Advanced` button content `StackPanel` margin to `40,0,0,0` (was `22,0,0,0`).
- Fixed the displayed text from `Advnaced` to `Advanced`.
- No changes were made to C# handlers such as `RoiManagementSelectMaster_Click`, `RoiManagementSelectInspection_Click`, `NavRoiManagement_Click`, or `NavMasterAdvanced_Click`.

### Testing
- No automated tests were run for this UI-only change.
- Change was committed and verified via local source inspection; runtime/visual verification was not executed in CI.
- No unit/integration tests were added or modified.
- Handlers and existing bindings were intentionally left untouched to avoid behavioral regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69584e8efb08832baee68c1da9b06e1a)