### PR TITLE
Fix ToggleSwitch style to preserve WPF-UI Fluent template

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -84,7 +84,8 @@
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
         </Style>
-        <Style TargetType="{x:Type ui:ToggleSwitch}">
+        <Style TargetType="{x:Type ui:ToggleSwitch}"
+               BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
@@ -495,9 +496,6 @@
                     </StackPanel>
                     <ui:ToggleSwitch Content="{DynamicResource LayoutAutosave}"
                                      IsChecked="{Binding LayoutAutosaveEnabled, Mode=TwoWay, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                     FontFamily="{DynamicResource UI.FontFamily.Body}"
-                                     FontSize="{DynamicResource UI.FontSize.CheckBox}"
-                                     Foreground="{DynamicResource UI.Brush.Foreground}"
                                      Margin="0,0,0,8"/>
                     <GroupBox Header="{DynamicResource Layouts}" Width="441" DataContext="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}}" Margin="0,60,0,120" HorizontalAlignment="Center">
                         <StackPanel>


### PR DESCRIPTION
### Motivation
- An implicit `ui:ToggleSwitch` style in `MainWindow.xaml` was replacing WPF-UI's default template, causing the Layout Autosave control to render like a plain `ToggleButton` instead of a Fluent `ToggleSwitch`.
- The Layout Autosave control must keep the exact same `IsChecked` binding and behavior while restoring the Fluent appearance.
- Typography and foreground tweaks should remain applied without removing the WPF-UI control template.

### Description
- Change the implicit `ui:ToggleSwitch` style in `MainWindow.xaml` to be `BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}"` so it inherits the WPF-UI default template.
- Remove redundant `FontFamily`, `FontSize`, and `Foreground` attributes from the `Layout Autosave` `ui:ToggleSwitch` element because the style already sets them.
- Preserve the `IsChecked` binding (`LayoutAutosaveEnabled`, `Mode=TwoWay`, `RelativeSource` to the `Window`) exactly as before.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695aeded87c0832e9148d0d1e366fedc)