### PR TITLE
Add missing BatchCellStatus values and update brush converter

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/BatchCellStatusToBrushConverter.cs
@@ -60,6 +60,8 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
             {
                 BatchCellStatus.Ok => Brushes.LimeGreen,
                 BatchCellStatus.Nok => Brushes.IndianRed,
+                BatchCellStatus.AnchorFail => Brushes.IndianRed,
+                BatchCellStatus.Skipped => Brushes.Gray,
                 _ => Brushes.Gray
             };
         }
@@ -73,7 +75,8 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
 
             if (text.Trim().Equals("NOK", StringComparison.OrdinalIgnoreCase)
                 || text.Trim().Equals("NG", StringComparison.OrdinalIgnoreCase)
-                || text.Trim().Equals("FAIL", StringComparison.OrdinalIgnoreCase))
+                || text.Trim().Equals("FAIL", StringComparison.OrdinalIgnoreCase)
+                || text.Trim().Replace(" ", string.Empty).Equals("ANCHORFAIL", StringComparison.OrdinalIgnoreCase))
             {
                 return Brushes.IndianRed;
             }
@@ -84,17 +87,12 @@ namespace BrakeDiscInspector_GUI_ROI.Converters
                 return Brushes.LimeGreen;
             }
 
-            return Brushes.Gray;
-        }
-
-        private static Brush MapStatus(BatchCellStatus status)
-        {
-            return status switch
+            if (text.Trim().Equals("SKIPPED", StringComparison.OrdinalIgnoreCase))
             {
-                BatchCellStatus.Ok => Brushes.LimeGreen,
-                BatchCellStatus.Nok => Brushes.IndianRed,
-                _ => Brushes.Gray
-            };
+                return Brushes.Gray;
+            }
+
+            return Brushes.Gray;
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/BatchCellStatus.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/BatchCellStatus.cs
@@ -4,6 +4,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
     {
         Unknown = 0,
         Ok = 1,
-        Nok = 2
+        Nok = 2,
+        AnchorFail = 3,
+        Skipped = 4
     }
 }


### PR DESCRIPTION
### Motivation

- Fix compile errors where `BatchCellStatus` was missing `AnchorFail` and `Skipped` values referenced by the UI converter.  
- Ensure batch UI cells render the correct brush for anchor failures and skipped items.  
- Keep enum/text-to-brush mapping consistent between enum values and string labels.  
- Remove duplicate converter implementation to avoid code duplication.

### Description

- Add `AnchorFail` and `Skipped` to the `BatchCellStatus` enum in `Workflow/BatchCellStatus.cs`.  
- Update `BatchCellStatusToBrushConverter.MapStatus` to map `AnchorFail` to `Brushes.IndianRed` and `Skipped` to `Brushes.Gray`.  
- Extend `MapStatusText` to recognize `ANCHORFAIL` (ignoring spaces) and `SKIPPED` string labels and map them to the same brushes.  
- Remove the duplicated `MapStatus` implementation and tidy the converter file.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69655b96111c832b82b91699b4ee1023)