### PR TITLE
Show Layout Setup in XAML designer via designer-only visibility

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -463,7 +463,7 @@
                        Margin="8,8,8,4"
                        Visibility="Collapsed"/>
 
-            <ScrollViewer x:Name="LayoutSetupPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" d:Visibility="Collapsed">
+            <ScrollViewer x:Name="LayoutSetupPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <ui:Button x:Name="BtnLoadImage"
@@ -550,7 +550,7 @@
                 </StackPanel>
         </ScrollViewer>
 
-            <ScrollViewer x:Name="RoiManagementPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Visible">
+            <ScrollViewer x:Name="RoiManagementPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Collapsed">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel x:Name="RoiManagementSelector"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">
@@ -1297,7 +1297,7 @@
         </StackPanel>
     </ScrollViewer>
 
-            <ScrollViewer x:Name="BatchInspectionPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" DataContext="{Binding DataContext, ElementName=WorkflowHost}">
+            <ScrollViewer x:Name="BatchInspectionPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Collapsed" DataContext="{Binding DataContext, ElementName=WorkflowHost}">
                 <Grid Margin="0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -1462,7 +1462,7 @@
                 </Grid>
             </ScrollViewer>
 
-            <ScrollViewer x:Name="CommsPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed">
+            <ScrollViewer x:Name="CommsPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Collapsed">
                 <Grid Margin="8" x:Name="CommsRoot">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>


### PR DESCRIPTION
### Motivation
- Make the "Layout Setup" side panel visible in the Visual Studio XAML designer without changing runtime behavior by using designer-only properties.
- Prevent other side panels from covering the Layout panel in the designer so the layout controls are immediately accessible when opening `MainWindow.xaml`.
- Preserve runtime `Visibility` bindings and logic so application behavior is unchanged at runtime.

### Description
- Set `d:Visibility="Visible"` on the `ScrollViewer` named `LayoutSetupPanel` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to force it visible in the designer only.
- Set `d:Visibility="Collapsed"` on `RoiManagementPanel`, `BatchInspectionPanel`, and `CommsPanel` to hide those panels in the designer only.
- Did not modify any runtime `Visibility` attributes or bindings; changes are designer-only via `d:Visibility`.

### Testing
- No automated tests were run against this change.
- Manual designer verification is recommended (open `MainWindow.xaml` in the VS designer) but was not executed as part of this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695abe9ad090832ebef120353da253e4)