### PR TITLE
Replace Layout Autosave CheckBox with Fluent ToggleSwitch

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -84,6 +84,11 @@
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
         </Style>
+        <Style TargetType="{x:Type ui:ToggleSwitch}">
+            <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
+            <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        </Style>
 
         <Style TargetType="{x:Type GroupBox}" BasedOn="{StaticResource CardGroupBoxStyle}">
         </Style>
@@ -488,8 +493,12 @@
                                    Content="{DynamicResource SaveLayout}"
                                    Click="BtnSaveLayout_Click" />
                     </StackPanel>
-                    <CheckBox Content="{DynamicResource LayoutAutosave}"
-                              IsChecked="{Binding LayoutAutosaveEnabled, Mode=TwoWay, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" Margin="0,20,0,0"/>
+                    <ui:ToggleSwitch Content="{DynamicResource LayoutAutosave}"
+                                     IsChecked="{Binding LayoutAutosaveEnabled, Mode=TwoWay, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                     FontFamily="{DynamicResource UI.FontFamily.Body}"
+                                     FontSize="{DynamicResource UI.FontSize.CheckBox}"
+                                     Foreground="{DynamicResource UI.Brush.Foreground}"
+                                     Margin="0,0,0,8"/>
                     <GroupBox Header="{DynamicResource Layouts}" Width="441" DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}" Margin="0,60,0,120" HorizontalAlignment="Center">
                         <StackPanel>
                             <ListBox ItemsSource="{Binding LayoutProfiles.Profiles}"


### PR DESCRIPTION
### Motivation
- Replace the legacy `CheckBox` in the Layout Setup panel with a Fluent-style `ui:ToggleSwitch` for visual consistency.
- Preserve the existing label and binding so behavior remains unchanged (`LayoutAutosave` and `LayoutAutosaveEnabled`).
- Ensure global typography/foreground parity by adding a corresponding `ui:ToggleSwitch` style.
- Make only UI changes and avoid touching code-behind or the `LayoutAutosaveEnabled` property.

### Description
- Added a `Style TargetType="{x:Type ui:ToggleSwitch}"` to `Window.Resources` mirroring the existing `CheckBox` typography and foreground settings in `MainWindow.xaml`.
- Replaced the `CheckBox` control in the `LayoutSetupPanel` with a `ui:ToggleSwitch` that keeps `Content="{DynamicResource LayoutAutosave}"` and the same `IsChecked` binding: `LayoutAutosaveEnabled, Mode=TwoWay, RelativeSource={RelativeSource AncestorType={x:Type Window}}`.
- Applied `FontFamily`, `FontSize`, and `Foreground` setters to the new `ui:ToggleSwitch` and adjusted the `Margin` to match layout spacing.
- No changes were made to code-behind, view-models, or property names; only `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` was modified.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695aeaf52a90832e8c44f2b54389d63e)