### PR TITLE
Prevent side panel switching during ROI operations

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -3639,6 +3639,7 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
+        // NOTE: NO llamar a ShowSidePanel desde acciones operativas; solo desde handlers de navegación (botones izquierda).
         private void ShowSidePanel(SidePanelMode mode)
         {
             if (LayoutSetupPanel == null || RoiManagementPanel == null || BatchInspectionPanel == null || CommsPanel == null)
@@ -5093,9 +5094,6 @@ namespace BrakeDiscInspector_GUI_ROI
             // Habilitación de tabs por etapas
             EnablePresetsTab(mastersReady || _hasLoadedImage);     // permite la pestaña de inspección tras cargar imagen o completar masters
 
-            // Selección de panel acorde a estado
-            ShowSidePanel(SidePanelMode.RoiManagement);
-
             if (_analysisViewActive && _state != MasterState.Ready)
             {
                 ResetAnalysisMarks();
@@ -5374,8 +5372,6 @@ namespace BrakeDiscInspector_GUI_ROI
             SetInspectionEditingFlag(inspectionIndex, true);
             UpdateEditableConfigState();
             UpdateInspectionEditButtons();
-
-            GoToInspectionTab();
             SetActiveInspectionIndex(inspectionIndex);
 
             RemoveAllRoiAdorners();
@@ -7771,7 +7767,6 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             _analysisViewActive = true;
-            ShowSidePanel(SidePanelMode.RoiManagement);
         }
 
         private string? ResolveRoiLabelText(RoiModel roi)
@@ -9048,13 +9043,11 @@ namespace BrakeDiscInspector_GUI_ROI
         private void OnPresetLoaded()
         {
             TryCollapseMasterEditors();
-            GoToInspectionTab();
         }
 
         private void OnLayoutLoaded()
         {
             TryCollapseMasterEditors();
-            GoToInspectionTab();
         }
 
         private void TryCollapseMasterEditors()
@@ -9064,11 +9057,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 MasterRoiGroup.Visibility = Visibility.Collapsed;
             }
 
-        }
-
-        private void GoToInspectionTab()
-        {
-            ShowSidePanel(SidePanelMode.RoiManagement);
         }
 
         private void RedrawAllRois()


### PR DESCRIPTION
### Motivation

- Fix unexpected left-side panel changes triggered by operational flows (save ROI, evaluate ROI, load preset/layout, enter edit) so the panel only changes on explicit navigation clicks.
- Preserve existing ROI/adorner/letterbox/transform logic while preventing UI navigation side-effects during workflows.

### Description

- Added a warning comment above `ShowSidePanel` and restricted its intended use to navigation handlers (left navigation buttons) in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.
- Removed the call to `ShowSidePanel(SidePanelMode.RoiManagement)` from `UpdateWizardState()` so saving a ROI no longer forces navigation.
- Removed the call to `ShowSidePanel` from `EnterAnalysisView()` so `Evaluate ROI` / heatmap display no longer forces navigation.
- Eliminated the `GoToInspectionTab()` helper and removed its invocations from `OnPresetLoaded()`, `OnLayoutLoaded()`, and `EnterInspectionEditMode()` to stop layout/preset/load and edit flows from forcing the ROI panel.

### Testing

- No automated tests were executed in this environment because the WPF app was not built here.
- Changes were limited to navigation calls in `MainWindow.xaml.cs` and verified by searching the source for remaining `ShowSidePanel` usages to ensure they remain only in navigation handlers and the constructor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6963ef3d18d8832b9d162388e228dbff)