### PR TITLE
Reorder inspection dataset tab UI and add selectable thumbnails

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
@@ -40,6 +40,8 @@ namespace BrakeDiscInspector_GUI_ROI.Models
         private int _datasetKoCount;
         private ObservableCollection<DatasetPreviewItem> _okPreview = new();
         private ObservableCollection<DatasetPreviewItem> _ngPreview = new();
+        private DatasetPreviewItem? _selectedOkPreviewItem;
+        private DatasetPreviewItem? _selectedNgPreviewItem;
         private bool _hasFitOk;
         private MasterAnchorChoice _anchorMaster = MasterAnchorChoice.Master1;
 
@@ -203,6 +205,30 @@ namespace BrakeDiscInspector_GUI_ROI.Models
             {
                 if (ReferenceEquals(_ngPreview, value)) return;
                 _ngPreview = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public DatasetPreviewItem? SelectedOkPreviewItem
+        {
+            get => _selectedOkPreviewItem;
+            set
+            {
+                if (ReferenceEquals(_selectedOkPreviewItem, value)) return;
+                _selectedOkPreviewItem = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public DatasetPreviewItem? SelectedNgPreviewItem
+        {
+            get => _selectedNgPreviewItem;
+            set
+            {
+                if (ReferenceEquals(_selectedNgPreviewItem, value)) return;
+                _selectedNgPreviewItem = value;
                 OnPropertyChanged();
             }
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewItemView.xaml
@@ -6,13 +6,10 @@
              mc:Ignorable="d"
              d:DesignHeight="100"
              d:DesignWidth="140">
-    <Border BorderBrush="#303030" BorderThickness="1" Margin="0">
-        <Image Source="{Binding Thumbnail}"
-               Width="120"
-               Height="90"
-               Margin="0,0,8,0"
-               Cursor="Hand"
-               Stretch="UniformToFill"
-               MouseLeftButtonUp="DatasetImage_Click"/>
-    </Border>
+    <Image Source="{Binding Thumbnail}"
+           Width="120"
+           Height="90"
+           Cursor="Hand"
+           Stretch="UniformToFill"
+           MouseLeftButtonUp="DatasetImage_Click"/>
 </UserControl>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
@@ -11,21 +11,53 @@
         <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}"
                    FontWeight="SemiBold"
                    Margin="0,6,0,4"/>
-        <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                      VerticalScrollBarVisibility="Disabled"
-                      Height="110">
-            <ItemsControl ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <StackPanel Orientation="Horizontal"/>
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <w:DatasetPreviewItemView/>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+        <ListBox ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}"
+                 SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}, Mode=TwoWay}"
+                 BorderThickness="0"
+                 Background="Transparent"
+                 Height="110"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                 ScrollViewer.VerticalScrollBarVisibility="Disabled">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="Margin" Value="0,0,8,0"/>
+                    <Setter Property="Padding" Value="0"/>
+                    <Setter Property="BorderBrush" Value="#303030"/>
+                    <Setter Property="BorderThickness" Value="1"/>
+                    <Setter Property="Background" Value="Transparent"/>
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="ListBoxItem">
+                                <Border x:Name="SelectionBorder"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Background="{TemplateBinding Background}">
+                                    <ContentPresenter/>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter TargetName="SelectionBorder" Property="BorderBrush" Value="#2D89EF"/>
+                                        <Setter TargetName="SelectionBorder" Property="BorderThickness" Value="2"/>
+                                        <Setter TargetName="SelectionBorder" Property="Background" Value="#332D89EF"/>
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <w:DatasetPreviewItemView/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
     </StackPanel>
 </UserControl>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml.cs
@@ -20,6 +20,13 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 typeof(DatasetPreviewStripView),
                 new PropertyMetadata(string.Empty));
 
