### PR TITLE
Backend dataset sidecars + dataset infer/calibrate; enforce CUDA; GUI backend dataset sync and circle resize lock

### DIFF
--- a/backend/tests/test_app_fastapi.py
+++ b/backend/tests/test_app_fastapi.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -50,6 +51,8 @@ if "backend.features" not in sys.modules:  # pragma: no cover
     features_any = cast(Any, features_stub)
     features_any.DinoV2Features = _StubFeatures
     sys.modules["backend.features"] = features_stub
+
+os.environ.setdefault("BDI_REQUIRE_CUDA", "0")
 
 from backend import app as app_mod
 

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -16,6 +16,7 @@ The backend located in `backend/` exposes the same endpoints implemented in `bac
 - Environment variables prefixed with `BDI_` (or legacy `BRAKEDISC_`) configure the server (see `_env_var` in `app.py` and `backend/config.py`). Relevant keys:
   - `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`: default `127.0.0.1:8000`.
   - `BDI_MODELS_DIR`: directory for embeddings/calibration (default `models`).
+  - `BDI_REQUIRE_CUDA`: when `1` (default), the backend fails to start if CUDA is unavailable. Set to `0` for CI/tests.
   - `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`: override inference defaults.
   - `BDI_CORS_ORIGINS`: comma-separated list for CORS (`*` by default).
   - `BDI_BACKEND_BASEURL` is consumed by the GUI client, not the server.
@@ -29,14 +30,16 @@ The backend located in `backend/` exposes the same endpoints implemented in `bac
     <role>__<roi>.npz          # embeddings + token grid (+metadata JSON string)
     <role>__<roi>_index.faiss  # optional FAISS index (if faiss is installed)
     <role>__<roi>_calib.json   # stored output of /calibrate_ng
-  datasets/<role>/<roi>/ok|ng  # if scripts choose to reuse ModelStore for datasets
+  recipes/<recipe_id>/datasets/<role>__<roi>/ok|ng
+    <uuid>.<ext>              # dataset images
+    <uuid>.json               # sidecar metadata (mm_per_px, shape_json, etc.)
 ```
 File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_name`), so the exact ids sent by the GUI remain round-trippable even if they contain dashes. `recipe_id` and `model_key` (defaults to `roi_id`) are sanitized and used to namespace artefacts under `recipes/`. Legacy layouts (`models/<role>/<roi>/memory.npz`, or flat `<role>_<roi>.npz`) are still read for backward compatibility.
 
 ## Endpoint behaviour
 - `GET /health`: returns `{status, device, model, version, request_id, recipe_id}`; device is `cuda` when `torch.cuda.is_available()`. Includes `reason: cuda_not_available` on CPU-only hosts.
 - `POST /fit_ok`:
-  - Input: multipart form with `role_id`, `roi_id`, `mm_per_px`, optional `memory_fit` flag, multiple `images` (PNG/JPG ROI crops).
+  - Input: multipart form with `role_id`, `roi_id`, `mm_per_px`, optional `memory_fit` flag, optional `use_dataset` flag, and multiple `images` (PNG/JPG ROI crops).
   - For each image `_extractor.extract` is called; the embeddings are concatenated, a coreset is built via `PatchCoreMemory.build` and persisted through `ModelStore.save_memory`. If FAISS is installed its serialised index is also saved.
   - Output: JSON with `n_embeddings`, `coreset_size`, `token_shape`, `coreset_rate_requested`, `coreset_rate_applied`, `request_id`, `recipe_id`.
 - `POST /calibrate_ng`:
@@ -47,7 +50,9 @@ File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_
   - Response: `{score, threshold?, token_shape, heatmap_png_base64?, regions[], request_id, recipe_id}`. `heatmap_png_base64` is the grayscale PNG produced by encoding `heatmap_u8`. The GUI always sends the ROI mask (`shape`) and `mm_per_px`, so `roi_mask.py` uses the exact crop geometry while `infer` converts `area_px` to `area_mm2` for the returned regions.
   - Errors: `400` for missing memory or token mismatch (message in the `error` field); `500` responses include `{error, trace, request_id, recipe_id}`.
 - `GET /manifest`: query `role_id`, `roi_id` and returns `ModelStore` availability plus calibration and dataset counts.
