### PR TITLE
Docs: Update dataset mapping and backend storage to recipe/model_key layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ BrakeDiscInspector is a two-part inspection cell: a WPF front-end (`gui/BrakeDis
 ## What the system does
 - **Manual inspection:** `WorkflowViewModel` exports a *canonical ROI* from the currently loaded image via `RoiCropUtils` and sends it to the backend using `BackendClient.InferAsync`. Heatmaps and regions are re-projected on top of the canvas (`MainWindow.xaml.cs`). Analyze options (rotation range, scale min/max, matcher thresholds) stay in sync between the active layout and the preset UI so manual runs reuse the same search parameters that were stored with the layout.
 - **Batch inspection:** the view-model iterates over every image under the selected folder, repositions each inspection ROI according to its chosen anchor (`InspectionRoiConfig.AnchorMaster`) with `InspectionAlignmentHelper.MoveInspectionTo` and the detected Master 1/2 centers, exports each ROI and evaluates it asynchronously while tracking per-row status (`BatchRow`, `BatchCellStatus`).
-- **Dataset management:** every layout name acts as a *recipe* rooted at `<exe>/Recipes/<LayoutName>/`. `EnsureInspectionDatasetStructure` creates `Dataset/Inspection_<n>/{ok,ng}` plus a `Model/Inspection_<n>` folder per slot, while `DatasetManager` saves each ROI crop and metadata JSON under `Dataset/datasets/<roi_id>/<ok|ng>/`. Obsolete masters/models are moved to `obsolete/` alongside the current files. The **Clear canvas** action now wipes masters, inspection slots, cached baselines and disables all inspection ROIs so the next edits start from a clean recipe without lingering inspection geometry.
+- **Dataset management:** every layout name acts as a *recipe* rooted at `<exe>/Recipes/<LayoutName>/`. `EnsureInspectionDatasetStructure` creates `Dataset/Inspection_<n>/{ok,ng}` plus a per-slot `Dataset/Inspection_<n>/Model/` folder. `DatasetManager` writes each ROI crop and metadata JSON into the recipe dataset folder, mapping `inspection-1..4` to `Inspection_1..4` directories (non-inspection ROIs fall back to their ROI id). Obsolete masters/models are moved to `obsolete/` alongside the current files. The **Clear canvas** action now wipes masters, inspection slots, cached baselines and disables all inspection ROIs so the next edits start from a clean recipe without lingering inspection geometry.
 - **Backend inference:** `backend/app.py` exposes `GET /health`, `POST /fit_ok`, `POST /calibrate_ng`, `POST /infer` plus `/manifest` and dataset helper routes. Images are decoded with OpenCV, features are extracted with `DinoV2Features`, PatchCore coreset is persisted through `ModelStore`, and responses include `request_id`/`recipe_id` for correlation along with `{score, threshold?, token_shape, heatmap_png_base64?, regions[]}`. `BackendClient` always sends `role_id`, `roi_id`, `mm_per_px` and the ROI mask (`shape` JSON) so the backend evaluates the same canonical crop that the GUI rendered.
 
 ## Quick start
@@ -26,11 +26,11 @@ Environment variables such as `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODEL
 ### Launch the GUI
 1. Open `gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` in Visual Studio.
 2. Ensure `appsettings.json` or environment variables define `Backend.BaseUrl` if you are not using `http://127.0.0.1:8000`.
-3. Run the app. On first launch it creates `<exe folder>/Recipes/<LayoutName>/` (defaults to `DefaultLayout`), with `Dataset/Inspection_1..4/{ok,ng}` for samples and `Model/Inspection_1..4/` for backend artefacts.
+3. Run the app. On first launch it creates `<exe folder>/Recipes/<LayoutName>/` (defaults to `DefaultLayout`), with `Dataset/Inspection_1..4/{ok,ng}` for samples and `Dataset/Inspection_1..4/Model/` for backend artefacts.
 
 ### Minimal end-to-end run
 1. Load a demo image, draw Master 1/2 anchors and one inspection ROI, then freeze it.
-2. Press **Add to OK** to persist a PNG plus metadata JSON under `Recipes/<LayoutName>/Dataset/datasets/<roi_id>/ok` (`DatasetManager.SaveSampleAsync`).
+2. Press **Add to OK** to persist a PNG plus metadata JSON under `Recipes/<LayoutName>/Dataset/Inspection_<n>/ok` (for inspection slots) or `Recipes/<LayoutName>/Dataset/<roi_id>/ok` (for non-inspection ROIs) (`DatasetManager.SaveSampleAsync`).
 3. Use **Train memory fit** (calls `/fit_ok`) and **Calibrate** (calls `/calibrate_ng`).
 4. Run **Evaluate** for manual inspection or select a batch folder and press **Start Batch** to analyze many files; the view refreshes per-row heatmaps while anchoring ROI positions from the masters.
 

--- a/agents.md
+++ b/agents.md
@@ -78,8 +78,8 @@ If any folder names differ, agents must **detect** and **adapt** paths without c
 
 ### Agent C — **Data Curator**
 - Organize datasets per `(role_id, roi_id)`:
-  - `datasets/<role>/<roi>/ok/*.png` (+ metadata JSON)
-  - `datasets/<role>/<roi>/ng/*.png` (+ metadata JSON)
+  - GUI recipes: `Recipes/<LayoutName>/Dataset/Inspection_<n>/ok|ng` for inspection slots (`inspection-1..4`) or `Recipes/<LayoutName>/Dataset/<roi_id>/ok|ng` for other ROIs.
+  - Backend helpers (`/datasets/*`): `BDI_MODELS_DIR/datasets/<role>/<roi>/ok|ng`.
 
 ### Agent D — **QA/Validation**
 - Build & run tests to verify no regressions in ROI placement, scaling, or overlay alignment.
@@ -131,7 +131,7 @@ If any folder names differ, agents must **detect** and **adapt** paths without c
     - “Remove Selected”, “Open Dataset Folder”
 - On add:
   1. **Canonicalize** ROI via existing pipeline (crop + rotation).
-  2. Save PNG → `datasets/<role>/<roi>/<ok|ng>/SAMPLE_yyyyMMdd_HHmmssfff.png`
+  2. Save PNG → `Recipes/<LayoutName>/Dataset/Inspection_<n>/<ok|ng>/SAMPLE_yyyyMMdd_HHmmssfff.png` for inspection slots (or `Recipes/<LayoutName>/Dataset/<roi_id>/<ok|ng>/` for other ROIs).
   3. Save metadata JSON (same base name):
      ```json
      {
@@ -282,7 +282,7 @@ uvicorn backend.app:app --reload
   - `POST /calibrate_ng` → JSON con `ok_scores`, `ng_scores?`, `score_percentile`, `area_mm2_thr`, opcional `recipe_id`.
   - `POST /infer` → multipart con `image`, `shape` (`rect|circle|annulus`), `mm_per_px`, opcional `recipe_id`, `model_key`.
   - Todas las respuestas incluyen `request_id` y `recipe_id` en el JSON (no headers).
-- **Persistencia**: `datasets/<role>/<roi>/ok|ng` (ModelStore datasets) y `<role>__<roi>.npz` + `<role>__<roi>_calib.json` bajo `BDI_MODELS_DIR`.
+- **Persistencia**: `datasets/<role>/<roi>/ok|ng` (ModelStore datasets) y `recipes/<recipe_id>/<model_key>/<role>__<roi>.npz` + `<role>__<roi>_calib.json` bajo `BDI_MODELS_DIR` (con compatibilidad legacy para rutas antiguas).
 - **Escala física**: `mm_per_px` obligatorio en todas las operaciones.
 - **Shape JSON**: siempre en coordenadas de ROI canónica (post-rotación).
 - **Logging**: correlacionar `request_id` entre GUI y backend.

--- a/backend/agents_for_backend.md
+++ b/backend/agents_for_backend.md
@@ -30,12 +30,13 @@ backend/
 - Estructura:
 ```
 <BDI_MODELS_DIR>/
-  <role>__<roi>.npz            # embeddings + token grid (+metadata)
-  <role>__<roi>_index.faiss    # índice FAISS opcional
-  <role>__<roi>_calib.json     # salida de /calibrate_ng
+  recipes/<recipe_id>/<model_key>/
+    <role>__<roi>.npz          # embeddings + token grid (+metadata)
+    <role>__<roi>_index.faiss  # índice FAISS opcional
+    <role>__<roi>_calib.json   # salida de /calibrate_ng
   datasets/<role>/<roi>/ok|ng  # imágenes de dataset (si se usan los helpers /datasets/*)
 ```
-- `ModelStore.manifest` devuelve memoria, calibración y resumen de datasets.
+- `ModelStore.manifest` devuelve memoria, calibración y resumen de datasets (compatibilidad legacy incluida).
 
 ## 4. Pipeline de inferencia
 1. Validar existencia de memoria y la grilla de tokens.
@@ -49,7 +50,7 @@ backend/
 ## 5. Calibración
 - Si `ng_scores` presente: umbral = punto medio entre `p99_ok` y `p5_ng`.
 - Si solo hay OK: usar percentil (`score_percentile`, por defecto 99).
-- Guardar calibración en `<role>__<roi>_calib.json`.
+- Guardar calibración en `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/<role>__<roi>_calib.json`.
 
 ## 6. Configuración
 - Variables: `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODELS_DIR`, `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`, `BDI_CORS_ORIGINS`.

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -128,7 +128,7 @@ Unknown kinds fall back to a full mask.
 
 ## File-based contracts
 ### Dataset samples (GUI side)
-`DatasetManager.SaveSampleAsync` stores each ROI crop as `PNG` plus a JSON file under `Recipes/<LayoutName>/Dataset/datasets/<roi_id>/<ok|ng>/` with the following schema:
+`DatasetManager.SaveSampleAsync` stores each ROI crop as `PNG` plus a JSON file under the recipe dataset folder. Inspection ROI ids map to `Recipes/<LayoutName>/Dataset/Inspection_<n>/<ok|ng>/`, while non-inspection ROIs use `Recipes/<LayoutName>/Dataset/<roi_id>/<ok|ng>/`. The metadata schema is:
 ```json
 {
   "role_id": "Inspection",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,8 +27,8 @@ This document summarises how the current codebase is wired: which processes exis
 4. Batch heatmaps share the same overlay control; `SetBatchHeatmapForRoi` and `UpdateBatchHeatmapIndex` keep manual and batch canvases aligned while logging placement metadata.
 
 ## Datasets and persistence
-- Each layout name is a recipe stored at `<exe>/Recipes/<LayoutName or DefaultLayout>/`. `EnsureInspectionDatasetStructure` creates `Dataset/Inspection_<slot>/{ok,ng}` folders and `Model/Inspection_<slot>/` to mirror the GUI panels, while `DatasetManager.SaveSampleAsync` writes PNG+JSON samples to `Dataset/datasets/<roi_id>/<ok|ng>/` using the backend-facing ROI identifiers (`inspection-1..4`).
-- The backend stores embeddings as `<role>__<roi>.npz`, optional FAISS indices as `<role>__<roi>_index.faiss` and calibration files `<role>__<roi>_calib.json` below `BDI_MODELS_DIR` (default `models/`).
+- Each layout name is a recipe stored at `<exe>/Recipes/<LayoutName or DefaultLayout>/`. `EnsureInspectionDatasetStructure` creates `Dataset/Inspection_<slot>/{ok,ng}` folders plus a per-slot `Dataset/Inspection_<slot>/Model/` directory. `DatasetManager.SaveSampleAsync` writes PNG+JSON samples into the recipe dataset tree, mapping backend-facing inspection IDs (`inspection-1..4`) to `Inspection_1..4` folder names (non-inspection ROIs use the ROI id directly).
+- The backend stores embeddings, indices and calibration files under `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/` (default `models/`), using urlsafe base64 names for `<role>__<roi>`; legacy flat/legacy directory layouts are still read for backwards compatibility.
 - Batch results can be exported through whatever pipeline consumes the GUI logs; no intermediate CSV is written by the code.
 
 ## Configuration and contracts

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -25,12 +25,13 @@ The backend located in `backend/` exposes the same endpoints implemented in `bac
 ## Persistence layout (`ModelStore`)
 ```
 <BDI_MODELS_DIR>/
-  <role>__<roi>.npz            # embeddings + token grid (+metadata JSON string)
-  <role>__<roi>_index.faiss    # optional FAISS index (if faiss is installed)
-  <role>__<roi>_calib.json     # stored output of /calibrate_ng
+  recipes/<recipe_id>/<model_key>/
+    <role>__<roi>.npz          # embeddings + token grid (+metadata JSON string)
+    <role>__<roi>_index.faiss  # optional FAISS index (if faiss is installed)
+    <role>__<roi>_calib.json   # stored output of /calibrate_ng
   datasets/<role>/<roi>/ok|ng  # if scripts choose to reuse ModelStore for datasets
 ```
-File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_name`), so the exact ids sent by the GUI remain round-trippable even if they contain dashes. Legacy layouts (`models/<role>/<roi>/memory.npz`, etc.) are still read for backward compatibility.
+File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_name`), so the exact ids sent by the GUI remain round-trippable even if they contain dashes. `recipe_id` and `model_key` (defaults to `roi_id`) are sanitized and used to namespace artefacts under `recipes/`. Legacy layouts (`models/<role>/<roi>/memory.npz`, or flat `<role>_<roi>.npz`) are still read for backward compatibility.
 
 ## Endpoint behaviour
 - `GET /health`: returns `{status, device, model, version, request_id, recipe_id}`; device is `cuda` when `torch.cuda.is_available()`. Includes `reason: cuda_not_available` on CPU-only hosts.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -29,9 +29,9 @@ The GUI is implemented in `gui/BrakeDiscInspector_GUI_ROI`. This guide describes
 
 ## Dataset layout
 - Root per layout: `RecipePathHelper` creates `<AppContext.BaseDirectory>/Recipes/<LayoutName or DefaultLayout>/` with `Dataset/`, `Model/` and `Master/` subfolders. `WorkflowViewModel.SetLayoutName` propagates the layout name to `DatasetManager` so every command reads/writes inside that recipe tree.
-- For every inspection slot (1–4) the GUI creates `Dataset/Inspection_<n>/{ok,ng}` for the on-disk dataset plus a `Model/Inspection_<n>/` directory for backend artefacts. Samples shown in the UI come from `Dataset/datasets/<roi_id>/<ok|ng>/` where `roi_id` is the stable identifier used in backend calls (e.g. `inspection-1`).
+- For every inspection slot (1–4) the GUI creates `Dataset/Inspection_<n>/{ok,ng}` for the on-disk dataset plus a `Dataset/Inspection_<n>/Model/` directory for backend artefacts. Samples shown in the UI come from the recipe dataset folder; `inspection-1..4` ROI ids map to `Inspection_1..4` on disk, while non-inspection ROIs use their `roi_id` as the folder name.
 - `DatasetManager.SaveSampleAsync` writes:
-  - PNG file: `SAMPLE_<roleId>_<roiId>_<UTC timestamp>.png` under `Dataset/datasets/<roi_id>/ok` or `Dataset/datasets/<roi_id>/ng` (folder created on demand).
+  - PNG file: `SAMPLE_<roleId>_<roiId>_<UTC timestamp>.png` under `Dataset/Inspection_<n>/ok` or `Dataset/<roi_id>/ok` (folder created on demand; same for `ng`).
   - Metadata JSON (same basename) containing `{role_id, roi_id, mm_per_px, shape_json, source_path, angle, timestamp}`.
 - Dataset validation performed by `RefreshDatasetCommand` walks the current recipe tree; CSV imports remain available but the canonical layout is the recipe folder. Older `<data root>/rois/Inspection_<n>` locations are only kept for backward compatibility paths already present in the layout files.
 

--- a/docs/ROI_AND_HEATMAP_FLOW.md
+++ b/docs/ROI_AND_HEATMAP_FLOW.md
@@ -5,7 +5,7 @@ This document explains how ROIs are defined, exported, aligned and how heatmaps 
 ## ROI identifiers and roles
 - Roles: `Inspection`, `Master1`, `Master2` (`RoiRole` enum). `BackendClient` forwards `role_id` unchanged to the FastAPI routes.
 - ROI ids: inspection slots keep `inspection-1..4` (see `MasterLayout.InspectionRois`), while Master anchors inherit their ids from the layout file. These ids are used in dataset file names (`SAMPLE_<role>_<roi>_*`) and in backend calls, so layout JSON, dataset JSON and recipes must match.
-- Recipes: each layout name resolves to `<exe>/Recipes/<LayoutName or DefaultLayout>/` with `Dataset/`, `Model/` and `Master/` subfolders. Dataset samples live under `Dataset/datasets/<roi_id>/<ok|ng>/` and masters/models are versioned by moving older files into `obsolete/`.
+- Recipes: each layout name resolves to `<exe>/Recipes/<LayoutName or DefaultLayout>/` with `Dataset/` and `Master/` subfolders. Dataset samples live under `Dataset/Inspection_<n>/<ok|ng>/` for inspection slots (mapped from `inspection-1..4`) or `Dataset/<roi_id>/<ok|ng>/` for other ROIs. Masters and ROI exports are versioned by moving older files into `obsolete/`.
 
 ## 1. Canonical ROI export
 1. `WorkflowViewModel` calls `_exportRoiAsync`, which ultimately uses `RoiCropUtils.TryBuildRoiCropInfo` to capture the ROI geometry (`shape`, `Left/Top/Width/Height`, rotation pivot).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,7 +13,7 @@ This checklist is derived from the current GUI/Backend code.
 - **Stale geometry after changing masters:** use **Clear canvas** to wipe masters, inspection slots and cached baselines. The command logs `[align] Reset solicitado/completado` and reinitialises the layout so new anchors do not inherit previous inspection ROIs.
 
 ## Backend-side issues
-- **`400` with "Memoria no encontrada":** `/infer` could not load `<role>__<roi>.npz`. Run `/fit_ok` again via the GUI or copy the expected file into `BDI_MODELS_DIR`.
+- **`400` with "Memoria no encontrada":** `/infer` could not load the model artefact stored under `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/<role>__<roi>.npz`. Run `/fit_ok` again via the GUI or copy the expected file into that folder.
 - **Token grid mismatch:** `/infer` returns `error` mentioning `Token grid mismatch`. The embedding grid stored during `/fit_ok` does not match the new input resolution. Rebuild the memory by running `/fit_ok` on crops with the current size.
 - **Calibration missing:** The GUI will still display scores even if `threshold` is `null`. Either run `/calibrate_ng` (button **Calibrate**) or set `InspectionRoiConfig.ThresholdDefault` to a conservative value.
 - **Slow inference:** Heatmaps are generated with Gaussian blur (`blur_sigma=1.0`). If using CPU only, consider reducing image size in the GUI, ensuring `torch` is compiled for CPU and that the Docker image has enough CPU shares.


### PR DESCRIPTION
### Motivation
- Align documentation with the actual on-disk layout used by the GUI and backend so users and contributors can find dataset samples and model artefacts reliably.
- Reflect the current mapping where GUI inspection IDs (`inspection-1..4`) map to `Inspection_1..4` folders in per-recipe `Recipes/<LayoutName>/Dataset` trees.
- Document backend persistence that namespaces artefacts by `recipe_id` and `model_key` under `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/` to match `ModelStore` behavior.
- Reduce confusion in troubleshooting and agent playbooks by making the storage and dataset helper contracts explicit in the docs.

### Description
- Updated `README.md` and multiple `docs/*` files (`ARCHITECTURE.md`, `FRONTEND.md`, `ROI_AND_HEATMAP_FLOW.md`, `API_CONTRACTS.md`, `BACKEND.md`, `TROUBLESHOOTING.md`) to describe the recipe-based dataset layout and the inspection-ID → `Inspection_<n>` mapping.
- Edited `agents.md` and `backend/agents_for_backend.md` to reflect the new per-recipe `recipes/<recipe_id>/<model_key>/` model storage and to clarify where `/datasets/*` helpers place files (`BDI_MODELS_DIR/datasets/...`).
- Clarified where `DatasetManager.SaveSampleAsync` writes samples (inspection slots → `Recipes/<LayoutName>/Dataset/Inspection_<n>/ok|ng`, others → `Recipes/<LayoutName>/Dataset/<roi_id>/ok|ng`) and updated examples accordingly.
- Updated troubleshooting notes to point to the new model artefact path used by `/infer` errors and to note backward-compatibility for legacy flat layouts.

### Testing
- No automated tests were run because this is a documentation-only change.
- Local changes were committed successfully (documentation files updated and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960c07ca6b8832ba3374f419bc7aed4)