### PR TITLE
Set minimum width (1220px) for central viewer column

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -245,7 +245,7 @@
             <ColumnDefinition x:Name="NavColumn" Width="220" MinWidth="180" />
             <ColumnDefinition x:Name="SidePanelColumn" Width="520" MinWidth="420" />
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition />
+            <ColumnDefinition Width="*" MinWidth="1220" />
         </Grid.ColumnDefinitions>
 
         <!-- ===== Top bar ===== -->


### PR DESCRIPTION
### Motivation
- Prevent the main inspection canvas (central/star column) from shrinking below 1220 px so the viewport/Canvas area retains the required minimum width.
- This is a layout-only change to XAML and must not touch any C# or control Grid.Column/Grid.Row assignments.
- Keep the existing fixed side panels unchanged (`NavColumn` 220 and `SidePanelColumn` 520 with their `MinWidth`).
- Force clipping/scrolling behavior instead of compressing the central viewing area when the window is narrower than the minimum.

### Description
- Modify `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to add a minimum width to the central ColumnDefinition.
- Replace the previous empty star column with: `<ColumnDefinition Width="*" MinWidth="1220" />`.
- No other `ColumnDefinition` entries or Grid placements were changed.
- This is a pure layout constraint change (no runtime/C# logic modified).

### Testing
- Verified that `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` now includes `MinWidth="1220"` on the star column and that only that line was changed.
- Confirmed the patch was applied and the updated file content matches the intended change in the repository.
- No WPF build or runtime resize tests were executed in this environment.
- Recommend running the WPF build and manually resizing the window locally to confirm the central area does not shrink below 1220 px.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962c3e646a8832bb6280bcfdfc40bf1)