### PR TITLE
Resolve MainWindow.xaml merge conflicts; restore top bar/nav layout and fix typos

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -158,7 +158,6 @@
         </Grid.ColumnDefinitions>
 
         <!-- ===== Top bar ===== -->
-<<<<<<< HEAD
         <Border Grid.Row="0"
                 Grid.Column="0"
                 Background="{DynamicResource BrushAppBackground}"
@@ -188,6 +187,7 @@
                          Text="" />
             </StackPanel>
         </Border>
+
         <Border x:Name="TopBarRightBorder"
                 Grid.Row="0"
                 Grid.Column="1"
@@ -196,10 +196,7 @@
                 Background="{DynamicResource BrushAppBackground}"
                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
                 BorderThickness="0,0,0,1">
-=======
-        <Border Grid.Row="0" Grid.ColumnSpan="4" Padding="16,10" Background="{DynamicResource BrushAppBackground}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,0,0,1" Margin="0,0,0,577">
->>>>>>> 12701d8 (Update MainWindow.xaml)
-            <DockPanel Margin="221,0,0,-1">
+            <DockPanel Margin="0,0,0,-1">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left"/>
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
                     <ui:Button x:Name="SetupGuiButton"
@@ -853,7 +850,7 @@
                                         </StackPanel>
 
                                         <StackPanel Orientation="Horizontal" Margin="0,4,0,0" Width="221" HorizontalAlignment="Left">
-                                            <TextBlock Text="Thershold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
+                                            <TextBlock Text="Threshold" VerticalAlignment="Center" Margin="0,0,1,0" Width="63"/>
                                             <TextBox x:Name="TxtThrM2" Width="128"
                                                      Text="{Binding AnalyzeThrM2, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Height="37"/>
                                         </StackPanel>
@@ -1691,15 +1688,11 @@
                 </Grid>
             </ScrollViewer>
         </Grid>
-<<<<<<< HEAD
-        <Border Grid.Row="1" Grid.Column="0"
-                BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
-                Background="{DynamicResource BrushAppBackground}">
-=======
         <Border Grid.Column="0"
-            BorderBrush="#D0D0D0" BorderThickness="0,0,1,0"
-            Background="{DynamicResource BrushAppBackground}" Margin="0,80,0,0">
->>>>>>> 12701d8 (Update MainWindow.xaml)
+                BorderBrush="#D0D0D0"
+                BorderThickness="0,0,1,0"
+                Background="{DynamicResource BrushAppBackground}"
+                Margin="0,80,0,0">
             <StackPanel Margin="8">
                 <ui:Button Style="{StaticResource LeftNavButtonStyle}"
                            Click="NavLayoutSetup_Click">
@@ -1712,7 +1705,7 @@
                            Click="NavRoiManagement_Click">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}" FontSize="18" Margin="0,0,10,0"/>
-                        <TextBlock Text="ROIs Management" VerticalAlignment="Center"/>
+                        <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
                 <!-- Submenú colapsable: mismo tamaño/estilo que el resto, con tabulación -->


### PR DESCRIPTION
### Motivation
- Remove leftover Git merge conflict markers that break the XAML parser and cause hundreds of designer/build errors in `MainWindow.xaml`. 
- Restore an intended top bar layout split (left logo+textbox, right top buttons) so the top controls are not shifted. 
- Keep the left navigation panel positioned below the top bar by preserving the top margin. 
- Fix two visible text typos in the UI labels.

### Description
- Deleted all merge markers and replaced the conflicted top-bar section in `MainWindow.xaml` with the merged container structure (left logo `Border` + right `TopBarRightBorder`) and changed the `DockPanel` margin to `0,0,0,-1`.
- Replaced the left navigation `Border` start to use `Grid.Column="0"` and `Margin="0,80,0,0"` so the nav starts below the top bar and follows the layout pattern.
- Corrected the two text typos: `"ROIs Management"` → `"ROI Management"` and `"Thershold"` → `"Threshold"`.
- Committed the change to `MainWindow.xaml` after verifying the file no longer contains conflict markers.

### Testing
- Verified no remaining conflict markers with `rg -n "<<<<<<<|=======|>>>>>>>" gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`, which returned no matches (succeeded).
- Attempted to run `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, but the command failed because `dotnet` is not installed in the current environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c18025be4832e83f7864b8b41098c)