### PR TITLE
Añadir logo en la navegación izquierda encima de `Layout Setup`

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1656,6 +1656,13 @@
             BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
             Background="{DynamicResource BrushAppBackground}">
             <StackPanel Margin="8">
+                <Image x:Name="NavLogo"
+                       Width="215"
+                       HorizontalAlignment="Center"
+                       Margin="0,12,0,16"
+                       Stretch="Uniform"
+                       SnapsToDevicePixels="True"
+                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
                 <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                            Click="NavLayoutSetup_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">


### PR DESCRIPTION
### Motivation
- Añadir un control de imagen en la columna de navegación izquierda para mostrar el logo de planta encima del botón `Layout Setup`.
- Forzar `Width=215` y mantener la proporción para que el logo tenga tamaño fijo y se ajuste al diseño.
- Aprovechar el `StackPanel` existente para desplazar automáticamente los botones hacia abajo sin alterar su comportamiento.
- No modificar estilos ni handlers de los botones para evitar regresiones en la navegación.

### Description
- Insertada una etiqueta `<Image>` en `MainWindow.xaml` con `x:Name="NavLogo"`, `Width="215"`, `Stretch="Uniform"`, `SnapsToDevicePixels="True"` y `Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png"`.
- La imagen se colocó inmediatamente antes del botón que ejecuta `NavLayoutSetup_Click` dentro del `StackPanel` de la columna izquierda para que el resto de botones se desplacen hacia abajo automáticamente.
- No se modificaron `LeftNavButtonStyle`, bindings, ni handlers de botones existentes; sólo se agregó el control de imagen.
- El recurso `LogoPlanta.png` ya está incluido como `Resource` en `BrakeDiscInspector_GUI_ROI.csproj` (no fue necesario cambiar el `.csproj`).

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c0679077c832eb636aea56889ed7a)