### PR TITLE
Docs: document recipe-aware backend, reserved recipe ids, multi-worker notes, and GUI health/recipe behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,6 @@ Every PR must include:
 ## 6. Communication
 - Report issues with steps to reproduce, relevant log excerpts (`gui.log`, backend stdout) and screenshots if heatmaps are involved.
 - When in doubt about ROI geometry or backend payloads, consult the owner listed in `agents.md`.
+
+## Tooling notes
+- The GUI targets `.NET 8 (net8.0-windows)`. Building from VS Code requires a **.NET SDK** installed on the machine; Visual Studio installs it automatically. The VS Code Dev Kit logs “No installed .NET SDK was found” when only the runtime is present.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,3 +34,12 @@ There is no API-key enforcement or TLS termination inside the app; use a reverse
 2. From the GUI, open **Tools → Health** (or whichever control is bound to `RefreshHealthCommand`). The status bar shows the backend model and device.
 3. Run a manual inference on a known OK sample and confirm `gui.log` contains `[eval] done ... OK`.
 4. Optional: run a small batch folder to confirm anchor alignment and dataset counters behave as expected.
+
+## Running with multiple workers
+Example (Linux):
+```bash
+uvicorn backend.app:app --host 0.0.0.0 --port 8000 --workers 2
+```
+Notes:
+- Each worker is a separate process (its own in-memory caches).
+- Persisted artifacts (memory/index/calibration/datasets) are stored under `BDI_MODELS_DIR`. If you use `--workers` or multiple containers, `BDI_MODELS_DIR` must point to a shared, writable volume.

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -29,3 +29,6 @@ The repository already contains concrete logging utilities. This page summarises
 2. Look at backend stdout for the matching `event`/`role_id` combination. If `fit_ok` failed you will see the exception in `fit_ok.error`.
 3. If heatmaps look misaligned or blank, inspect `gui_heatmap.log` to verify the calculated transform (`sx`, `sy`, `offX`, `offY`) matches the current canvas size.
 4. For dataset issues, `DatasetManager` logs every file it writes plus the reason when validation fails (e.g. missing `/ok` directory).
+
+## Correlation fields
+Backend JSON responses include `request_id` and `recipe_id` in the response body. Use these fields (and the backend’s structured logs) to correlate GUI actions to backend operations.

--- a/agents.md
+++ b/agents.md
@@ -287,3 +287,8 @@ uvicorn backend.app:app --reload
 - **Shape JSON**: siempre en coordenadas de ROI canónica (post-rotación).
 - **Logging**: correlacionar `request_id` entre GUI y backend.
 - **Pruebas**: ejecutar `pytest` (backend) + validación manual GUI tras cambios en contrato.
+
+## Recipe guardrails (backend)
+- `last` is a **reserved** recipe id and MUST NOT be used for backend artifacts. Any backend change must keep this invariant (400 on `last`).
+- The backend uses the `X-Recipe-Id` header for recipe context. Treat recipe ids as case-insensitive; backend storage normalizes/sanitizes them.
+- When documenting or testing, prefer using `default` or a simple lowercase id like `layout_a`.

--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -14,3 +14,9 @@ Environment variables such as `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODEL
 
 ## Endpoints
 `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, `/manifest` and the dataset helper routes — payloads and responses exactly match [`docs/API_CONTRACTS.md`](../docs/API_CONTRACTS.md). The GUI always supplies `role_id`, `roi_id`, `mm_per_px` and the ROI `shape` mask so `roi_mask.py` can apply the same crop geometry used on the WPF side.
+
+## Recipes and reserved ids
+- The backend is recipe-aware for artifacts stored under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
+- Recipe context comes from `recipe_id` (when provided) or `X-Recipe-Id`.
+- `last` is reserved and invalid as a backend recipe id (HTTP 400).
+- Recipe ids are normalized (sanitized + lowercase) for storage; treat them as case-insensitive.

--- a/backend/agents_for_backend.md
+++ b/backend/agents_for_backend.md
@@ -65,3 +65,8 @@ backend/
 - Ejecutar `pytest` antes de PR.
 - Usar `docs/API_CONTRACTS.md` para validar manualmente.
 - Revisar `docs/BACKEND.md` para detalles extendidos.
