### PR TITLE
ROI Master: toggle Advanced analyze options panel and dynamic side title

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -562,126 +562,160 @@
 
                     <StackPanel x:Name="MasterRoisPanel"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Master}">
-                        <GroupBox x:Name="MasterRoiGroup"
-                                  Header="Master ROI"
-                                  Margin="10,0,0,0" Height="202" ScrollViewer.VerticalScrollBarVisibility="Disabled" Width="441" HorizontalAlignment="Left">
-                            <Grid Margin="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="10*"/>
-                                    <ColumnDefinition Width="179*"/>
-                                    <ColumnDefinition Width="204*"/>
-                                </Grid.ColumnDefinitions>
+                        <StackPanel x:Name="MasterDefaultPanel" Visibility="Visible">
+                            <GroupBox x:Name="MasterRoiGroup"
+                                      Header="Master ROI"
+                                      Margin="10,0,0,0" Height="202" ScrollViewer.VerticalScrollBarVisibility="Disabled" Width="441" HorizontalAlignment="Left">
+                                <Grid Margin="8">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="10*"/>
+                                        <ColumnDefinition Width="179*"/>
+                                        <ColumnDefinition Width="204*"/>
+                                    </Grid.ColumnDefinitions>
 
-                                <StackPanel Grid.Column="0" Grid.ColumnSpan="2">
-                                    <TextBlock Text="Master 1" FontWeight="SemiBold" Margin="0,0,0,6" FontSize="18" Width="165" HorizontalAlignment="Left"/>
-                                    <Grid Width="218" HorizontalAlignment="Left">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" MinWidth="49"/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="Shape:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                        <ComboBox x:Name="ComboMasterRoiShape" Grid.Column="1" Height="37" HorizontalAlignment="Left" Width="135" Margin="1,0,0,0">
-                                            <ComboBoxItem Content="Rectangle"/>
-                                            <ComboBoxItem Content="Circle"/>
-                                            <ComboBoxItem Content="Annulus"/>
-                                        </ComboBox>
-                                    </Grid>
-                                    <Grid Margin="0,0,0,6" Width="216" HorizontalAlignment="Left">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" MinWidth="50"/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                        <ComboBox x:Name="ComboMasterRoiRole" Grid.Column="1" RenderTransformOrigin="0.521,0.527" HorizontalAlignment="Left" Width="135" Height="37"/>
-                                    </Grid>
-                                    <WrapPanel Width="112" RenderTransformOrigin="0.515,0.547" HorizontalAlignment="Left" Margin="65,0,0,0">
-                                        <ui:Button x:Name="BtnEditM1"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   ToolTip="Edit Master 1"
-                                                   Click="BtnEditM1_Click" Height="37" Width="37" HorizontalAlignment="Center">
-                                            <ui:SymbolIcon x:Name="IconEditM1" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
-                                        </ui:Button>
-                                        <ui:Button x:Name="BtnM1_Remove"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   Click="BtnM1_Remove_Click" Width="37" Height="37" VerticalAlignment="Stretch" HorizontalAlignment="Left">
-                                            <StackPanel Orientation="Horizontal" Height="22" HorizontalAlignment="Left" RenderTransformOrigin="1,0.521" Width="17">
-                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
-                                            </StackPanel>
-                                        </ui:Button>
-                                        <ui:Button x:Name="BtnM1_Create"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   Click="BtnM1_Create_Click" Width="37" Height="37" HorizontalAlignment="Left">
-                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Height="18" Width="15">
-                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
-                                            </StackPanel>
-                                        </ui:Button>
-                                    </WrapPanel>
-                                </StackPanel>
+                                    <StackPanel Grid.Column="0" Grid.ColumnSpan="2">
+                                        <TextBlock Text="Master 1" FontWeight="SemiBold" Margin="0,0,0,6" FontSize="18" Width="165" HorizontalAlignment="Left"/>
+                                        <Grid Width="218" HorizontalAlignment="Left">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" MinWidth="49"/>
+                                                <ColumnDefinition/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="Shape:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                            <ComboBox x:Name="ComboMasterRoiShape" Grid.Column="1" Height="37" HorizontalAlignment="Left" Width="135" Margin="1,0,0,0">
+                                                <ComboBoxItem Content="Rectangle"/>
+                                                <ComboBoxItem Content="Circle"/>
+                                                <ComboBoxItem Content="Annulus"/>
+                                            </ComboBox>
+                                        </Grid>
+                                        <Grid Margin="0,0,0,6" Width="216" HorizontalAlignment="Left">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" MinWidth="50"/>
+                                                <ColumnDefinition/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                            <ComboBox x:Name="ComboMasterRoiRole" Grid.Column="1" RenderTransformOrigin="0.521,0.527" HorizontalAlignment="Left" Width="135" Height="37"/>
+                                        </Grid>
+                                        <WrapPanel Width="112" RenderTransformOrigin="0.515,0.547" HorizontalAlignment="Left" Margin="65,0,0,0">
+                                            <ui:Button x:Name="BtnEditM1"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       ToolTip="Edit Master 1"
+                                                       Click="BtnEditM1_Click" Height="37" Width="37" HorizontalAlignment="Center">
+                                                <ui:SymbolIcon x:Name="IconEditM1" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
+                                            </ui:Button>
+                                            <ui:Button x:Name="BtnM1_Remove"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       Click="BtnM1_Remove_Click" Width="37" Height="37" VerticalAlignment="Stretch" HorizontalAlignment="Left">
+                                                <StackPanel Orientation="Horizontal" Height="22" HorizontalAlignment="Left" RenderTransformOrigin="1,0.521" Width="17">
+                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
+                                                </StackPanel>
+                                            </ui:Button>
+                                            <ui:Button x:Name="BtnM1_Create"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       Click="BtnM1_Create_Click" Width="37" Height="37" HorizontalAlignment="Left">
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Height="18" Width="15">
+                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
+                                                </StackPanel>
+                                            </ui:Button>
+                                        </WrapPanel>
+                                    </StackPanel>
 
