### PR TITLE
Remove references to deleted inspection controls

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -8023,26 +8023,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 Dispatcher.Invoke(RefreshCreateButtonsEnabled);
                 return;
             }
-
-            if (BtnCreateInspection1 != null)
-            {
-                BtnCreateInspection1.IsEnabled = !HasInspectionRoi(1);
-            }
-
-            if (BtnCreateInspection2 != null)
-            {
-                BtnCreateInspection2.IsEnabled = !HasInspectionRoi(2);
-            }
-
-            if (BtnCreateInspection3 != null)
-            {
-                BtnCreateInspection3.IsEnabled = !HasInspectionRoi(3);
-            }
-
-            if (BtnCreateInspection4 != null)
-            {
-                BtnCreateInspection4.IsEnabled = !HasInspectionRoi(4);
-            }
         }
 
         private void RefreshInspectionRoiSlots(IReadOnlyList<RoiModel>? rois = null)
@@ -9805,20 +9785,6 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private RoiShape ReadInspectionShapeForIndex(int index)
         {
-            ComboBox? combo = index switch
-            {
-                1 => CmbShapeInspection1,
-                2 => CmbShapeInspection2,
-                3 => CmbShapeInspection3,
-                4 => CmbShapeInspection4,
-                _ => null
-            };
-
-            if (combo?.SelectedItem is RoiShape shape)
-            {
-                return shape;
-            }
-
             var config = GetInspectionConfigByIndex(index);
             if (config != null)
             {


### PR DESCRIPTION
### Motivation
- The code referenced missing UI controls (`BtnCreateInspection1..4`, `CmbShapeInspection1..4`) which produced active `CS0103` compile errors. 
- Remove direct dependencies on deleted XAML controls to avoid null-reference and build failures. 
- Ensure inspection shape selection still works by falling back to stored config or the current draw tool.

### Description
- Remove direct updates to `BtnCreateInspection1`..`BtnCreateInspection4` from `RefreshCreateButtonsEnabled` in `MainWindow.xaml.cs`.
- Simplify `ReadInspectionShapeForIndex` to use `GetInspectionConfigByIndex` and fallback to `ReadCurrentInspectionShape` instead of looking up `CmbShapeInspection` controls.
- Changes are limited to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` and prevent accesses to deleted controls at runtime.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69599e2b8770832e9fc3e3587f0f38ec)