### PR TITLE
Add TextBox under nav logo in left panel

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1656,6 +1656,22 @@
             BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
             Background="{DynamicResource BrushAppBackground}">
             <StackPanel Margin="8">
+                <Image x:Name="NavLogo"
+                       Width="215"
+                       HorizontalAlignment="Center"
+                       Margin="0,12,0,0"
+                       Stretch="Uniform"
+                       SnapsToDevicePixels="True"
+                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
+                <TextBox x:Name="NavLogoTextBox"
+                         Width="215"
+                         HorizontalAlignment="Center"
+                         Margin="0,0,0,16"
+                         Padding="10,6"
+                         TextAlignment="Center"
+                         VerticalContentAlignment="Center"
+                         Text=""
+                         ToolTip=""/>
                 <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                            Click="NavLayoutSetup_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
@@ -2012,12 +2028,5 @@
                 </StackPanel>
             </Border>
         </Grid>
-        <Image x:Name="NavLogo"
-                       Width="216"
-                       HorizontalAlignment="Center"
-                       Margin="0,4,0,24"
-                       Stretch="Uniform"
-                       SnapsToDevicePixels="True"
-                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
     </Grid>
 </Window>


### PR DESCRIPTION
### Motivation
- Add an informational/input `TextBox` immediately below the left navigation logo while preserving the original top-row sizing and layout constraints.
- Ensure the `TextBox` has the same visual width as the logo and keeps the previous spacing before the first nav button.
- Keep all changes confined to the left navigation `StackPanel` so the main `Grid` `RowDefinitions` and heights are not modified.

### Description
- Moved the `Image` named `NavLogo` into the left navigation `StackPanel` and adjusted its properties to `Width="215"` and `Margin="0,12,0,0"` so it leaves no extra gap underneath.
- Inserted a new `TextBox` named `NavLogoTextBox` immediately below the `Image` with `Width="215"`, `Margin="0,0,0,16"`, `Padding="10,6"`, centered alignment, and empty `Text`/`ToolTip`.
- Removed the duplicate/original `NavLogo` instance previously placed at the root grid to avoid duplication.
- No changes were made to the main `Grid` `RowDefinitions`, the top row heights, or the left nav button structure; the `StackPanel` will naturally push buttons down.

### Testing
- No automated tests were executed for this UI-only XAML change.
- Manual build/run was not invoked by the automated rollout steps (UI verification recommended after merging).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c0c52aef0832ea4f854cb0f9aa7af)