### PR TITLE
Restore viewer overlay buttons for Setup GUI and theme (Light/Dark)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -198,31 +198,7 @@
                 BorderThickness="0,0,0,1">
             <DockPanel Margin="0,0,0,-1">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left"/>
-                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right">
-                    <ui:Button x:Name="SetupGuiButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="SetupGuiButton_Click"
-                               Margin="0,0,8,0"
-                               ToolTip="Open GUI setup" HorizontalAlignment="Right" VerticalAlignment="Center">
-                        <StackPanel Orientation="Horizontal">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" Margin="0,0,6,0" FontSize="16"/>
-                            <TextBlock Text="Setup GUI" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </ui:Button>
-                    <ui:Button x:Name="ThemeLightButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="ThemeLightButton_Click"
-                               Margin="0,0,6,0"
-                               ToolTip="Light theme" HorizontalAlignment="Right" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherSunny24}" FontSize="18"/>
-                    </ui:Button>
-                    <ui:Button x:Name="ThemeDarkButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="ThemeDarkButton_Click"
-                               ToolTip="Dark theme" HorizontalAlignment="Right" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
-                    </ui:Button>
-                </StackPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" VerticalAlignment="Center" HorizontalAlignment="Right"/>
             </DockPanel>
         </Border>
 
@@ -1777,6 +1753,47 @@
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
+
+                <!-- ===== Top-right overlay buttons (over the viewer canvas) ===== -->
+                <StackPanel x:Name="ViewerTopRightButtons"
+                            Grid.Row="1"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Margin="0,8,12,0"
+                            Panel.ZIndex="1200">
+                    <ui:Button x:Name="SetupGuiButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="SetupGuiButton_Click"
+                               Margin="0,0,8,0"
+                               ToolTip="Open GUI setup"
+                               HorizontalAlignment="Right"
+                               VerticalAlignment="Center">
+                        <StackPanel Orientation="Horizontal">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" Margin="0,0,6,0" FontSize="16"/>
+                            <TextBlock Text="Setup GUI" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ui:Button>
+
+                    <ui:Button x:Name="ThemeLightButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeLightButton_Click"
+                               Margin="0,0,6,0"
+                               ToolTip="Light theme"
+                               HorizontalAlignment="Right"
+                               VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherSunny24}" FontSize="18"/>
+                    </ui:Button>
+
+                    <ui:Button x:Name="ThemeDarkButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeDarkButton_Click"
+                               ToolTip="Dark theme"
+                               HorizontalAlignment="Right"
+                               VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
+                    </ui:Button>
+                </StackPanel>
 
                 <AdornerDecorator Grid.Row="1" Margin="0,8,0,0">
                     <Grid Background="#111">


### PR DESCRIPTION
### Motivation
- The Setup GUI and theme buttons had been removed from the viewer overlay and were remaining only in the top bar, causing either disappearance or x:Name duplicates; they must be visible over the canvas.
- Buttons must keep their existing `x:Name`, `Click` handlers and `AppButtonStyle` so existing popups and handlers wire up without changes.
- The buttons should appear in the top-right corner above the viewer/canvas (not in the top bar).
- Avoid duplicating named controls to prevent XAML name collisions and broken `PlacementTarget` bindings.

### Description
- Removed the `SetupGuiButton`, `ThemeLightButton` and `ThemeDarkButton` controls from the top bar to eliminate duplicate `x:Name` definitions.
- Added a new overlay `StackPanel` named `ViewerTopRightButtons` inside the `ViewerHost` grid with `Grid.Row="1"`, `HorizontalAlignment="Right"`, `VerticalAlignment="Top"`, and `Panel.ZIndex="1200"` so the buttons sit on top of `ImgMain`/`CanvasROI`.
- Reintroduced the three buttons with the original `x:Name` values, `Style="{StaticResource AppButtonStyle}"` and their original `Click` handlers (`SetupGuiButton_Click`, `ThemeLightButton_Click`, `ThemeDarkButton_Click`).
- Preserved `GuiSetupPopup` which still binds `PlacementTarget="{Binding ElementName=SetupGuiButton}"`, so the popup continues to function after the button was moved.

### Testing
- No automated tests were executed for this change (UI-only XAML modification).
- Manual runtime validation was suggested (compile and run) but not performed by the automated pipeline.
- XAML build / runtime verification remains recommended to confirm overlay placement and that `GuiSetupPopup` opens and theme handlers run.
- Commit was created after the change and pushed to the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c1a665f80832ebc5511811f5ea1ba)