### PR TITLE
Hide inspection dataset section in ROI Inspection panel

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1282,7 +1282,9 @@
                                 </ui:Button>
                             </StackPanel>
 
-                                    <workflow:WorkflowControl x:Name="WorkflowHost" Margin="0,12,0,0"/>
+                                    <workflow:WorkflowControl x:Name="WorkflowHost"
+                                                              ShowInspectionDatasetSection="False"
+                                                              Margin="0,12,0,0"/>
                                 </StackPanel>
                             </GroupBox>
                         </StackPanel>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -8,6 +8,9 @@
              mc:Ignorable="d"
              d:DesignHeight="600"
              d:DesignWidth="480">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10" Orientation="Vertical">
             <StackPanel.Resources>
@@ -28,7 +31,10 @@
                 </Grid>
             </GroupBox>
 
-            <GroupBox Header="Inspection ROIs">
+            <GroupBox Header="Inspection ROIs"
+                      Visibility="{Binding ShowInspectionDatasetSection,
+                                           RelativeSource={RelativeSource AncestorType={x:Type w:WorkflowControl}},
+                                           Converter={StaticResource BoolToVis}}">
                 <DockPanel Margin="8">
                     <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
                         <!-- Per-selected-ROI summary -->

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml.cs
@@ -9,9 +9,22 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 {
     public partial class WorkflowControl : UserControl
     {
+        public static readonly DependencyProperty ShowInspectionDatasetSectionProperty =
+            DependencyProperty.Register(
+                nameof(ShowInspectionDatasetSection),
+                typeof(bool),
+                typeof(WorkflowControl),
+                new PropertyMetadata(true));
+
         public event EventHandler<LoadModelRequestedEventArgs>? LoadModelRequested;
         public event EventHandler<ToggleEditRequestedEventArgs>? ToggleEditRequested;
         public event EventHandler? ClearCanvasRequested;
+
+        public bool ShowInspectionDatasetSection
+        {
+            get => (bool)GetValue(ShowInspectionDatasetSectionProperty);
+            set => SetValue(ShowInspectionDatasetSectionProperty, value);
+        }
 
         public WorkflowControl()
         {


### PR DESCRIPTION
### Motivation
- The ROI Inspection view must hide the large Dataset tabs block (tabs, dataset path, thumbnails, Train/Calibrate/Evaluate) while keeping the smaller Inspection selector and other sections intact.
- The Dataset panel must continue to show the full dataset UI unchanged.
- Implement a minimal, non-destructive toggle to avoid removing XAML or breaking existing bindings and styles.
- Provide an opt-out boolean so the default behavior for Dataset remains unchanged.

### Description
- Added a dependency property `ShowInspectionDatasetSection` to `WorkflowControl` with default `true` to control visibility of the dataset group.
- Added a `BooleanToVisibilityConverter` resource and bound the `GroupBox Header="Inspection ROIs"` `Visibility` to `ShowInspectionDatasetSection` in `Workflow/WorkflowControl.xaml`.
- Set `ShowInspectionDatasetSection="False"` on the `WorkflowControl` instance used by the ROI Inspection host in `MainWindow.xaml` so the dataset block is hidden only in that view.
- No internal contents of the `Inspection ROIs` group or other `GroupBox` elements (`Scale`, `Visualization`, `Regions`, etc.) were modified.

### Testing
- No automated tests were executed as part of this change.
- Changes were limited to XAML and a small code-behind addition and should be build-time safe given the property default of `true`.
- Manual QA checklist (not automated) recommended: open ROI Inspection to verify dataset block hidden and open Dataset view to verify dataset block visible.
- Ensure existing commands/bindings for inspection add/edit/delete still function (no automated verification performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6959af0187dc832e8cc312c9d3feb26b)