+
+## Notas sobre recipes (enero 2026)
+- El backend es *recipe-aware*: persiste memoria/índice/calibración/datasets bajo `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
+- `last` está **reservado** y NO puede usarse como `recipe_id` en el backend (debe responder 400 si se envía por header o payload).
+- El backend normaliza `recipe_id` (sanitizado + lowercase) antes de usarlo como clave en disco. Los clientes deben tratarlo como identificador *case-insensitive*.

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,3 +21,10 @@ docker run --gpus all -p 8000:8000 \
 
 ## Configure the GUI
 Point `Backend.BaseUrl` to the host/port exposed above (for example `http://server-ip:8000`). No additional headers or API keys are required.
+
+## Multiple workers in Docker
+The default container command may start a single worker. To run multiple workers, override the command, for example:
+```bash
+docker run --rm -p 8000:8000 -v "$(pwd)/models:/app/models" brakedisc-backend   python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000 --workers 2
+```
+Ensure the mounted models directory is shared across workers/containers.

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -12,7 +12,7 @@ This document describes the backend HTTP contracts used by the GUI, and the reci
 For endpoints that accept `recipe_id` in the payload/query/form:
 
 1. Explicit `recipe_id` field/query parameter (if provided), else
-2. Header `X-Recipe-Id` (configurable via `BDI_RECIPE_HEADER`), else
+2. Header `X-Recipe-Id` (standard HTTP header; case-insensitive match), else
 3. `"default"`.
 
 ### Reserved recipe ids
