### PR TITLE
Use StaticResource for ToggleSwitch BasedOn to fix XamlParseException

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -217,7 +217,7 @@
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
         </Style>
         <Style TargetType="{x:Type ui:ToggleSwitch}"
-               BasedOn="{DynamicResource {x:Type ui:ToggleSwitch}}">
+               BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />


### PR DESCRIPTION
### Motivation
- The app crashed at runtime with a `XamlParseException` because `Style.BasedOn` was set with a `DynamicResource`, which is invalid since `BasedOn` is not a `DependencyProperty`.
- The goal is to remove the runtime crash while keeping the ToggleSwitch UI rendering identical to the Wpf.Ui base style.

### Description
- Replaced `BasedOn="{DynamicResource {x:Type ui:ToggleSwitch}}"` with `BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}"` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` to avoid the runtime error.
- Preserved the existing `Setter` values which remain as `DynamicResource` so runtime theming behavior is unchanged.
- Verified that `gui/BrakeDiscInspector_GUI_ROI/App.xaml` already merges `ui:ThemesDictionary` and `ui:ControlsDictionary`, so no changes were necessary there.

### Testing
- Attempted an automated build with `dotnet build ./gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj -c Debug`, but the `dotnet` CLI is not available in the execution environment so the build could not be run.
- No other automated tests were executed in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965f7b6ac00832b9ca95ebb537a5133)