### PR TITLE
Show Inspection ROI panel in designer and add design-time data for inspection tabs

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -767,7 +767,8 @@
                           d:Visibility="Visible">
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel x:Name="RoiManagementSelector"
-                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}">
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Selector}"
+                                d:Visibility="Collapsed">
                         <TextBlock Text="Selecciona 'Master ROIs' o 'Inspection ROIs' desde el menú de la izquierda."
                                    TextWrapping="Wrap"
                                    Opacity="0.7"
@@ -775,7 +776,8 @@
                     </StackPanel>
 
                     <StackPanel x:Name="MasterRoisPanel"
-                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Master}">
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Master}"
+                                d:Visibility="Collapsed">
                         <StackPanel x:Name="MasterDefaultPanel" Visibility="Visible">
                             <GroupBox x:Name="MasterRoiGroup"
                                       Header="Master ROI"
@@ -1029,7 +1031,8 @@
                     </StackPanel>
 
                     <StackPanel x:Name="InspectionRoisPanel"
-                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Inspection}">
+                                Visibility="{Binding RoiPanelMode, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource RoiPanelModeToVisibility}, ConverterParameter=Inspection}"
+                                d:Visibility="Visible">
                         <StackPanel x:Name="InspectionDefaultPanel">
                             <GroupBox x:Name="InspectionRoisGroup" Header="Inspection ROIs" Margin="0,12,0,0">
                                 <StackPanel Margin="8,4,0,0">

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using BrakeDiscInspector_GUI_ROI.Models;
+using BrakeDiscInspector_GUI_ROI.Workflow;
+
+namespace BrakeDiscInspector_GUI_ROI.Workflow.DesignTime
+{
+    internal sealed class DesignWorkflowViewModel
+    {
+        private const int ThumbnailWidth = 120;
+        private const int ThumbnailHeight = 90;
+
+        public DesignWorkflowViewModel()
+        {
+            BrowseDatasetCommand = new NoOpCommand();
+            OpenDatasetFolderCommand = new NoOpCommand();
+            TrainSelectedRoiCommand = new NoOpCommand();
+            CalibrateSelectedRoiCommand = new NoOpCommand();
+            EvaluateSelectedRoiCommand = new NoOpCommand();
+            RemoveSelectedCommand = new NoOpCommand();
+            InferEnabledRoisCommand = new NoOpCommand();
+
+            InspectionRois = new ObservableCollection<InspectionRoiConfig>
+            {
+                CreateRoi(1, Colors.SeaGreen, Colors.MediumSeaGreen),
+                CreateRoi(2, Colors.SteelBlue, Colors.DodgerBlue),
+                CreateRoi(3, Colors.IndianRed, Colors.OrangeRed),
+                CreateRoi(4, Colors.Goldenrod, Colors.Gold)
+            };
+
+            SelectedInspectionRoi = InspectionRois.First();
+            MmPerPx = 0.185;
+            HeatmapOpacity = 0.65;
+            LocalThreshold = 0.85;
+            Regions = new ObservableCollection<Region>
+            {
+                new Region { x = 12, y = 18, w = 32, h = 24, area_px = 768, area_mm2 = 4.2 },
+                new Region { x = 58, y = 44, w = 26, h = 18, area_px = 468, area_mm2 = 2.6 }
+            };
+        }
+
+        public ObservableCollection<InspectionRoiConfig> InspectionRois { get; }
+
+        public InspectionRoiConfig SelectedInspectionRoi { get; set; }
+
+        public double MmPerPx { get; set; }
+
+        public double HeatmapOpacity { get; set; }
+
+        public double LocalThreshold { get; set; }
+
+        public ObservableCollection<Region> Regions { get; }
+
+        public ICommand BrowseDatasetCommand { get; }
+
+        public ICommand OpenDatasetFolderCommand { get; }
+
+        public ICommand TrainSelectedRoiCommand { get; }
+
+        public ICommand CalibrateSelectedRoiCommand { get; }
+
+        public ICommand EvaluateSelectedRoiCommand { get; }
+
+        public ICommand RemoveSelectedCommand { get; }
+
+        public ICommand InferEnabledRoisCommand { get; }
+
+        private static InspectionRoiConfig CreateRoi(int index, Color okBase, Color ngBase)
+        {
+            var roi = new InspectionRoiConfig(index)
+            {
+                DatasetStatus = "Dataset listo",
+                DatasetOkCount = 24,
+                DatasetKoCount = 6,
+                ThresholdDefault = 0.5,
+                CalibratedThreshold = 0.72,
+                HasFitOk = true
+            };
+
+            roi.OkPreview = CreatePreviewCollection("ok", okBase);
+            roi.NgPreview = CreatePreviewCollection("ng", ngBase);
+
+            return roi;
+        }
+
+        private static ObservableCollection<DatasetPreviewItem> CreatePreviewCollection(string label, Color baseColor)
+        {
+            var items = new ObservableCollection<DatasetPreviewItem>();
+            for (var i = 0; i < 5; i++)
+            {
+                var accent = Color.FromRgb(
+                    (byte)Math.Clamp(baseColor.R + i * 12, 0, 255),
+                    (byte)Math.Clamp(baseColor.G + i * 8, 0, 255),
+                    (byte)Math.Clamp(baseColor.B + i * 6, 0, 255));
+                items.Add(new DatasetPreviewItem
+                {
+                    Path = $"{label}_sample_{i + 1}.png",
+                    Thumbnail = CreateThumbnail(baseColor, accent)
+                });
+            }
+
+            return items;
+        }
+
+        private static BitmapSource CreateThumbnail(Color start, Color end)
+        {
+            var writeable = new WriteableBitmap(ThumbnailWidth, ThumbnailHeight, 96, 96, PixelFormats.Bgra32, null);
+            var stride = ThumbnailWidth * 4;
+            var pixels = new byte[ThumbnailHeight * stride];
+
+            for (var y = 0; y < ThumbnailHeight; y++)
+            {
+                var t = ThumbnailHeight == 1 ? 0 : (double)y / (ThumbnailHeight - 1);
+                var r = (byte)(start.R + (end.R - start.R) * t);
+                var g = (byte)(start.G + (end.G - start.G) * t);
+                var b = (byte)(start.B + (end.B - start.B) * t);
+
+                for (var x = 0; x < ThumbnailWidth; x++)
+                {
+                    var offset = (y * stride) + (x * 4);
+                    pixels[offset] = b;
+                    pixels[offset + 1] = g;
+                    pixels[offset + 2] = r;
+                    pixels[offset + 3] = 255;
+                }
+            }
+
+            writeable.WritePixels(new System.Windows.Int32Rect(0, 0, ThumbnailWidth, ThumbnailHeight), pixels, stride, 0);
+            writeable.Freeze();
+            return writeable;
+        }
+
+        private sealed class NoOpCommand : ICommand
+        {
+            public event System.EventHandler? CanExecuteChanged
+            {
+                add { }
+                remove { }
+            }
+
+            public bool CanExecute(object? parameter) => true;
+
+            public void Execute(object? parameter)
+            {
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabsControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabsControl.xaml
@@ -4,9 +4,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:m="clr-namespace:BrakeDiscInspector_GUI_ROI.Models"
+             xmlns:dt="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow.DesignTime"
              xmlns:w="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=dt:DesignWorkflowViewModel, IsDesignTimeCreatable=True}"
              d:DesignHeight="300"
              d:DesignWidth="480">
     <UserControl.Resources>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -4,8 +4,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:w="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
+             xmlns:dt="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow.DesignTime"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance Type=dt:DesignWorkflowViewModel, IsDesignTimeCreatable=True}"
              d:DesignHeight="600"
              d:DesignWidth="480">
     <UserControl.Resources>


### PR DESCRIPTION
### Motivation

- Make the designer show the full "Inspection" section inside the ROI management panel so designers can reorder and edit controls without affecting runtime behavior. 
- Ensure the `InspectionDatasetTabsControl` and `WorkflowControl` render tabs and thumbnails in the Visual Studio/Blend designer even when the runtime DataContext is not available. 
- Provide safe, runtime-independent sample data and no-op commands so designer visuals are representative but do not change application runtime logic. 

### Description

- Force design-time visibility: added `d:Visibility="Visible"` to the `InspectionRoisPanel` and set `d:Visibility="Collapsed"` on `RoiManagementSelector` and `MasterRoisPanel` in `MainWindow.xaml` so only the Inspection section is shown in the designer. 
- Wire design-time viewmodels: added `d:DataContext` design instances in `InspectionDatasetTabsControl.xaml` and `WorkflowControl.xaml` pointing to a `DesignWorkflowViewModel` in the design-time namespace. 
- New design-time VM: added `gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs` which constructs 4 `InspectionRoiConfig` instances with populated `OkPreview`/`NgPreview` thumbnails, sample regions and stub `ICommand` no-op implementations so XAML bindings render safely. 

### Testing

- Attempted to build the solution with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, but the `dotnet` SDK was not available in the environment so compilation could not be verified. (build attempt failed)
- Verified XAML edits and the new design-time class were added and committed; no runtime behavior was changed because only `d:` attributes and a design-time-only class were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964064cb10c832bbbd18248a4477ec0)