@@ -260,3 +260,8 @@ When present, the GUI sends the ROI mask to the backend in canonical ROI coordin
 ```
 
 Unknown kinds fall back to a full mask.
+
+## Recipe id normalization (implementation note)
+- The backend normalizes recipe ids (sanitization and lowercase) before using them as on-disk keys under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
+- Clients should treat recipe ids as case-insensitive; do not create two recipes that differ only by casing.
+- `last` is reserved and invalid (HTTP 400) when provided via header or payload.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,3 +38,8 @@ This document summarises how the current codebase is wired: which processes exis
 ## Logging overview
 - GUI logs go to `%LocalAppData%/BrakeDiscInspector/logs/`: `gui.log` (general), `gui_heatmap.log`, `roi_load_coords.log`, `roi_analyze_master.log`. They are plain text with `yyyy-MM-dd HH:mm:ss.fff [LEVEL] message` format (see `Util/GuiLog.cs`).
 - Backend logs are emitted through `slog` in `app.py` and printed to stdout as JSON lines containing `ts`, `event`, `role_id`, `roi_id`, `request_id`, `recipe_id`, etc.
+
+## Recipe-aware backend artifacts
+- Backend artifacts are stored per recipe under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
+- Recipe context is resolved from an explicit `recipe_id` field (when present) or the `X-Recipe-Id` header.
+- `last` is reserved and invalid as a backend recipe id (400).

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -54,3 +54,12 @@ File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_
 
 ## Running tests
 `pytest` is configured under `backend/tests/`. The suite expects a working Python environment with NumPy, Torch, etc. If you only need to validate HTTP contracts, use the real FastAPI server plus the curl snippets from `docs/API_CONTRACTS.md`.
+
+## Recipe ids and normalization
+- Recipe ids are sanitized for filesystem safety and normalized to lowercase for storage.
+- Treat recipe ids as case-insensitive identifiers; do not rely on casing differences.
+- `last` is reserved and MUST be rejected with HTTP 400.
+
+## Concurrency and multi-worker deployments
+- The backend can be deployed with multiple Uvicorn workers (`--workers N`).
+- Each worker has its own process memory; avoid relying on in-process caches for correctness. All durable state must be persisted under `BDI_MODELS_DIR`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog (selected)
+## 2026-01
+- Recipe-aware backend artifacts and dataset helpers (per-recipe persistence + default fallback).
+- Reserved recipe id `last` rejected by backend (HTTP 400); GUI avoids sending it.
+- Type-safety cleanup to reduce Pylance errors; safer feature/token extraction and concurrency locks.
+- GUI batch inspection controls repositioned for better visibility.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -67,3 +67,7 @@ The GUI only calls the four routes implemented in `backend/app.py`. Every reques
 - Dataset management: `Workflow/DatasetManager.cs`, `Workflow/DatasetSample.cs`.
 - Batch orchestration: `Workflow/WorkflowViewModel.cs` (`RunBatchAsync`, `UpdateBatchHeatmapIndex`, etc.).
 - Backend communications: `Workflow/BackendClient.cs`.
+
+## Backend online indicator behavior
+- The status dot/text is driven by the workflow DataContext (`IsBackendOnline`, `HealthSummary`) and refreshed via the `RefreshHealthCommand` (`GET /health`).
+- If the backend is started after the GUI, a single refresh at startup can leave the indicator offline. Add polling or expose a manual refresh action if operators need live status.

--- a/docs/ROI_AND_HEATMAP_FLOW.md
+++ b/docs/ROI_AND_HEATMAP_FLOW.md
@@ -43,3 +43,7 @@ Values are expressed in pixels of the *canonical crop* (after rotation). Backend
 - `PresetManager.SaveInspection` clones the selected ROI into `Preset.Inspection1/2` with ids `Inspection_<slot>` to keep dataset and backend IDs consistent.
 - Layouts are saved through `MasterLayoutManager.Save` into `Layouts/<timestamp>.layout.json`. When reloading, `EnsureInspectionRoiDefaults` reinstates the four inspection slots even if they were missing in older files.
 - `SyncModelFromShape` keeps `X/Y` aligned with `CX/CY` for circle/annulus ROIs so canvas geometry and persisted layouts stay consistent after edits.
+
+## Note on recipes (GUI vs backend)
+- The GUI recipe folder (`<exe>/Recipes/<LayoutName>/...`) is for local layout/dataset persistence.
+- Backend recipe ids are independent and normalized for storage under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,3 +23,14 @@ This checklist is derived from the current GUI/Backend code.
 2. Backend stdout (or Docker logs) – `slog("infer.response", ...)` includes `elapsed_ms`, `score`, `threshold`.
 3. `%LocalAppData%/BrakeDiscInspector/logs/gui_heatmap.log` – overlay placement details.
 4. `%LocalAppData%/BrakeDiscInspector/logs/roi_analyze_master.log` – master anchor detection status when batch alignment fails.
+
+## GitHub remote moved
+If `git` reports “This repository moved”, update your remote URL:
+```bash
+git remote set-url origin https://github.com/MillyGit01/BrakeDiscInspector.git
+git fetch --prune origin
+```
+Then re-run your `pull`/`push`.
+
+## VS Code .NET SDK error
+If VS Code logs “No installed .NET SDK was found”, install the .NET SDK (or use Visual Studio, which installs it). The runtime alone is not sufficient to restore/build the WPF solution.

--- a/instructions_codex_gui_workflow.md
+++ b/instructions_codex_gui_workflow.md
@@ -35,3 +35,7 @@ Este documento está orientado a asistentes IA que colaboran en tareas GUI/back-
 - [ ] Validación manual GUI (fit/calibrate/infer en dataset demo).
 - [ ] Documentación actualizada (este archivo + relevantes).
 - [ ] Capturas/heatmaps si hay cambios visuales.
+
+## Backend readiness + recipe notes
+- The GUI health indicator uses `GET /health`. If the backend is not ready at app start, the indicator may remain offline until a refresh is executed.
+- The GUI must never send `X-Recipe-Id: last` (reserved). Use the active layout name; when the active layout name is `last`, the GUI must send no recipe header (fallback to `default`).


### PR DESCRIPTION
### Motivation
- Fix a small API contract mismatch and expand repository documentation to reflect recent backend/GUI changes (recipe-aware backend, reserved recipe ids, multi-worker notes, GUI batch controls and health indicator behavior).
- Ensure clients and operators know how recipe context is resolved and that `last` is reserved to avoid accidental backend conflicts.
- Provide deployment guidance for multi-worker `uvicorn` and Docker setups so persisted artifacts (`BDI_MODELS_DIR`) are shared across workers/containers.
- Surface GUI tooling/health behaviors and logging correlation fields to improve operator troubleshooting and contributor onboarding.

### Description
- Updated many Markdown docs to describe the recipe-aware backend storage layout and normalization semantics (per-recipe artifacts under `BDI_MODELS_DIR/recipes/<recipe_id>/...`) and that recipe ids are lowercased and sanitized.
- Added explicit guidance that `last` is a reserved recipe id and must be rejected by the backend (HTTP 400), and clarified the GUI must avoid sending `X-Recipe-Id: last` (fallback semantics documented).
- Added multi-worker notes for `uvicorn --workers N` and Docker examples, plus GUI health indicator behavior and logging correlation guidance, and a new `docs/CHANGELOG.md` summarizing selected 2026-01 changes.
- Fixed the API contract line in `docs/API_CONTRACTS.md` (replaced the `BDI_RECIPE_HEADER` phrasing with `X-Recipe-Id` as a standard case-insensitive header) and appended recipe normalization implementation notes.

### Testing
- No automated tests were run because this is a documentation-only change.  
- A local repository check ensured only Markdown files were modified before committing.  
- No runtime/backend changes were made, so no `pytest` or server validation was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69629131a9e0832b976181341186e180)