### PR TITLE
Update top bar header layout

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -291,10 +291,30 @@
                 Background="{DynamicResource BrushAppBackground}"
                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
                 BorderThickness="0,0,0,1">
-            <DockPanel Margin="0,0,0,-1">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" DockPanel.Dock="Left"/>
-                <StackPanel Orientation="Horizontal"
-                            DockPanel.Dock="Right"
+            <Grid Margin="0,0,0,-1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Title (left) -->
+                <!-- Viewbox DownOnly keeps the title from overflowing into the button area on narrow widths -->
+                <Viewbox Grid.Column="0"
+                         Stretch="Uniform"
+                         StretchDirection="DownOnly"
+                         HorizontalAlignment="Left"
+                         VerticalAlignment="Center"
+                         Margin="0,0,12,0">
+                    <TextBlock Text="Part Inspector"
+                               FontFamily="Candara Light"
+                               FontSize="65"
+                               FontWeight="Bold"
+                               Foreground="{DynamicResource UI.Brush.Foreground}"/>
+                </Viewbox>
+
+                <!-- Buttons (right) -->
+                <StackPanel Grid.Column="1"
+                            Orientation="Horizontal"
                             VerticalAlignment="Top"
                             HorizontalAlignment="Right"
                             Margin="0,6,8,0">
@@ -331,7 +351,7 @@
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.WeatherMoon24}" FontSize="18"/>
                     </ui:Button>
                 </StackPanel>
-            </DockPanel>
+            </Grid>
         </Border>
 
         <Popup x:Name="GuiSetupPopup"


### PR DESCRIPTION
### Motivation
- Move the application title into the top bar and arrange the header area into two columns so the title sits on the left and the existing controls remain on the right.
- Ensure the title scales down on narrow windows so it does not overlap the buttons by using a `Viewbox` with `StretchDirection=DownOnly`.
- Preserve existing button names and click handlers so popup placement and code-behind behavior are unchanged.
- Make the change only in XAML inside the `TopBarRightBorder` so Border attributes and code-behind remain untouched.

### Description
- Replaced the inner child of `Border x:Name="TopBarRightBorder"` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` with a two-column `Grid` where the left column holds a `Viewbox`+`TextBlock` title "Part Inspector" and the right column contains the original button `StackPanel`.
- Kept the three buttons with their original `x:Name` values: `SetupGuiButton`, `ThemeLightButton`, and `ThemeDarkButton` and preserved their `Style` and `Click` handlers.
- Did not change any `Border` attributes (such as `Padding`, `Background`, `BorderBrush`, `BorderThickness`) or any code-behind files.
- Ensured `GuiSetupPopup` placement binding to `SetupGuiButton` remains valid because the button name and XAML element are unchanged.

### Testing
- Attempted to build with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, which failed in this environment because `dotnet` is not available.
- Ran `git diff -- gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to confirm the change is limited to replacing the `DockPanel` content inside `TopBarRightBorder`, and that the button elements were preserved.
- No other automated tests were executed in this environment due to missing .NET SDK tooling.
- Manual/visual verification recommended after building: confirm title appears left, buttons appear right, popup still anchors to `SetupGuiButton`, and title scales on narrow widths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69629dc85b70832bab9e22c33da250ef)