-                                <StackPanel Grid.Column="2" HorizontalAlignment="Left" Width="188" Margin="10,0,0,0">
-                                    <TextBlock Text="Master 2" FontWeight="SemiBold" FontSize="18" Width="146" HorizontalAlignment="Left" Margin="0,0,0,6"/>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="Shape:" VerticalAlignment="Top" Margin="0,10,8,0"/>
-                                        <ComboBox x:Name="ComboM2Shape" Grid.Column="1" HorizontalAlignment="Center" Width="135" VerticalAlignment="Center" Height="35">
-                                            <ComboBoxItem Content="Rectangle"/>
-                                            <ComboBoxItem Content="Circle"/>
-                                            <ComboBoxItem Content="Annulus"/>
-                                        </ComboBox>
-                                    </Grid>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" MinWidth="40"/>
-                                            <ColumnDefinition/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
-                                        <ComboBox x:Name="ComboM2Role" Grid.Column="1" Margin="10,0,0,0" Height="37" HorizontalAlignment="Left" Width="135"/>
-                                    </Grid>
-                                    <WrapPanel Width="118" HorizontalAlignment="Left" Margin="60,7,0,0">
-                                        <ui:Button x:Name="BtnEditM2"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   Margin="4,0,0,0"
-                                                   ToolTip="Edit Master 2"
-                                                   Click="BtnEditM2_Click" Width="37" Height="37">
-                                            <ui:SymbolIcon x:Name="IconEditM2" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
-                                        </ui:Button>
-                                        <ui:Button x:Name="BtnM2_Remove"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   Click="BtnM2_Remove_Click" Width="37" HorizontalAlignment="Center" Height="37">
-                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
-                                            </StackPanel>
-                                        </ui:Button>
-                                        <ui:Button x:Name="BtnM2_Create"
-                                                   MinHeight="26"
-                                                   Padding="8,4"
-                                                   Click="BtnM2_Create_Click" RenderTransformOrigin="4.067,0.5" HorizontalAlignment="Center" Width="37" Height="37">
-                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
-                                            </StackPanel>
-                                        </ui:Button>
-                                    </WrapPanel>
-                                </StackPanel>
-                            </Grid>
-                        </GroupBox>
+                                    <StackPanel Grid.Column="2" HorizontalAlignment="Left" Width="188" Margin="10,0,0,0">
+                                        <TextBlock Text="Master 2" FontWeight="SemiBold" FontSize="18" Width="146" HorizontalAlignment="Left" Margin="0,0,0,6"/>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="Shape:" VerticalAlignment="Top" Margin="0,10,8,0"/>
+                                            <ComboBox x:Name="ComboM2Shape" Grid.Column="1" HorizontalAlignment="Center" Width="135" VerticalAlignment="Center" Height="35">
+                                                <ComboBoxItem Content="Rectangle"/>
+                                                <ComboBoxItem Content="Circle"/>
+                                                <ComboBoxItem Content="Annulus"/>
+                                            </ComboBox>
+                                        </Grid>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" MinWidth="40"/>
+                                                <ColumnDefinition/>
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Text="Type:" VerticalAlignment="Center" Margin="0,0,8,0" Height="19"/>
+                                            <ComboBox x:Name="ComboM2Role" Grid.Column="1" Margin="10,0,0,0" Height="37" HorizontalAlignment="Left" Width="135"/>
+                                        </Grid>
+                                        <WrapPanel Width="118" HorizontalAlignment="Left" Margin="60,7,0,0">
+                                            <ui:Button x:Name="BtnEditM2"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       Margin="4,0,0,0"
+                                                       ToolTip="Edit Master 2"
+                                                       Click="BtnEditM2_Click" Width="37" Height="37">
+                                                <ui:SymbolIcon x:Name="IconEditM2" Symbol="{x:Static ui:SymbolRegular.Edit24}" FontSize="16"/>
+                                            </ui:Button>
+                                            <ui:Button x:Name="BtnM2_Remove"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       Click="BtnM2_Remove_Click" Width="37" HorizontalAlignment="Center" Height="37">
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0" FontSize="16"/>
+                                                </StackPanel>
+                                            </ui:Button>
+                                            <ui:Button x:Name="BtnM2_Create"
+                                                       MinHeight="26"
+                                                       Padding="8,4"
+                                                       Click="BtnM2_Create_Click" RenderTransformOrigin="4.067,0.5" HorizontalAlignment="Center" Width="37" Height="37">
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
+                                                </StackPanel>
+                                            </ui:Button>
+                                        </WrapPanel>
+                                    </StackPanel>
+                                </Grid>
+                            </GroupBox>
 
