### PR TITLE
Add backend online indicator to status bar

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -2133,7 +2133,33 @@
 
                 <StackPanel Orientation="Horizontal" Grid.Column="0" VerticalAlignment="Center">
                     <TextBlock Text="{DynamicResource StatusBackend}" FontWeight="SemiBold" />
-                    <TextBlock Text="{Binding DataContext.HealthSummary, ElementName=WorkflowHost}" Margin="6,0,0,0" />
+                    <Ellipse Width="10"
+                             Height="10"
+                             Margin="6,0,0,0"
+                             VerticalAlignment="Center"
+                             Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                             StrokeThickness="1"
+                             Fill="{Binding DataContext.IsBackendOnline, ElementName=WorkflowHost, Converter={StaticResource BoolToBrush}}" />
+                    <TextBlock Margin="6,0,0,0"
+                               VerticalAlignment="Center"
+                               FontWeight="SemiBold"
+                               Foreground="{Binding DataContext.IsBackendOnline, ElementName=WorkflowHost, Converter={StaticResource BoolToBrush}}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="offline" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding DataContext.IsBackendOnline, ElementName=WorkflowHost}" Value="True">
+                                        <Setter Property="Text" Value="online" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding DataContext.IsBackendOnline, ElementName=WorkflowHost}" Value="{x:Null}">
+                                        <Setter Property="Text" Value="--" />
+                                        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock Text="{Binding DataContext.HealthSummary, ElementName=WorkflowHost}" Margin="8,0,0,0" />
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Grid.Column="1" VerticalAlignment="Center">


### PR DESCRIPTION
### Motivation
- Provide a clear visual indicator in the status bar for backend connectivity (online / offline / unknown).
- Surface the backend state to the UI while preserving the existing `HealthSummary` text and layout.
- Reuse the existing `BoolToBrushConverter` for LED/text coloring to keep the current WPF-UI theme.
- Avoid breaking existing bindings and keep network health checks async and non-blocking.

### Description
- Expose a nullable backend state property `IsBackendOnline` (`bool?`) on `WorkflowViewModel` with a backing field and a `SetProperty` helper for change notification.
- Update `RefreshHealthAsync` to set `IsBackendOnline = true` when `_client.GetHealthAsync()` returns a non-null result, and `IsBackendOnline = false` when it returns null or throws an exception.
- Add a small LED (`Ellipse`) and an `online`/`offline`/`--` `TextBlock` in `MainWindow.xaml`, bound to `DataContext.IsBackendOnline` via the existing `BoolToBrush` converter, placed next to the `StatusBackend` label and preserving `HealthSummary`.
- Keep all previous bindings and behavior intact (no changes to existing commands or `HealthSummary` population logic).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695fa983c7f4832ea9ff8a181074aa9b)