### PR TITLE
Remove blank dataset (+) button from layout panel and drop BlankDataset command

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -542,14 +542,6 @@
                                         <TextBlock Text="Delete" VerticalAlignment="Center"/>
                                     </StackPanel>
                                 </ui:Button>
-                                <ui:Button Margin="4,0,0,0"
-                                           Command="{Binding BlankDatasetCommand}"
-                                           ToolTip="Create a blank dataset for the current layout" Height="45" Width="72" Padding="4,5,4,6">
-                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
-                                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Add24}" Margin="0,0,8,0" FontSize="16"/>
-                                        <TextBlock Text="Blank "/>
-                                    </StackPanel>
-                                </ui:Button>
                             </WrapPanel>
                         </StackPanel>
                     </GroupBox>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -507,7 +507,6 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }, _ => _isBatchRunning);
 
             BrowseDatasetCommand = CreateCommand(_ => BrowseDatasetAsync(), _ => !IsBusy && SelectedInspectionRoi != null);
-            BlankDatasetCommand = CreateCommand(_ => BlankDatasetAsync(), _ => !IsBusy);
             TrainSelectedRoiCommand = CreateCommand(async _ => await TrainSelectedRoiAsync().ConfigureAwait(false), _ => !IsBusy && SelectedInspectionRoi != null);
             CalibrateSelectedRoiCommand = CreateCommand(async _ => await CalibrateSelectedRoiAsync().ConfigureAwait(false), _ => !IsBusy && CanCalibrateSelectedRoi());
             EvaluateSelectedRoiCommand = CreateCommand(_ => EvaluateSelectedRoiAsync(), _ => !IsBusy && SelectedInspectionRoi != null && SelectedInspectionRoi.Enabled);
@@ -648,78 +647,6 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                 roi.DatasetPath = newPath;
                 _log($"[dataset:align] layout='{layoutName}' roi='{roi.DisplayName}' path='{roi.DatasetPath}'");
-            }
-        }
-
-        private Task BlankDatasetAsync()
-        {
-            BlankDataset();
-            return Task.CompletedTask;
-        }
-
-        private void BlankDataset()
-        {
-            var layoutName = string.IsNullOrWhiteSpace(_currentLayoutName)
-                ? "DefaultLayout"
-                : _currentLayoutName;
-
-            string datasetRoot;
-            try
-            {
-                datasetRoot = RecipePathHelper.GetDatasetFolder(layoutName);
-            }
-            catch (Exception ex)
-            {
-                _log($"[dataset] blank: failed to resolve dataset folder for layout '{layoutName}': {ex.Message}");
-                return;
-            }
-
-            foreach (var roi in InspectionRois ?? Enumerable.Empty<InspectionRoiConfig>())
-            {
-                if (roi == null)
-                {
-                    continue;
-                }
-
-                var roiFolder = MapRoiIdToFolder(roi.ModelKey);
-                var roiPath = Path.Combine(datasetRoot, roiFolder);
-
-                DeleteFilesIn(Path.Combine(roiPath, "ok"));
-                DeleteFilesIn(Path.Combine(roiPath, "ng"));
-                DeleteFilesIn(Path.Combine(roiPath, "Model"));
-            }
-
-            _log?.Invoke($"[dataset] Cleared dataset for layout '{layoutName}'");
-
-            foreach (var roi in InspectionRois ?? Enumerable.Empty<InspectionRoiConfig>())
-            {
-                if (roi == null)
-                {
-                    continue;
-                }
-
-                _ = RefreshRoiDatasetStateAsync(roi);
-                _ = RefreshDatasetPreviewsForRoiAsync(roi);
-            }
-        }
-
-        private static void DeleteFilesIn(string dir)
-        {
-            if (!Directory.Exists(dir))
-            {
-                return;
-            }
-
-            foreach (var file in Directory.GetFiles(dir))
-            {
-                try
-                {
-                    File.Delete(file);
-                }
-                catch
-                {
-                    // ignore individual file delete errors
-                }
             }
         }
 
@@ -2605,7 +2532,6 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         public AsyncCommand RefreshDatasetCommand { get; }
         public AsyncCommand RefreshHealthCommand { get; }
         public AsyncCommand BrowseDatasetCommand { get; }
-        public AsyncCommand BlankDatasetCommand { get; }
         public AsyncCommand TrainSelectedRoiCommand { get; }
         public AsyncCommand CalibrateSelectedRoiCommand { get; }
         public AsyncCommand EvaluateSelectedRoiCommand { get; }


### PR DESCRIPTION
### Motivation
- Remove the "+" (Blank dataset) control from the Layout setup panel to avoid accidental dataset clearing and simplify the UI.
- Remove the associated ViewModel logic and helper functions since the UI entry point is no longer present.
- Keep other layout and dataset workflows intact and avoid introducing dangling bindings or API changes.

### Description
- Deleted the Blank dataset button from `MainWindow.xaml` (Layout setup WrapPanel) so the UI no longer exposes the "+" action.
- Removed `BlankDatasetCommand`, `BlankDatasetAsync`, `BlankDataset`, and the `DeleteFilesIn` helper from `WorkflowViewModel.cs` and cleaned up the related public command declaration.
- Updated command initialization to avoid referencing the removed command so there are no leftover bindings or unused members.

### Testing
- No automated tests were executed for this change.
- This change is UI/ViewModel-only; a full build and UI smoke test are recommended to validate there are no runtime binding errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695aefe66a7c832ea559b1015b698958)