-                        <WrapPanel Margin="0,12,0,12">
-                            <ui:Button x:Name="BtnClearCanvas"
-                                       Click="BtnClearCanvas_Click" Margin="10,0,0,0">
+                            <WrapPanel Margin="0,12,0,12">
+                                <ui:Button x:Name="BtnClearCanvas"
+                                           Click="BtnClearCanvas_Click" Margin="10,0,0,0">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0" FontSize="16"/>
+                                        <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </ui:Button>
+                            </WrapPanel>
+
+                            <ui:Button x:Name="BtnAnalyzeMaster"
+                                       Click="BtnAnalyzeMaster_Click"
+                                       Margin="0,8,0,0">
                                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Eraser24}" Margin="0,0,8,0" FontSize="16"/>
-                                    <TextBlock Text="Clear Canvas" VerticalAlignment="Center"/>
+                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
+                                    <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </ui:Button>
-                        </WrapPanel>
+
+                            <GroupBox Header="Match Options"
+                                      Width="260"
+                                      DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
+                                <StackPanel Margin="8,4,0,0">
+                                    <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
+                                        <TextBlock Text="RotRange:" VerticalAlignment="Center"/>
+                                        <TextBox x:Name="TxtRot" Width="60" Margin="4,0,8,0" Text="10"/>
+                                        <TextBlock Text="ScaleMin:" VerticalAlignment="Center"/>
+                                        <TextBox x:Name="TxtSMin" Width="60" Margin="4,0,8,0" Text="0.95"/>
+                                        <TextBlock Text="ScaleMax:" VerticalAlignment="Center"/>
+                                        <TextBox x:Name="TxtSMax" Width="60" Margin="4,0,0,0" Text="1.05"/>
+                                    </StackPanel>
+                                    <WrapPanel>
+                                        <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0" FontSize="16"/>
+                                                <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
+                                            </StackPanel>
+                                        </ui:Button>
+                                    </WrapPanel>
+                                </StackPanel>
+                            </GroupBox>
+                        </StackPanel>
 
                         <StackPanel x:Name="MasterAdvancedOptionsPanel"
                                     Visibility="Collapsed"
@@ -769,38 +803,6 @@
                             </GroupBox>
                         </StackPanel>
 
-                        <!-- Acción siempre visible (no dentro de Advanced) -->
-                        <ui:Button x:Name="BtnAnalyzeMaster"
-                                   Click="BtnAnalyzeMaster_Click"
-                                   Margin="0,8,0,0">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" Margin="0,0,8,0" FontSize="16"/>
-                                <TextBlock Text="Force Analyze Master" VerticalAlignment="Center"/>
-                            </StackPanel>
-                        </ui:Button>
-
-                        <GroupBox Header="Match Options"
-                                  Width="260"
-                                  DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}">
-                            <StackPanel Margin="8,4,0,0">
-                                <StackPanel Orientation="Horizontal" Margin="0,4,0,8">
-                                    <TextBlock Text="RotRange:" VerticalAlignment="Center"/>
-                                    <TextBox x:Name="TxtRot" Width="60" Margin="4,0,8,0" Text="10"/>
-                                    <TextBlock Text="ScaleMin:" VerticalAlignment="Center"/>
-                                    <TextBox x:Name="TxtSMin" Width="60" Margin="4,0,8,0" Text="0.95"/>
-                                    <TextBlock Text="ScaleMax:" VerticalAlignment="Center"/>
-                                    <TextBox x:Name="TxtSMax" Width="60" Margin="4,0,0,0" Text="1.05"/>
-                                </StackPanel>
-                                <WrapPanel>
-                                    <ui:Button x:Name="BtnSavePreset" Click="BtnSavePreset_Click" Margin="0,0,8,0">
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0" FontSize="16"/>
-                                            <TextBlock Text="Save Preset" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </ui:Button>
-                                </WrapPanel>
-                            </StackPanel>
-                        </GroupBox>
                     </StackPanel>
 
                     <StackPanel x:Name="InspectionRoisPanel"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3670,11 +3670,28 @@ namespace BrakeDiscInspector_GUI_ROI
                 : Visibility.Visible;
         }
 
