### PR TITLE
Reject reserved recipe id "last" (backend + GUI + docs + tests)

### DIFF
--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -15,6 +15,12 @@ For endpoints that accept `recipe_id` in the payload/query/form:
 2. Header `X-Recipe-Id` (configurable via `BDI_RECIPE_HEADER`), else
 3. `"default"`.
 
+### Reserved recipe ids
+
+The following values are reserved and MUST NOT be used as recipes by clients:
+
+- `last` — reserved for GUI layout state (e.g., `last.layout.json`). If provided as `X-Recipe-Id` or `recipe_id`, the backend will return **HTTP 400**.
+
 ### Artifact fallback (recipe -> default)
 
 For recipe-aware artifacts (`memory`, `index`, `calib`, `datasets`), when `recipe_id != "default"` and the artifact does **not** exist for that recipe, the backend falls back to `"default"` (and finally to legacy layouts when applicable).

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs
@@ -564,10 +564,16 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             request.Headers.Remove("X-Request-Id");
             request.Headers.TryAddWithoutValidation("X-Request-Id", requestId);
 
-            if (!string.IsNullOrWhiteSpace(RecipeId))
+            if (!string.IsNullOrWhiteSpace(RecipeId) &&
+                !string.Equals(RecipeId, "last", StringComparison.OrdinalIgnoreCase))
             {
                 request.Headers.Remove("X-Recipe-Id");
                 request.Headers.TryAddWithoutValidation("X-Recipe-Id", RecipeId);
+            }
+            else
+            {
+                // No enviar recipe header si no hay recipe o si es reservado ("last")
+                request.Headers.Remove("X-Recipe-Id");
             }
         }
 


### PR DESCRIPTION
### Motivation

- Prevent the special layout identifier `last` from being treated as a real recipe and avoid accidental mapping to persistent artifacts.
- Ensure the backend returns a clear HTTP 400 when clients send the reserved `last` via `X-Recipe-Id` header or `recipe_id` payload instead of silently falling back.
- Stop the GUI from sending `X-Recipe-Id: last` or creating `Recipes/last` dataset folders by treating `last` as reserved.
- Keep logging and error-handling stable in multi-worker deployments by avoiding crashes when invalid recipe ids are encountered.

### Description

- Backend: introduced `_RECIPE_ID_RE` and `_RESERVED_RECIPE_IDS = {"last"}` and replaced `_sanitize_recipe_id()` to validate, normalize and raise `ValueError` for reserved/invalid ids in `backend/storage.py`.
- Backend: replaced `_resolve_request_context()` with a variant that raises `HTTPException(status_code=400)` for reserved ids and added `_resolve_request_context_safe()` for use in exception handlers, and updated endpoint `except` blocks to `except HTTPException: raise` and to use the safe resolver in `backend/app.py`.
- GUI: prevented sending `last` by changing `SetLayoutName()` and `AlignDatasetPathsWithCurrentLayout()` to treat `last` as reserved and avoid creating `Recipes/last`, and hardened `AddCommonHeaders()` in `BackendClient` to skip sending the header when `RecipeId == "last"` in `gui/.../WorkflowViewModel.cs` and `gui/.../BackendClient.cs`.
- Docs and tests: documented the reserved id in `docs/API_CONTRACTS.md` and added tests `test_reject_last_recipe_header_health` and `test_reject_last_recipe_payload_calibrate_ng` to `backend/tests/test_app_fastapi.py` to assert the backend returns HTTP 400 for `last`.

### Testing

- Added unit tests in `backend/tests/test_app_fastapi.py` for header and payload rejection of `last` (two tests added). 
- No automated test suite was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6960f5e31d88832bb1005468938a78a9)