### PR TITLE
Move header setup/theme buttons to top-left and restore logo

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -164,28 +164,76 @@
                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
                 BorderThickness="0,0,0,1"
                 Padding="0"
-                SnapsToDevicePixels="True">
-            <StackPanel Width="215"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Margin="0"
-                        Orientation="Vertical">
-                <Image x:Name="NavLogo"
-                       Width="215"
-                       Height="22"
-                       Margin="0"
-                       Stretch="Uniform"
-                       SnapsToDevicePixels="True"
-                       Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
-                <TextBox x:Name="NavLogoTextBox"
-                         Width="215"
-                         Height="22"
-                         Margin="0"
-                         Padding="10,0"
-                         TextAlignment="Center"
-                         VerticalContentAlignment="Center"
-                         Text="" />
-            </StackPanel>
+                SnapsToDevicePixels="True"
+                VerticalAlignment="Top">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <!-- Botones (esquina superior izquierda) -->
+                <StackPanel Grid.Row="0"
+                            Orientation="Horizontal"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            Margin="8,8,0,0"
+                            Panel.ZIndex="5">
+
+                    <ui:Button x:Name="SetupGuiButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="SetupGuiButton_Click"
+                               Margin="0,0,8,0"
+                               ToolTip="Open GUI setup">
+                        <StackPanel Orientation="Horizontal">
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" Margin="0,0,6,0" FontSize="16"/>
+                            <TextBlock Text="Setup GUI" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </ui:Button>
+
+                    <ui:Button x:Name="ThemeLightButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeLightButton_Click"
+                               Margin="0,0,6,0"
+                               ToolTip="Light theme">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherSunny24}" FontSize="18"/>
+                    </ui:Button>
+
+                    <ui:Button x:Name="ThemeDarkButton"
+                               Style="{StaticResource AppButtonStyle}"
+                               Click="ThemeDarkButton_Click"
+                               ToolTip="Dark theme">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
+                    </ui:Button>
+                </StackPanel>
+
+                <!-- Logo recuperado (centrado bajo los botones, mismo ancho 215) -->
+                <StackPanel Grid.Row="1"
+                            Width="215"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Top"
+                            Margin="0,6,0,0"
+                            Orientation="Vertical">
+
+                    <Image x:Name="NavLogo"
+                           Width="215"
+                           Height="22"
+                           Margin="0"
+                           Stretch="Uniform"
+                           SnapsToDevicePixels="True"
+                           Source="pack://application:,,,/BrakeDiscInspector_GUI_ROI;component/LogoPlanta.png" />
+
+                    <TextBox x:Name="NavLogoTextBox"
+                             Width="215"
+                             Height="22"
+                             Margin="0"
+                             Padding="10,0"
+                             TextAlignment="Center"
+                             VerticalContentAlignment="Center"
+                             Text="" />
+                </StackPanel>
+
+            </Grid>
         </Border>
 
         <Border x:Name="TopBarRightBorder"
@@ -1753,47 +1801,6 @@
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-
-                <!-- ===== Top-right overlay buttons (over the viewer canvas) ===== -->
-                <StackPanel x:Name="ViewerTopRightButtons"
-                            Grid.Row="1"
-                            Orientation="Horizontal"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Top"
-                            Margin="0,8,12,0"
-                            Panel.ZIndex="1200">
-                    <ui:Button x:Name="SetupGuiButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="SetupGuiButton_Click"
-                               Margin="0,0,8,0"
-                               ToolTip="Open GUI setup"
-                               HorizontalAlignment="Right"
-                               VerticalAlignment="Center">
-                        <StackPanel Orientation="Horizontal">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" Margin="0,0,6,0" FontSize="16"/>
-                            <TextBlock Text="Setup GUI" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </ui:Button>
-
-                    <ui:Button x:Name="ThemeLightButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="ThemeLightButton_Click"
-                               Margin="0,0,6,0"
-                               ToolTip="Light theme"
-                               HorizontalAlignment="Right"
-                               VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherSunny24}" FontSize="18"/>
-                    </ui:Button>
-
-                    <ui:Button x:Name="ThemeDarkButton"
-                               Style="{StaticResource AppButtonStyle}"
-                               Click="ThemeDarkButton_Click"
-                               ToolTip="Dark theme"
-                               HorizontalAlignment="Right"
-                               VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
-                    </ui:Button>
-                </StackPanel>
 
                 <AdornerDecorator Grid.Row="1" Margin="0,8,0,0">
                     <Grid Background="#111">


### PR DESCRIPTION
### Motivation
- Place the `SetupGuiButton`, `ThemeLightButton` and `ThemeDarkButton` outside the viewer canvas and into the application header so they appear in the top-left corner (Grid.Row="0", Grid.Column="0").
- Remove overlay duplicates that were placed inside the `ViewerHost` to avoid multiple `x:Name` definitions and naming conflicts.
- Recover the header logo `NavLogo` and keep the original `NavLogoTextBox` layout under the buttons.
- Preserve existing handlers and bindings such as `SetupGuiButton_Click` and the `GuiSetupPopup` `PlacementTarget` which references `SetupGuiButton`.

### Description
- Replaced the left header `Border` content with a two-row `Grid` that places the three buttons in a left-aligned `StackPanel` on the first row and the `NavLogo` + `NavLogoTextBox` centered in the second row.
- Removed the top-right viewer overlay `StackPanel` named `ViewerTopRightButtons` which previously contained `SetupGuiButton`, `ThemeLightButton`, and `ThemeDarkButton` to eliminate duplicate `x:Name` definitions.
- Kept the same `x:Name` values and `Click` handlers (`SetupGuiButton_Click`, `ThemeLightButton_Click`, `ThemeDarkButton_Click`) and preserved the `AppButtonStyle` usage.
- Ensured the header `Border` uses `VerticalAlignment="Top"` so it does not stretch when the header row is taller than expected.

### Testing
- No automated tests were executed for this UI-only XAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c26941c6c832eb3384837db3d826f)