+        public static readonly DependencyProperty SelectedItemProperty =
+            DependencyProperty.Register(
+                nameof(SelectedItem),
+                typeof(object),
+                typeof(DatasetPreviewStripView),
+                new PropertyMetadata(null));
+
         public DatasetPreviewStripView()
         {
             InitializeComponent();
@@ -35,6 +42,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         {
             get => (string?)GetValue(TitleProperty);
             set => SetValue(TitleProperty, value);
+        }
+
+        public object? SelectedItem
+        {
+            get => GetValue(SelectedItemProperty);
+            set => SetValue(SelectedItemProperty, value);
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
@@ -19,7 +19,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -28,45 +30,18 @@
         <StackPanel Orientation="Horizontal">
             <TextBlock Text="Name" Width="70" VerticalAlignment="Center"/>
             <TextBox Text="{Binding Name}" Width="200" Margin="0,0,12,0"/>
-            <CheckBox Content="Enabled" IsChecked="{Binding Enabled}" VerticalAlignment="Center"/>
-            <ui:Button Margin="8,0,0,0"
-                       Padding="12,4"
-                       Click="BtnToggleEdit_Click"
-                       IsEnabled="{Binding Enabled}">
-                <ui:Button.Style>
-                    <Style TargetType="{x:Type ui:Button}">
-                        <Setter Property="Content">
-                            <Setter.Value>
-                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Edit24}" Margin="0,0,8,0"/>
-                                    <TextBlock Text="{Binding Path=Index, StringFormat=Edit ROI{0}}" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Setter.Value>
-                        </Setter>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsEditable}" Value="True">
-                                <Setter Property="Content">
-                                    <Setter.Value>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0"/>
-                                            <TextBlock Text="{Binding Path=Index, StringFormat=Save ROI{0}}" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </Setter.Value>
-                                </Setter>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </ui:Button.Style>
-            </ui:Button>
         </StackPanel>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,8,0,0">
-            <TextBlock Text="ModelKey" Width="70" VerticalAlignment="Center"/>
-            <TextBox Text="{Binding ModelKey}" Width="220" Margin="0,0,12,0"/>
-            <CheckBox Content="Memory fit" IsChecked="{Binding TrainMemoryFit}" VerticalAlignment="Center"/>
-        </StackPanel>
+        <CheckBox Grid.Row="1" Content="Enabled" IsChecked="{Binding Enabled}" VerticalAlignment="Center" Margin="0,8,0,0"/>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,8,0,0">
+            <TextBlock Text="ModelKey" Width="70" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding ModelKey}" Width="220" Margin="0,0,12,0"/>
+        </StackPanel>
+
+        <CheckBox Grid.Row="3" Content="Memory fit" IsChecked="{Binding TrainMemoryFit}" VerticalAlignment="Center" Margin="0,8,0,0"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,8,0,0">
             <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
                 <TextBlock Text="Anchor master:" VerticalAlignment="Center" Margin="0,0,8,0"/>
                 <ComboBox Width="90"
@@ -82,33 +57,40 @@
             </StackPanel>
         </StackPanel>
 
-        <Grid Grid.Row="3" Margin="0,8,0,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock Text="Dataset" VerticalAlignment="Center" Margin="0,0,8,0"/>
-            <TextBox Grid.Column="1" Text="{Binding DatasetPath}" Margin="0,0,8,0" VerticalAlignment="Center"/>
-            <ui:Button Grid.Column="2"
-                       Padding="12,4"
-                       Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0"/>
-                    <TextBlock Text="Browse..." VerticalAlignment="Center"/>
-                </StackPanel>
-            </ui:Button>
-            <ui:Button Grid.Column="3" Padding="12,4"
-                       Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                    <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Folder24}" Margin="0,0,8,0"/>
-                    <TextBlock Text="Open Folder" VerticalAlignment="Center"/>
-                </StackPanel>
-            </ui:Button>
-        </Grid>
+        <StackPanel Grid.Row="5" Margin="0,8,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Text="Dataset" Width="70" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <TextBox Grid.Column="1"
+                         Text="{Binding DatasetPath}"
+                         Margin="0,0,8,0"
+                         VerticalAlignment="Center"
+                         HorizontalAlignment="Stretch"
+                         FontSize="{Binding FontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+            </Grid>
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
+                <ui:Button Padding="12,4"
+                           Margin="0,0,8,0"
+                           Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0"/>
+                        <TextBlock Text="Browse..." VerticalAlignment="Center"/>
+                    </StackPanel>
+                </ui:Button>
+                <ui:Button Padding="12,4"
+                           Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Folder24}" Margin="0,0,8,0"/>
+                        <TextBlock Text="Open Folder" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </ui:Button>
+            </StackPanel>
+        </StackPanel>
 
