### PR TITLE
Refactor dataset previews into editable UserControls and remove design-time mock layout

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml
@@ -1,0 +1,18 @@
+<UserControl x:Class="BrakeDiscInspector_GUI_ROI.Workflow.DatasetPreviewItemView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="100"
+             d:DesignWidth="140">
+    <Border BorderBrush="#303030" BorderThickness="1" Margin="0">
+        <Image Source="{Binding Thumbnail}"
+               Width="120"
+               Height="90"
+               Margin="0,0,8,0"
+               Cursor="Hand"
+               Stretch="UniformToFill"
+               MouseLeftButtonUp="DatasetImage_Click"/>
+    </Border>
+</UserControl>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows.Controls;
+using System.Windows.Input;
+using BrakeDiscInspector_GUI_ROI.Util;
+
+namespace BrakeDiscInspector_GUI_ROI.Workflow
+{
+    public partial class DatasetPreviewItemView : UserControl
+    {
+        public DatasetPreviewItemView()
+        {
+            InitializeComponent();
+        }
+
+        private void DatasetImage_Click(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is Image image && image.DataContext is DatasetPreviewItem item && File.Exists(item.Path))
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo(item.Path) { UseShellExecute = true });
+                }
+                catch (Exception ex)
+                {
+                    GuiLog.Warn($"[dataset] Failed to open '{item.Path}': {ex.Message}");
+                }
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
@@ -1,0 +1,31 @@
+<UserControl x:Class="BrakeDiscInspector_GUI_ROI.Workflow.DatasetPreviewStripView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:w="clr-namespace:BrakeDiscInspector_GUI_ROI.Workflow"
+             mc:Ignorable="d"
+             d:DesignHeight="140"
+             d:DesignWidth="420">
+    <StackPanel>
+        <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}"
+                   FontWeight="SemiBold"
+                   Margin="0,6,0,4"/>
+        <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Disabled"
+                      Height="110">
+            <ItemsControl ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <w:DatasetPreviewItemView/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </StackPanel>
+</UserControl>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace BrakeDiscInspector_GUI_ROI.Workflow
+{
+    public partial class DatasetPreviewStripView : UserControl
+    {
+        public static readonly DependencyProperty ItemsSourceProperty =
+            DependencyProperty.Register(
+                nameof(ItemsSource),
+                typeof(IEnumerable),
+                typeof(DatasetPreviewStripView),
+                new PropertyMetadata(null));
+
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register(
+                nameof(Title),
+                typeof(string),
+                typeof(DatasetPreviewStripView),
+                new PropertyMetadata(string.Empty));
+
+        public DatasetPreviewStripView()
+        {
+            InitializeComponent();
+        }
+
+        public IEnumerable? ItemsSource
+        {
+            get => (IEnumerable?)GetValue(ItemsSourceProperty);
+            set => SetValue(ItemsSourceProperty, value);
+        }
+
+        public string? Title
+        {
+            get => (string?)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
@@ -12,7 +12,7 @@
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
     </UserControl.Resources>
-    <Grid Margin="0,8,0,0" x:Name="RuntimeLayout" d:Visibility="Collapsed">
+    <Grid Margin="0,8,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -131,57 +131,10 @@
                      Visibility="{Binding IsDatasetLoading, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
         <StackPanel Grid.Row="6" Margin="0,8,0,0">
-            <TextBlock Text="OK dataset" FontWeight="SemiBold" Margin="0,6,0,4"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Disabled"
-                          Height="110">
-                <ItemsControl ItemsSource="{Binding OkPreview}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate DataType="{x:Type w:DatasetPreviewItem}">
-                            <Border BorderBrush="#303030" BorderThickness="1" Margin="0">
-                                <Image Source="{Binding Thumbnail}"
-                                       Width="120"
-                                       Height="90"
-                                       Margin="0,0,8,0"
-                                       Cursor="Hand"
-                                       Stretch="UniformToFill"
-                                       MouseLeftButtonUp="DatasetImage_Click"/>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
-
-            <TextBlock Text="NG dataset" FontWeight="SemiBold" Margin="0,8,0,4"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Disabled"
-                          Height="110">
-                <ItemsControl ItemsSource="{Binding NgPreview}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal"/>
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate DataType="{x:Type w:DatasetPreviewItem}">
-                            <Border BorderBrush="#303030" BorderThickness="1" Margin="0">
-                                <Image Source="{Binding Thumbnail}"
-                                       Width="120"
-                                       Height="90"
-                                       Margin="0,0,8,0"
-                                       Cursor="Hand"
-                                       Stretch="UniformToFill"
-                                       MouseLeftButtonUp="DatasetImage_Click"/>
-                            </Border>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
-            </ScrollViewer>
+            <w:DatasetPreviewStripView Title="OK dataset" ItemsSource="{Binding OkPreview}" />
+            <w:DatasetPreviewStripView Title="NG dataset"
+                                       ItemsSource="{Binding NgPreview}"
+                                       Margin="0,8,0,0" />
         </StackPanel>
 
         <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
@@ -251,112 +204,6 @@
                     </Style>
                 </TextBlock.Style>
             </TextBlock>
-        </StackPanel>
-    </Grid>
-    <Grid x:Name="DesignLayout" Margin="0,8,0,0" Visibility="Collapsed" d:Visibility="Visible">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Name" Width="70" VerticalAlignment="Center"/>
-            <TextBox Width="200" Text="ROI 1" Margin="0,0,12,0"/>
-            <CheckBox Content="Enabled" IsChecked="True" VerticalAlignment="Center"/>
-            <Button Content="Edit" Width="80" Margin="8,0,0,0" Padding="12,4"/>
-        </StackPanel>
-
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="ModelKey" Width="70" VerticalAlignment="Center"/>
-            <TextBox Width="220" Text="role_1_roi_1" Margin="0,0,12,0"/>
-            <CheckBox Content="Memory fit" IsChecked="True" VerticalAlignment="Center"/>
-        </StackPanel>
-
-        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="Anchor master:" VerticalAlignment="Center" Margin="0,0,8,0"/>
-            <ComboBox Width="90" SelectedIndex="0">
-                <ComboBoxItem Content="Master1"/>
-                <ComboBoxItem Content="Master2"/>
-                <ComboBoxItem Content="Mid"/>
-            </ComboBox>
-        </StackPanel>
-
-        <Grid Grid.Row="3" Margin="0,8,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock Text="Dataset" VerticalAlignment="Center" Margin="0,0,8,0"/>
-            <TextBox Grid.Column="1" Height="26" Text="C:\\Recipes\\LayoutX\\Dataset\\Inspection_1" Margin="0,0,8,0" VerticalAlignment="Center"/>
-            <Button Grid.Column="2" Padding="12,4" Content="Browse..."/>
-            <Button Grid.Column="3" Padding="12,4" Content="Open Folder"/>
-        </Grid>
-
-        <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="Dataset ready (mock)" FontWeight="SemiBold" Foreground="ForestGreen"/>
-            <TextBlock Text="  "/>
-            <TextBlock Text="OK: 12  NG: 3"/>
-        </StackPanel>
-
-        <ProgressBar Grid.Row="5" Height="4" Margin="0,4,0,0" IsIndeterminate="True"/>
-
-        <StackPanel Grid.Row="6" Margin="0,8,0,0">
-            <TextBlock Text="OK dataset" FontWeight="SemiBold" Margin="0,6,0,4"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Disabled"
-                          Height="110">
-                <WrapPanel>
-                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,8,0" Padding="2">
-                        <Rectangle Width="120" Height="90"/>
-                    </Border>
-                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,8,0" Padding="2">
-                        <Rectangle Width="120" Height="90"/>
-                    </Border>
-                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,8,0" Padding="2">
-                        <Rectangle Width="120" Height="90"/>
-                    </Border>
-                </WrapPanel>
-            </ScrollViewer>
-
-            <TextBlock Text="NG dataset" FontWeight="SemiBold" Margin="0,8,0,4"/>
-            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Disabled"
-                          Height="110">
-                <WrapPanel>
-                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,8,0" Padding="2">
-                        <Rectangle Width="120" Height="90"/>
-                    </Border>
-                    <Border BorderBrush="Gray" BorderThickness="1" Margin="0,0,8,0" Padding="2">
-                        <Rectangle Width="120" Height="90"/>
-                    </Border>
-                </WrapPanel>
-            </ScrollViewer>
-        </StackPanel>
-
-        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
-            <Button Content="Load model" Margin="0,0,8,0" Padding="12,4"/>
-            <Button Content="Delete Selected" Margin="0,0,8,0" Padding="12,4"/>
-            <Button Content="Train" Margin="0,0,8,0" Padding="12,4"/>
-            <Button Content="Calibrate" Margin="0,0,8,0" Padding="12,4"/>
-            <Button Content="Evaluate ROI" Padding="12,4"/>
-        </StackPanel>
-
-        <StackPanel Grid.Row="8" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="Score:"/>
-            <TextBlock Text="0.123" Margin="4,0,12,0"/>
-            <TextBlock Text="Threshold:"/>
-            <TextBlock Text="0.456" Margin="4,0,12,0"/>
-            <TextBlock Text="Result:"/>
-            <TextBlock Text="OK" Margin="4,0,0,0" Foreground="ForestGreen"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using BrakeDiscInspector_GUI_ROI.Models;
 using BrakeDiscInspector_GUI_ROI.Util;
 
@@ -66,19 +63,5 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
         }
 
-        private void DatasetImage_Click(object sender, MouseButtonEventArgs e)
-        {
-            if (sender is Image image && image.DataContext is DatasetPreviewItem item && File.Exists(item.Path))
-            {
-                try
-                {
-                    Process.Start(new ProcessStartInfo(item.Path) { UseShellExecute = true });
-                }
-                catch (Exception ex)
-                {
-                    GuiLog.Warn($"[dataset] Failed to open '{item.Path}': {ex.Message}");
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- The designer experience was hindered by inline `DataTemplate` thumbnails and a duplicated design-time `DesignLayout` grid that hid the runtime layout with `d:Visibility`.
- Expose the thumbnail and strip UI as real XAML views so they can be opened and edited in the designer without breaking bindings.
- Preserve existing data bindings (`OkPreview`/`NgPreview`, `Thumbnail`, `Path`) and the thumbnail click behavior that opens images with `Process.Start`.

### Description
- Removed the `DesignLayout` duplicate grid and cleared the `d:Visibility="Collapsed"` wrapper so `InspectionDatasetTabView.xaml` contains a single real `Grid` visible in the designer.
- Introduced `DatasetPreviewItemView` (`.xaml` + `.xaml.cs`) that renders the thumbnail (`120x90`) and implements `DatasetImage_Click` with the same `Process.Start`/file-exists/logging logic as before.
- Added `DatasetPreviewStripView` (`.xaml` + `.xaml.cs`) exposing `DependencyProperty` `ItemsSource` and `Title`, and hosting an `ItemsControl` that uses `DatasetPreviewItemView` for each item.
- Replaced the inline OK/NG `ItemsControl`/`DataTemplate` blocks in `InspectionDatasetTabView.xaml` with two `DatasetPreviewStripView` instances and removed the now-unreferenced `DatasetImage_Click` handler from `InspectionDatasetTabView.xaml.cs`.

### Testing
- No automated tests were executed as part of this change; please run the GUI build and the runtime/designer validation steps locally to verify behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964ad5bd448832ba7369edd79098276)