### PR TITLE
Default Side Panel to ROI Management → Master ROIs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -563,7 +563,11 @@
                        Margin="8,8,8,4"
                        Visibility="Collapsed"/>
 
-            <ScrollViewer x:Name="LayoutSetupPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" d:Visibility="Visible">
+            <ScrollViewer x:Name="LayoutSetupPanel"
+                          Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          Visibility="Collapsed"
+                          d:Visibility="Collapsed">
                 <ScrollViewer.Resources>
                     <Style TargetType="{x:Type ui:Button}"
                            BasedOn="{StaticResource LayoutPanelButtonStyle}" />
@@ -646,7 +650,11 @@
                 </StackPanel>
             </ScrollViewer>
 
-            <ScrollViewer x:Name="RoiManagementPanel" Grid.Row="1" VerticalScrollBarVisibility="Auto" Visibility="Collapsed" d:Visibility="Collapsed">
+            <ScrollViewer x:Name="RoiManagementPanel"
+                          Grid.Row="1"
+                          VerticalScrollBarVisibility="Auto"
+                          Visibility="Visible"
+                          d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel x:Name="RoiManagementSelector"
                                 Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -146,7 +146,7 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         private int _freezeRoiRepositionCounter;
-        private RoiPanelMode _roiPanelMode = RoiPanelMode.Selector;
+        private RoiPanelMode _roiPanelMode = RoiPanelMode.Master;
         private bool _pendingActiveInspectionSync;
         private bool _globalUnlocked = false;
         private bool _editingM1;
@@ -3460,7 +3460,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 CaptureDefaultGuiResources();
                 InitializeGuiSetupPanel();
 
-                ShowSidePanel(SidePanelMode.LayoutSetup);
+                ShowSidePanel(SidePanelMode.RoiManagement);
+                RoiPanelMode = RoiPanelMode.Master;
 
                 ConfigureCommandBindings();
                 ApplySavedUiPreferences();


### PR DESCRIPTION
### Motivation
- Make the ROI Management → Master ROIs panel the visible default when opening `MainWindow.xaml` both at runtime and in the XAML designer.
- Ensure the Layout panel is hidden by default so users see Master ROI controls immediately.
- Preserve existing navigation behavior so left menu buttons still switch panels.
- Avoid duplicating XAML properties and keep the UI valid for designer previews.

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to set `LayoutSetupPanel` `Visibility`/`d:Visibility` to `Collapsed` and `RoiManagementPanel` `Visibility`/`d:Visibility` to `Visible` so the designer and runtime show ROI Management by default.
- Changed the initial backing field value for `RoiPanelMode` from `Selector` to `Master` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` so the Master subpanel is selected on startup.
- Switched the constructor to call `ShowSidePanel(SidePanelMode.RoiManagement)` and set `RoiPanelMode = RoiPanelMode.Master` to avoid later overrides and ensure runtime startup matches the designer preview.
- Kept existing navigation handlers untouched so all menu buttons continue to switch panels as before.

### Testing
- No automated tests were run against these changes.
- Manual runtime/designer verification is recommended to confirm the `ROI Master` controls are visible on startup and the `Layout` panel remains collapsed until selected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e0deee590832e8f5b031ac381d195)