-- Dataset utilities: `/datasets/ok/upload`, `/datasets/ng/upload`, `/datasets/list`, `/datasets/file` (DELETE), `/datasets/clear` (DELETE).
+- `POST /infer_dataset`: runs inference over backend datasets using per-sample `mm_per_px` metadata.
+- `POST /calibrate_dataset`: calibrates threshold using backend datasets with per-sample `mm_per_px`.
+- Dataset utilities: `/datasets/ok/upload`, `/datasets/ng/upload` (accept `metas[]` JSON strings), `/datasets/list`, `/datasets/file` (GET/DELETE), `/datasets/meta`, `/datasets/clear` (DELETE).
 
 ## Logging
 `app.py` uses the helper `slog(event, **kw)` which prints JSON lines to stdout/stderr. Fields include `ts`, the logical event (`fit_ok.request`, `fit_ok.response`, etc.), `role_id`, `roi_id`, `request_id`, `recipe_id`, `elapsed_ms`, and error information. Request/recipe IDs are returned in every JSON response and mirrored in log lines for correlation.

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Windows.Controls;
+using System.Windows.Shapes;
 using BrakeDiscInspector_GUI_ROI;
 using Xunit;
 
@@ -47,6 +48,37 @@ public class RoiAdornerTests
         Assert.True(Math.Abs(annulus.Width - annulus.Height) < 1e-6);
         Assert.True(Math.Abs(roi.Width - roi.Height) < 1e-6);
         Assert.True(annulus.InnerRadius <= annulus.Width / 2.0 + 1e-6);
+    }
+
+    [StaFact]
+    public void ResizeByCorner_KeepsCircleUniform()
+    {
+        var roi = new RoiModel
+        {
+            Shape = RoiShape.Circle,
+            CX = 50,
+            CY = 50,
+            Width = 120,
+            Height = 80,
+            R = 60
+        };
+
+        var circle = new Ellipse
+        {
+            Width = 120,
+            Height = 80,
+            Tag = roi
+        };
+
+        Canvas.SetLeft(circle, 0);
+        Canvas.SetTop(circle, 0);
+
+        var adorner = new RoiAdorner(circle, (_, _) => { }, _ => { });
+
+        InvokeResizeByCorner(adorner, 30.0, -10.0, "NE");
+
+        Assert.True(Math.Abs(circle.Width - circle.Height) < 1e-6);
+        Assert.True(Math.Abs(roi.Width - roi.Height) < 1e-6);
     }
 
     private static void InvokeResizeByCorner(RoiAdorner adorner, double dx, double dy, string cornerName)

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -205,6 +205,7 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             bool isAnnulus = roi?.Shape == RoiShape.Annulus;
+            bool isCircle = roi?.Shape == RoiShape.Circle;
 
             Point[] cornerPositions = new Point[4];
             cornerPositions[0] = TransformPoint(GetCornerLocalPoint(Corner.NW, w, h));
@@ -218,7 +219,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 _corners[i].Arrange(new Rect(corner.X - r, corner.Y - r, 2 * r, 2 * r));
             }
 