-        <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,8,0,0">
+        <StackPanel Grid.Row="6" Orientation="Horizontal" Margin="0,8,0,0">
             <TextBlock Text="{Binding DatasetStatus}">
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
@@ -126,18 +108,21 @@
             <TextBlock Text="{Binding DatasetCountsText}"/>
         </StackPanel>
 
-        <ProgressBar Grid.Row="5" Height="4" Margin="0,4,0,0"
+        <ProgressBar Grid.Row="7" Height="4" Margin="0,4,0,0"
                      IsIndeterminate="True"
                      Visibility="{Binding IsDatasetLoading, Converter={StaticResource BoolToVisibilityConverter}}"/>
 
-        <StackPanel Grid.Row="6" Margin="0,8,0,0">
-            <w:DatasetPreviewStripView Title="OK dataset" ItemsSource="{Binding OkPreview}" />
+        <StackPanel Grid.Row="8" Margin="0,8,0,0">
+            <w:DatasetPreviewStripView Title="OK dataset"
+                                       ItemsSource="{Binding OkPreview}"
+                                       SelectedItem="{Binding SelectedOkPreviewItem, Mode=TwoWay}"/>
             <w:DatasetPreviewStripView Title="NG dataset"
                                        ItemsSource="{Binding NgPreview}"
+                                       SelectedItem="{Binding SelectedNgPreviewItem, Mode=TwoWay}"
                                        Margin="0,8,0,0" />
         </StackPanel>
 
-        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+        <StackPanel Grid.Row="9" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
             <ui:Button Padding="12,4"
                        Margin="0,0,8,0"
                        Tag="{Binding Index}"
@@ -180,7 +165,7 @@
             </ui:Button>
         </StackPanel>
 
-        <StackPanel Grid.Row="8" Orientation="Horizontal" Margin="0,8,0,0">
+        <StackPanel Grid.Row="10" Orientation="Horizontal" Margin="0,8,0,0">
             <TextBlock Text="Score:"/>
             <TextBlock Text="{Binding LastScore, StringFormat={}{0:0.000}}" Margin="4,0,12,0"/>
             <TextBlock Text="Threshold:"/>


### PR DESCRIPTION
### Motivation
- Apply UI-only layout changes to `InspectionDatasetTabView.xaml` so controls follow the new ordered rows and spacing rules.
- Remove the Edit/Save button from the XAML while preserving existing code-behind handlers to avoid runtime breakage.
- Make dataset controls more ergonomic by placing `Browse`/`Open Folder` under the `DatasetPath` textbox and ensure its `FontSize` matches labels.
- Provide visible selection for dataset thumbnails so clicking an OK/NG thumbnail marks it as selected while preserving the image-open action.

### Description
- Reworked `InspectionDatasetTabView.xaml` to reorder rows: `Name` + textbox (row 0), `Enabled` checkbox moved to its own row (row 1), `ModelKey` (row 2), `Memory fit` checkbox moved under `ModelKey` (row 3), dataset block redesigned with buttons below the `DatasetPath` textbox and `FontSize` bound to the `UserControl` font size.
- Removed the Edit/Save button element from the XAML (left code-behind handlers intact) and added required `RowDefinition` entries to match the new layout.
- Replaced the `ItemsControl` preview strips with a `ListBox` in `DatasetPreviewStripView.xaml` and added selection visuals via an `ItemContainerStyle`; added a `SelectedItem` dependency property in `DatasetPreviewStripView.xaml.cs` to allow binding selection.
- Added `SelectedOkPreviewItem` and `SelectedNgPreviewItem` properties to `InspectionRoiConfig` to track the selected thumbnail items, and simplified `DatasetPreviewItemView.xaml` (keeps `MouseLeftButtonUp="DatasetImage_Click"`) so thumbnail clicks still open images while allowing ListBox selection.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964c4298f74832bb60207282f8cb0c9)