### PR TITLE
Layout panel buttons: match panel background and show grey hover shadow

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -67,6 +67,48 @@
         </Style>
         <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource AppButtonStyle}" />
 
+        <Style x:Key="LayoutPanelButtonStyle"
+               TargetType="{x:Type ui:Button}"
+               BasedOn="{StaticResource AppButtonStyle}">
+            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Effect" Value="{x:Null}" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Effect">
+                        <Setter.Value>
+                            <DropShadowEffect BlurRadius="12"
+                                              ShadowDepth="0"
+                                              Opacity="0.35"
+                                              Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" />
+                        </Setter.Value>
+                    </Setter>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="LayoutIconTextButtonStyle"
+               TargetType="{x:Type ui:Button}"
+               BasedOn="{StaticResource IconTextButtonStyle}">
+            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Effect" Value="{x:Null}" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Effect">
+                        <Setter.Value>
+                            <DropShadowEffect BlurRadius="12"
+                                              ShadowDepth="0"
+                                              Opacity="0.35"
+                                              Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" />
+                        </Setter.Value>
+                    </Setter>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
         <Style TargetType="TextBox">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ControlText}" />
@@ -470,24 +512,28 @@
                        Visibility="Collapsed"/>
 
             <ScrollViewer x:Name="LayoutSetupPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" d:Visibility="Visible">
+                <ScrollViewer.Resources>
+                    <Style TargetType="{x:Type ui:Button}"
+                           BasedOn="{StaticResource LayoutPanelButtonStyle}" />
+                </ScrollViewer.Resources>
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
                         <ui:Button x:Name="BtnLoadImage"
-                                   Style="{StaticResource IconTextButtonStyle}"
+                                   Style="{StaticResource LayoutIconTextButtonStyle}"
                                    MinWidth="140"
                                    ToolTip="{DynamicResource LoadPictureTooltip}"
                                    Tag="{x:Static ui:SymbolRegular.Image24}"
                                    Content="{DynamicResource LoadImage}"
                                    Click="BtnLoadImage_Click" />
                         <ui:Button x:Name="BtnLoadLayout"
-                                   Style="{StaticResource IconTextButtonStyle}"
+                                   Style="{StaticResource LayoutIconTextButtonStyle}"
                                    MinWidth="140"
                                    ToolTip="{DynamicResource LoadLayoutTooltip}"
                                    Tag="{x:Static ui:SymbolRegular.Folder24}"
                                    Content="{DynamicResource LoadLayout}"
                                    Click="BtnLoadLayout_Click" />
                         <ui:Button x:Name="BtnSaveLayout"
-                                   Style="{StaticResource IconTextButtonStyle}"
+                                   Style="{StaticResource LayoutIconTextButtonStyle}"
                                    MinWidth="140"
                                    ToolTip="{DynamicResource SaveLayoutTooltip}"
                                    Tag="{x:Static ui:SymbolRegular.Save24}"


### PR DESCRIPTION
### Motivation
- Make all buttons inside the Layout Setup panel visually blend with the panel background and remove the blue accent on hover.
- Keep existing Fluent templates, bindings, commands and click handlers by creating styles `BasedOn` the app/icon styles instead of changing templates.
- Limit the scope of the style change to the Layout Setup panel so other panels retain the current hover accent.

### Description
- Added two new styles in `MainWindow.xaml`: `LayoutPanelButtonStyle` (BasedOn `AppButtonStyle`) and `LayoutIconTextButtonStyle` (BasedOn `IconTextButtonStyle`) that set `Background` to `BrushAppBackground` and use a grey `DropShadowEffect` on hover.
- Scoped the layout-specific style to the `ScrollViewer` named `LayoutSetupPanel` by adding a local `ScrollViewer.Resources` entry that makes the implicit `ui:Button` style `BasedOn` `LayoutPanelButtonStyle`.
- Updated the three top action buttons `BtnLoadImage`, `BtnLoadLayout`, and `BtnSaveLayout` to use `LayoutIconTextButtonStyle` so their IconText template is preserved while adopting the new background/hover effect.
- Only `MainWindow.xaml` was modified and all existing `Click`, `Command`, `Content`, `Tag`, and bindings were left unchanged.

### Testing
- No automated tests were executed because this is a UI-only XAML style change.
- Verified the change was limited to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` and committed successfully.
- Manual visual validation is recommended by running the application and checking that Layout Setup panel buttons use `BrushAppBackground` and show a grey shadow on hover while other panels keep the blue accent.
- No regressions to non-Layout UI elements were introduced by the change as styles are scoped locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695af2d35a74832ea2e1d4d91d68a4de)