### PR TITLE
Fix: BatchCellStatusToBrushConverter handles enum explicitly and fixes NOK/OK color bug

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using BrakeDiscInspector_GUI_ROI.Workflow;
 
 namespace BrakeDiscInspector_GUI_ROI.Converters
 {
@@ -23,6 +24,16 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
             if (value is bool boolValue)
             {
                 return boolValue ? Brushes.LimeGreen : Brushes.IndianRed;
+            }
+
+            if (value is BatchCellStatus status)
+            {
+                return MapStatus(status);
+            }
+
+            if (value is int intValue && Enum.IsDefined(typeof(BatchCellStatus), intValue))
+            {
+                return MapStatus((BatchCellStatus)intValue);
             }
 
             if (value is string textValue)
@@ -50,19 +61,30 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
                 return Brushes.Gray;
             }
 
-            if (text.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0
-                || text.IndexOf("PASS", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return Brushes.LimeGreen;
-            }
-
-            if (text.IndexOf("NG", StringComparison.OrdinalIgnoreCase) >= 0
-                || text.IndexOf("FAIL", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (text.Trim().Equals("NOK", StringComparison.OrdinalIgnoreCase)
+                || text.Trim().Equals("NG", StringComparison.OrdinalIgnoreCase)
+                || text.Trim().Equals("FAIL", StringComparison.OrdinalIgnoreCase))
             {
                 return Brushes.IndianRed;
             }
 
+            if (text.Trim().Equals("OK", StringComparison.OrdinalIgnoreCase)
+                || text.Trim().Equals("PASS", StringComparison.OrdinalIgnoreCase))
+            {
+                return Brushes.LimeGreen;
+            }
+
             return Brushes.Gray;
+        }
+
+        private static Brush MapStatus(BatchCellStatus status)
+        {
+            return status switch
+            {
+                BatchCellStatus.Ok => Brushes.LimeGreen,
+                BatchCellStatus.Nok => Brushes.IndianRed,
+                _ => Brushes.Gray
+            };
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Fix an incorrect UI color mapping in batch inspection where `Nok` values were rendered green because of substring checks for "OK".
- Ensure the converter treats `BatchCellStatus` enum values explicitly rather than relying on `ToString()` + `Contains` semantics.
- Locate and document where the converter resource is defined and applied in XAML so the mapping change is clearly traced to the UI.

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs` to explicitly handle `BatchCellStatus` and `int` values and to add a `MapStatus` switch that returns `Brushes.LimeGreen` for `BatchCellStatus.Ok` and `Brushes.IndianRed` for `BatchCellStatus.Nok`.
- Replaced case-insensitive `IndexOf/Contains` checks with exact `Equals` checks in `MapStatusText` and reordered negative checks before positive ones to avoid `NOK` matching `OK`.
- The converter resource is declared in `MainWindow.xaml` as `<conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />` and is applied to the batch `DataGridTemplateColumn` ROI ellipses via `Fill="{Binding ROI1, Converter={StaticResource BatchCellStatusToBrush}}"` (same for `ROI2`, `ROI3`, `ROI4`).
- No XAML resource key/name changes were made; only the converter implementation was hardened to avoid accidental substring matches.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964f32d8f80832bb79b5e627a1e69e1)