### PR TITLE
Remove ResultLabel usage and report inference results via log/snackbar

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -2061,12 +2061,6 @@
                         Content="Heatmap"
                         IsChecked="True"
                         Margin="0,0,8,0"/>
-                        <TextBlock x:Name="ResultLabel"
-                         Text="Result: --"
-                         Foreground="LightGreen"
-                         FontFamily="Segoe UI"
-                         FontWeight="SemiBold"
-                         Margin="0,0,8,0"/>
                         <TextBlock x:Name="HeatmapScaleLabel"
                          Text="Heatmap Scale: 1.00"
                          Foreground="#39FF14"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -14332,16 +14332,21 @@ namespace BrakeDiscInspector_GUI_ROI
                 };
                 var resp = await BackendAPI.InferAsync(request);
 
-                // 6) Mostrar texto (si tienes el TextBlock en XAML)
+                // 6) Reportar resultado sin UI dedicada
                 bool isNg = resp.threshold.HasValue && resp.score > resp.threshold.Value;
                 _lastIsNg = isNg;
-                if (ResultLabel != null)
+                string thrText = resp.threshold.HasValue ? resp.threshold.Value.ToString("0.###") : "n/a";
+                var msg = isNg
+                    ? $"NG (score={resp.score:F3} / thr {thrText})"
+                    : $"OK (score={resp.score:F3} / thr {thrText})";
+                AppendLog(msg);
+                try
                 {
-                    string thrText = resp.threshold.HasValue ? resp.threshold.Value.ToString("0.###") : "n/a";
-                    ResultLabel.Text = isNg
-                        ? $"NG (score={resp.score:F3} / thr {thrText})"
-                        : $"OK (score={resp.score:F3} / thr {thrText})";
-                    ResultLabel.Foreground = isNg ? Brushes.OrangeRed : Brushes.LightGreen;
+                    Snack(msg);
+                }
+                catch
+                {
+                    System.Windows.MessageBox.Show(msg);
                 }
 
                 // 7) Decodificar heatmap y pintarlo en el Image del XAML


### PR DESCRIPTION
### Motivation
- The UI `ResultLabel` was removed from XAML but code-behind still referenced it, causing CS0103 compile errors. 
- The project’s upstream pattern reports inspection results via logging and snackbar rather than a dedicated label. 
- Preserve end-user feedback for inference results while removing the obsolete UI control. 
- Avoid re-adding the `ResultLabel` control to XAML and remove all code references to it.

### Description
- Deleted the `ResultLabel` `TextBlock` from `MainWindow.xaml` in the heatmap HUD to remove the UI element entirely. 
- Replaced the code that updated `ResultLabel` in `MainWindow.xaml.cs` with a non-UI reporting block that builds the same result text, calls `AppendLog(msg)`, and then attempts `Snack(msg)` falling back to `System.Windows.MessageBox.Show(msg)` if `Snack` is unavailable. 
- Removed usage of label color/foreground (no UI color recreation) and kept only the textual message content. 
- Files changed: `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` (removed `ResultLabel` TextBlock) and `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` (replaced ResultLabel updates with log/snackbar reporting).

### Testing
- Confirmed there are zero remaining `ResultLabel` occurrences in `gui/BrakeDiscInspector_GUI_ROI` by repository search. 
- Attempted to build with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` but the environment lacks `dotnet`, so the build could not be executed here. 
- Changes were added and committed locally (`Remove ResultLabel usage`). 
- Manual runtime verification is recommended (launch the app) to ensure `Snack(...)` is available and inference results surface via snackbar/log without crashes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696643d69904832b97b35d39c03c15fd)