### PR TITLE
Move nav logo and textbox into top bar header column

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -159,7 +159,43 @@
         </Grid.ColumnDefinitions>
 
         <!-- ===== Top bar ===== -->
-        <Border Grid.Row="0" Grid.ColumnSpan="4" Padding="16,10" Background="{DynamicResource BrushAppBackground}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,0,0,1">
+        <Border Grid.Row="0"
+                Grid.Column="0"
+                Background="{DynamicResource BrushAppBackground}"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                BorderThickness="0,0,0,1"
+                Padding="0"
+                SnapsToDevicePixels="True">
+            <StackPanel Width="215"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Margin="0"
+                        Orientation="Vertical">
+                <Image x:Name="NavLogo"
+                       Width="215"
+                       Height="22"
+                       Margin="0"
+                       Stretch="Uniform"
+                       SnapsToDevicePixels="True"
+                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
+                <TextBox x:Name="NavLogoTextBox"
+                         Width="215"
+                         Height="22"
+                         Margin="0"
+                         Padding="10,0"
+                         TextAlignment="Center"
+                         VerticalContentAlignment="Center"
+                         Text="" />
+            </StackPanel>
+        </Border>
+        <Border x:Name="TopBarRightBorder"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.ColumnSpan="3"
+                Padding="16,10"
+                Background="{DynamicResource BrushAppBackground}"
+                BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                BorderThickness="0,0,0,1">
             <DockPanel Margin="221,0,0,-1">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left"/>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
@@ -1653,25 +1689,9 @@
             </ScrollViewer>
         </Grid>
         <Border Grid.Row="1" Grid.Column="0"
-            BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
-            Background="{DynamicResource BrushAppBackground}">
+                BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
+                Background="{DynamicResource BrushAppBackground}">
             <StackPanel Margin="8">
-                <Image x:Name="NavLogo"
-                       Width="215"
-                       HorizontalAlignment="Center"
-                       Margin="0,12,0,0"
-                       Stretch="Uniform"
-                       SnapsToDevicePixels="True"
-                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
-                <TextBox x:Name="NavLogoTextBox"
-                         Width="215"
-                         HorizontalAlignment="Center"
-                         Margin="0,0,0,16"
-                         Padding="10,6"
-                         TextAlignment="Center"
-                         VerticalContentAlignment="Center"
-                         Text=""
-                         ToolTip=""/>
                 <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                            Click="NavLayoutSetup_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">


### PR DESCRIPTION
### Motivation
- Place the navigation logo and its TextBox into the header row (`Grid.Row="0"`) aligned with the navigation column (`Grid.Column="0"`) so they are not inside the left button panel.
- Keep the header row height unchanged while keeping the logo/TextBox width at `Width="215"` and vertically adjacent (no vertical margin).
- Avoid changing `RowDefinitions` by splitting the existing full-width header `Border` so the right side continues to determine the row height.

### Description
- Split the original top `Border` (`Grid.Row="0" Grid.ColumnSpan="4"`) into two borders: a left header `Border` at `Grid.Row="0" Grid.Column="0"` with `Padding="0"` hosting a `StackPanel` that contains `Image x:Name="NavLogo"` and `TextBox x:Name="NavLogoTextBox"`, both set to `Width="215"` and `Height="22"` with zero vertical margin.
- Changed the original header `Border` into `TopBarRightBorder` at `Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3"` and kept its `Padding="16,10"` so it continues to determine the header height.
- Removed the duplicated `NavLogo` and `NavLogoTextBox` elements from the left navigation panel (`Grid.Row="1" Grid.Column="0"`) so only the new header instances remain.
- Edited `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to implement the layout changes and added `SnapsToDevicePixels="True"` and minimal padding on the left header to ensure the logo and textbox remain visually tight.

### Testing
- No automated tests were executed for this change because it is a UI layout modification only.
- The change was limited to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` and committed; no compile/run verification was performed as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c13b7ffb4832e880303015a254e0f)