### PR TITLE
Fix GUI ROI designer build issues

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -217,7 +217,7 @@
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
         </Style>
         <Style TargetType="{x:Type ui:ToggleSwitch}"
-               BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}">
+               BasedOn="{DynamicResource {x:Type ui:ToggleSwitch}}">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml
@@ -8,11 +8,11 @@
              d:DesignHeight="140"
              d:DesignWidth="420">
     <StackPanel>
-        <TextBlock Text="{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}"
+        <TextBlock Text="{Binding Title, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:DatasetPreviewStripView}}}"
                    FontWeight="SemiBold"
                    Margin="0,6,0,4"/>
-        <ListBox ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}}"
-                 SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType={x:Type w:DatasetPreviewStripView}}, Mode=TwoWay}"
+        <ListBox ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:DatasetPreviewStripView}}}"
+                 SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:DatasetPreviewStripView}}, Mode=TwoWay}"
                  BorderThickness="0"
                  Background="Transparent"
                  Height="110"

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs
@@ -91,6 +91,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         public string roi_id { get; set; } = string.Empty;
         public string label { get; set; } = string.Empty;
         public string filename { get; set; } = string.Empty;
+        public double? angle { get; set; }
+        public DateTime? timestamp { get; set; }
         public double mm_per_px { get; set; }
         public object? shape_json { get; set; }
         public string? created_at_utc { get; set; }

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
@@ -9,7 +9,7 @@ using BrakeDiscInspector_GUI_ROI.Workflow;
 
 namespace BrakeDiscInspector_GUI_ROI.Workflow.DesignTime
 {
-    internal sealed class DesignWorkflowViewModel
+    public sealed class DesignWorkflowViewModel
     {
         private const int ThumbnailWidth = 120;
         private const int ThumbnailHeight = 90;

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
@@ -74,14 +74,14 @@
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,6,0,0">
                 <ui:Button Padding="12,4"
                            Margin="0,0,8,0"
-                           Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                          Command="{Binding DataContext.BrowseDatasetCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Browse..." VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
                 <ui:Button Padding="12,4"
-                           Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                          Command="{Binding DataContext.OpenDatasetFolderCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Folder24}" Margin="0,0,8,0"/>
                         <TextBlock Text="Open Folder" VerticalAlignment="Center"/>
@@ -134,7 +134,7 @@
             </ui:Button>
             <ui:Button Padding="12,4"
                        Margin="0,0,8,0"
-                       Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                      Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                     <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>
@@ -142,7 +142,7 @@
             </ui:Button>
             <ui:Button Padding="12,4"
                        Margin="0,0,8,0"
-                       Command="{Binding DataContext.TrainSelectedRoiCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                      Command="{Binding DataContext.TrainSelectedRoiCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Rocket24}" Margin="0,0,8,0"/>
                     <TextBlock Text="Train" VerticalAlignment="Center"/>
@@ -150,14 +150,14 @@
             </ui:Button>
             <ui:Button Padding="12,4"
                        Margin="0,0,8,0"
-                       Command="{Binding DataContext.CalibrateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                      Command="{Binding DataContext.CalibrateSelectedRoiCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Wrench24}" Margin="0,0,8,0"/>
                     <TextBlock Text="Calibrate" VerticalAlignment="Center"/>
                 </StackPanel>
             </ui:Button>
             <ui:Button Padding="12,4"
-                       Command="{Binding DataContext.EvaluateSelectedRoiCommand, RelativeSource={RelativeSource AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                      Command="{Binding DataContext.EvaluateSelectedRoiCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Search24}" Margin="0,0,8,0"/>
                     <TextBlock Text="Evaluate ROI" VerticalAlignment="Center"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -35,7 +35,7 @@
 
             <GroupBox Header="Inspection ROIs"
                       Visibility="{Binding ShowInspectionDatasetSection,
-                                           RelativeSource={RelativeSource AncestorType={x:Type w:WorkflowControl}},
+                                           RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:WorkflowControl}},
                                            Converter={StaticResource BoolToVis}}">
                 <DockPanel Margin="8">
                     <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">


### PR DESCRIPTION
### Motivation
- Resolve compile-time and XAML designer failures caused by missing metadata fields and design-time type visibility which produced cascading XDG errors.
- Ensure the XAML designer can resolve ancestor bindings by making `RelativeSource` usage explicit.
- Prevent design-time resource lookup hard-fails for the `ToggleSwitch` base style.

### Description
- Added nullable properties `angle` and `timestamp` to `SampleMetadata` in `gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetSample.cs` to satisfy `DatasetManager` usage.
- Made the design-time view model `DesignWorkflowViewModel` `public` in `gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs` so the XAML designer can instantiate it.
- Updated bindings to include `RelativeSource Mode=FindAncestor` in `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml`, `gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml`, and `gui/BrakeDiscInspector_GUI_ROI/Workflow/DatasetPreviewStripView.xaml` to address XDG0031 designer requirements.
- Changed the `BasedOn` lookup for `ui:ToggleSwitch` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` from `StaticResource` to `DynamicResource` to defer style resolution at design-time.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965f4531d4c832bbc3ad8896ddd4b9c)