+        private void SetMasterAdvancedOpen(bool open)
+        {
+            if (MasterAdvancedOptionsPanel != null)
+            {
+                MasterAdvancedOptionsPanel.Visibility = open ? Visibility.Visible : Visibility.Collapsed;
+            }
+
+            if (MasterDefaultPanel != null)
+            {
+                MasterDefaultPanel.Visibility = open ? Visibility.Collapsed : Visibility.Visible;
+            }
+
+            SetSidePanelTitle(open
+                ? "ROI Management -> ROI Master -> Advanced"
+                : "ROI Management -> ROI Master");
+        }
+
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
             ShowSidePanel(SidePanelMode.LayoutSetup);
             SetSidePanelTitle("Layout Setup");
         }
@@ -3684,7 +3701,7 @@ namespace BrakeDiscInspector_GUI_ROI
             var expand = RoiNavSubmenu.Visibility != Visibility.Visible;
             RoiNavSubmenu.Visibility = expand ? Visibility.Visible : Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
 
             if (expand)
             {
@@ -3702,9 +3719,8 @@ namespace BrakeDiscInspector_GUI_ROI
         private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
         {
             RoiPanelMode = RoiPanelMode.Master;
-            SetSidePanelTitle("ROI Management -> ROI Master");
             MasterRoiSubmenu.Visibility = Visibility.Visible;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
         }
 
         private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
@@ -3712,20 +3728,20 @@ namespace BrakeDiscInspector_GUI_ROI
             RoiPanelMode = RoiPanelMode.Inspection;
             SetSidePanelTitle("ROI Management -> ROI Inspection");
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
         }
 
         private void NavMasterAdvanced_Click(object sender, RoutedEventArgs e)
         {
-            var show = MasterAdvancedOptionsPanel.Visibility != Visibility.Visible;
-            MasterAdvancedOptionsPanel.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+            var show = MasterAdvancedOptionsPanel?.Visibility != Visibility.Visible;
+            SetMasterAdvancedOpen(show);
         }
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
             ShowSidePanel(SidePanelMode.BatchInspection);
             SetSidePanelTitle("Batch Inspection");
         }
@@ -3734,7 +3750,7 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
-            MasterAdvancedOptionsPanel.Visibility = Visibility.Collapsed;
+            SetMasterAdvancedOpen(false);
             ShowSidePanel(SidePanelMode.Comms);
             SetSidePanelTitle("Comms");
         }


### PR DESCRIPTION
### Motivation
- Provide an "Advanced" submenu under `Master ROIs` that hides the normal master controls and shows only Analyze Options.
- Keep all existing button bindings and handlers intact while changing only container visibility.
- Update the side panel title to reflect when Advanced mode is open (`ROI Management -> ROI Master -> Advanced`).
- Ensure Advanced state is reset when navigating away to avoid stale UI state.

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to introduce `MasterDefaultPanel` and `MasterAdvancedOptionsPanel`, moving non-Analyze controls into `MasterDefaultPanel` and leaving the three Analyze Options group boxes only inside `MasterAdvancedOptionsPanel`.
- Moved `BtnAnalyzeMaster` and the `Match Options` group into the default container so they are hidden when Advanced is opened and not duplicated.
- Added `SetMasterAdvancedOpen(bool)` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` to toggle `MasterAdvancedOptionsPanel` and `MasterDefaultPanel` visibility and update the side title via the existing `SetSidePanelTitle` helper.
- Wired navigation handlers (`NavMasterAdvanced_Click`, `RoiManagementSelectMaster_Click`, `RoiManagementSelectInspection_Click`, `NavRoiManagement_Click`, `NavLayoutSetup_Click`, `NavBatchInspection_Click`, and `NavComms_Click`) to call `SetMasterAdvancedOpen` as appropriate while leaving existing button handlers and bindings unchanged.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6958504ce534832b87440a4896103733)