-            if (isAnnulus)
+            bool hideEdges = isAnnulus || isCircle;
+            if (hideEdges)
             {
                 for (int i = 0; i < _edges.Length; i++)
                 {
@@ -383,7 +385,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     break;
             }
 
-            if (roi.Shape == RoiShape.Annulus)
+            if (roi.Shape == RoiShape.Annulus || roi.Shape == RoiShape.Circle)
             {
                 double widthCandidate = newWidth;
                 double heightCandidate = newHeight;
@@ -412,7 +414,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private void ResizeByEdge(double dragDx, double dragDy, Edge edge)
         {
             var roi = _shape.Tag as RoiModel;
-            if (roi == null || roi.Shape == RoiShape.Annulus) return;
+            if (roi == null || roi.Shape == RoiShape.Annulus || roi.Shape == RoiShape.Circle) return;
 
             double x = Canvas.GetLeft(_shape); if (double.IsNaN(x)) x = 0;
             double y = Canvas.GetTop(_shape); if (double.IsNaN(y)) y = 0;

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetDtos.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetDtos.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+
+namespace BrakeDiscInspector_GUI_ROI.Workflow
+{
+    public sealed class DatasetListResponse
+    {
+        public DatasetListClasses? classes { get; set; }
+    }
+
+    public sealed class DatasetListClasses
+    {
+        public DatasetClassDto? ok { get; set; }
+        public DatasetClassDto? ng { get; set; }
+    }
+
+    public sealed class DatasetListDto
+    {
+        public DatasetClassDto ok { get; set; } = new();
+        public DatasetClassDto ng { get; set; } = new();
+    }
+
+    public sealed class DatasetClassDto
+    {
+        public int count { get; set; }
+        public List<string> files { get; set; } = new();
+        public Dictionary<string, bool> meta { get; set; } = new();
+    }
+
+    public sealed class CalibrateDatasetResponse
+    {
+        public string? status { get; set; }
+        public double threshold { get; set; }
+        public int score_percentile { get; set; }
+        public double area_mm2_thr { get; set; }
+        public int n_ok { get; set; }
+        public int n_ng { get; set; }
+        public string? request_id { get; set; }
+        public string? recipe_id { get; set; }
+        public string? role_id { get; set; }
+        public string? roi_id { get; set; }
+        public string? model_key { get; set; }
+    }
+
+    public sealed class InferDatasetResponse
+    {
+        public string? status { get; set; }
+        public string? role_id { get; set; }
+        public string? roi_id { get; set; }
+        public string? recipe_id { get; set; }
+        public string? model_key { get; set; }
+        public string? request_id { get; set; }
+        public int n_total { get; set; }
+        public int n_errors { get; set; }
+        public List<InferDatasetItem> items { get; set; } = new();
+    }
+
+    public sealed class InferDatasetItem
+    {
+        public string? label { get; set; }
+        public string? filename { get; set; }
+        public double? mm_per_px { get; set; }
+        public double? score { get; set; }
+        public double? threshold { get; set; }
+        public List<Region>? regions { get; set; }
+        public int n_regions { get; set; }
+        public string? heatmap_png_base64 { get; set; }
+        public string? error { get; set; }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs
@@ -89,10 +89,11 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
     {
         public string role_id { get; set; } = string.Empty;
         public string roi_id { get; set; } = string.Empty;
+        public string label { get; set; } = string.Empty;
+        public string filename { get; set; } = string.Empty;
         public double mm_per_px { get; set; }
-        public string? shape_json { get; set; }
+        public object? shape_json { get; set; }
+        public string? created_at_utc { get; set; }
         public string? source_path { get; set; }
-        public double angle { get; set; }
-        public DateTime timestamp { get; set; }
     }
 }


### PR DESCRIPTION
### Motivation
- Treat backend as the single source of truth for datasets and store per-sample metadata (including `mm_per_px`) so inference/calibration use per-sample physical scale.
- Prevent circle ROI deformation in the GUI so circular ROIs always keep `Width == Height` after resizing.
- Require GPU by default for the extractor to ensure production deployments use CUDA, while allowing CI/tests to disable that via `BDI_REQUIRE_CUDA`.
- Provide backend-only dataset operations for calibration and batch inference so training/calibration can run without re-uploading images from the GUI.

### Description
- Backend: enforce CUDA by default with `REQUIRE_CUDA = os.getenv("BDI_REQUIRE_CUDA", "1")`, enable `cudnn.benchmark`, and force the extractor to `device="cuda"`/`half=True` when CUDA is available in `backend/app.py`.
- Backend storage/API: add sidecar meta support in `backend/storage.py` (`save_dataset_meta`, `load_dataset_meta`, `resolve_dataset_meta_existing`), list only image files and report meta presence, and delete sidecars on file delete.
- Backend endpoints (`backend/app.py`): extend uploads to accept `metas[]` and save JSON sidecars; add `GET /datasets/file` and `GET /datasets/meta`; make `/fit_ok` accept `use_dataset=true` to train from backend-stored OKs; add `POST /infer_dataset` (per-sample `mm_per_px`, optional heatmap) and `POST /calibrate_dataset` (calibrate threshold from backend dataset and persist via `store.save_calib`).
- GUI: lock circle behavior in `RoiAdorner.cs` (hide edge thumbs for circles and force uniform sizing in corner resize and disallow edge resize); add a unit test `ResizeByCorner_KeepsCircleUniform` in `RoiAdornerTests.cs`.
- GUI dataset flow (C#): add dataset DTOs and new `BackendClient` methods (`UploadDatasetSampleAsync`, `GetDatasetListAsync`, `DownloadDatasetFileAsync`, `GetDatasetMetaAsync`, `DeleteDatasetFileAsync`, `FitOkFromDatasetAsync`, `CalibrateDatasetAsync`, `InferDatasetAsync`), change `WorkflowViewModel` to upload samples to backend (not write canonical dataset as source of truth), cache thumbnails under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets`, refresh dataset lists from `GET /datasets/list`, and call backend dataset training/calibration endpoints.
- Docs/README: update `docs/API_CONTRACTS.md`, `docs/BACKEND.md`, `docs/FRONTEND.md`, and `README.md` to document `metas[]` uploads, `GET /datasets/file`, `GET /datasets/meta`, `POST /infer_dataset`, `POST /calibrate_dataset`, the `use_dataset` flag for `/fit_ok`, and the `BDI_REQUIRE_CUDA` flag.
- Tests: modified `backend/tests/test_app_fastapi.py` to set `BDI_REQUIRE_CUDA=0` for CI compatibility.

### Testing
- Unit/CI changes: the backend test fixture was updated to `os.environ.setdefault("BDI_REQUIRE_CUDA", "0")` so the test suite can import the app in CPU CI environments (no CUDA required); this change was committed to tests.
- GUI unit test added: `RoiAdornerTests.ResizeByCorner_KeepsCircleUniform` verifies circle resize keeps `Width == Height` (test added but not executed here).
- No automated tests were executed as part of this PR run; please run `pytest` (backend) and the GUI test runner in CI to validate integration with your environment and GPU availability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69655eafeb94832b94de02afee3e6917)