### PR TITLE
Fix recipe lookup (case-insensitive) and avoid torch.Tensor truthiness crash

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -358,7 +358,14 @@ class DinoV2Features:
         feats_any = self.model.forward_features(x)
         if isinstance(feats_any, dict):
             feats = cast(dict[str, Any], feats_any)
-            tokens_any = feats.get("x_norm_patchtokens") or feats.get("x") or feats.get("tokens")
+            tokens_any: Any = None
+            # IMPORTANT: do NOT use `or` on torch.Tensor.
+            # `bool(tensor)` raises: RuntimeError: Boolean value of Tensor with more than one value is ambiguous
+            for k in ("x_norm_patchtokens", "x", "tokens"):
+                v = feats.get(k)
+                if torch.is_tensor(v):
+                    tokens_any = v
+                    break
             if tokens_any is None:
                 cands = [v for v in feats.values() if isinstance(v, torch.Tensor)]
                 if not cands:


### PR DESCRIPTION
### Motivation
- Preserve API canonicalization of `recipe_id` to lowercase while remaining backward-compatible with existing mixed-case recipe folders on disk. 
- Avoid creating directories when resolving whether existing artifacts/datasets are present. 
- Prevent a hard crash in `DinoV2Features._forward_tokens` caused by boolean evaluation of `torch.Tensor` when selecting outputs from `forward_features()`. 
- Keep reserved recipe id `last` behavior unchanged (still invalid).

### Description
- Changed `DinoV2Features` token selection to explicitly choose the first tensor among `"x_norm_patchtokens"`, `"x"`, `"tokens"` using `torch.is_tensor` instead of `or`, avoiding `bool(tensor)` evaluation. 
- Added `ModelStore._find_recipe_dir_case_insensitive` to discover on-disk recipe directories ignoring case and updated dataset/memory/index/calib resolution to attempt this alternate path before falling back. 
- Modified `resolve_models_dir` and path helpers to accept a `create: bool` flag and updated `_memory_path`, `_index_path`, `_calib_path`, and dataset resolution to call with `create=False` when checking for existing artifacts so no directories are created during lookup. 
- Kept existing sanitization/canonicalization logic for `recipe_id` while adding the backward-compatible lookup; also adjusted effective `model_key` handling in resolve routines.

### Testing
- No automated tests were run in this rollout. 
- Recommended validation: run `python -m compileall backend` and project backend `pytest`, and manually verify resolving mixed-case recipe folders (e.g., `recipes/DefaultLayout/...`) and a minimal inference path that exercises `DinoV2Features.extract()` to ensure no tensor-truthiness crash occurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69614bc57044832b95d555f5dd074e68)