### PR TITLE
Fix: BatchCellStatusToBrushConverter handles BatchCellStatus explicitly

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using BrakeDiscInspector_GUI_ROI.Workflow;
 
 namespace BrakeDiscInspector_GUI_ROI.Converters
 {
@@ -25,12 +26,22 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
                 return boolValue ? Brushes.LimeGreen : Brushes.IndianRed;
             }
 
+            if (value is BatchCellStatus statusValue)
+            {
+                return MapStatus(statusValue);
+            }
+
+            if (value is int statusInt && Enum.IsDefined(typeof(BatchCellStatus), statusInt))
+            {
+                return MapStatus((BatchCellStatus)statusInt);
+            }
+
             if (value is string textValue)
             {
                 return MapStatusText(textValue);
             }
 
-            if (value is Enum || value is int)
+            if (value is Enum)
             {
                 return MapStatusText(value.ToString());
             }
@@ -43,6 +54,16 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
             return DependencyProperty.UnsetValue;
         }
 
+        private static Brush MapStatus(BatchCellStatus status)
+        {
+            return status switch
+            {
+                BatchCellStatus.Ok => Brushes.LimeGreen,
+                BatchCellStatus.Nok => Brushes.IndianRed,
+                _ => Brushes.Gray
+            };
+        }
+
         private static Brush MapStatusText(string text)
         {
             if (string.IsNullOrWhiteSpace(text) || text.Trim() == "-")
@@ -50,16 +71,17 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
                 return Brushes.Gray;
             }
 
-            if (text.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0
-                || text.IndexOf("PASS", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                return Brushes.LimeGreen;
-            }
-
-            if (text.IndexOf("NG", StringComparison.OrdinalIgnoreCase) >= 0
-                || text.IndexOf("FAIL", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (text.Equals("NOK", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("NG", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("FAIL", StringComparison.OrdinalIgnoreCase))
             {
                 return Brushes.IndianRed;
+            }
+
+            if (text.Equals("OK", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("PASS", StringComparison.OrdinalIgnoreCase))
+            {
+                return Brushes.LimeGreen;
             }
 
             return Brushes.Gray;


### PR DESCRIPTION
### Motivation
- The batch inspection grid showed NOK cells as green because the converter used string `Contains`/`IndexOf` checks so "Nok" matched "Ok" case-insensitively.  
- The converter is the single source of truth for drawing batch ROI status colors, so it must map the `BatchCellStatus` enum explicitly.  
- The `BatchCellStatusToBrushConverter` resource is declared in `MainWindow.xaml` and applied to the batch DataGrid ROI indicators, so fixing it fixes the UI symptom.  

### Description
- Updated `gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs` to add `using BrakeDiscInspector_GUI_ROI.Workflow;` and handle `BatchCellStatus` enum and integer values explicitly via a new `MapStatus` method.  
- Reworked string fallback logic in `MapStatusText` to avoid `Contains`/`IndexOf` and use exact `Equals` checks with negative statuses (`NOK`/`NG`/`FAIL`) evaluated before positives.  
- Preserved original boolean and generic-enum fallbacks and returned `Brushes.Gray` for unknown values.  
- Converter usage (XAML): resource defined as `<conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`, and applied to the batch grid ellipses as `Fill="{Binding ROI1, Converter={StaticResource BatchCellStatusToBrush}}"` (and similarly for `ROI2`, `ROI3`, `ROI4`).  

### Testing
- No automated tests were executed for this change.  
- No automated build or GUI run was performed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964f2bb6268832b9168279af46512fc)