### PR TITLE
Disable inspection ROIs by default on blank layouts

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs
@@ -244,6 +244,18 @@ namespace BrakeDiscInspector_GUI_ROI
                 loadedFromFile = false;
             }
 
+            // If we are effectively in "no valid layout loaded" mode, do NOT preload any inspection ROI as enabled.
+            if (!loadedFromFile && layout.InspectionRois != null)
+            {
+                foreach (var roi in layout.InspectionRois)
+                {
+                    if (roi != null)
+                    {
+                        roi.Enabled = false;
+                    }
+                }
+            }
+
             layout.Master2Pattern ??= new RoiModel { Role = RoiRole.Master2Pattern };
             layout.Master2Search ??= new RoiModel { Role = RoiRole.Master2Search };
             return (layout, loadedFromFile);

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
@@ -20,7 +20,7 @@ namespace BrakeDiscInspector_GUI_ROI.Models
     {
         private int _index;
         private string _id;
-        private bool _enabled = true;
+        private bool _enabled = false;
         private bool _isEditable;
         private string _modelKey;
         private double _threshold;
@@ -48,7 +48,7 @@ namespace BrakeDiscInspector_GUI_ROI.Models
         public InspectionRoiConfig(int index)
         {
             Index = index;
-            _enabled = index <= 2;
+            _enabled = false;
             _name = $"Inspection {index}";
             _modelKey = $"inspection-{index}";
             _id = $"Inspection_{index}";


### PR DESCRIPTION
### Motivation
- At app startup with no layout loaded the HUD showed `Inspection 1` and `Inspection 2` because inspection ROI configs were auto-enabled by default. 
- The expected behavior is that a new/blank layout shows no inspection ROIs until the user enables them or a real layout file explicitly sets them. 
- Changes must preserve persisted `Enabled` values when a layout is actually loaded from disk. 

### Description
- Changed the default enabled flag in `gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs` by setting `private bool _enabled = false` and initializing `_enabled = false` in the `InspectionRoiConfig(int index)` constructor. 
- Removed the prior auto-enable rule (`_enabled = index <= 2`) so newly created inspection ROI configs start disabled. 
- Added a guard in `gui/BrakeDiscInspector_GUI_ROI/MasterLayout.cs` inside `MasterLayoutManager.LoadOrNew` that, when `loadedFromFile` is `false`, iterates `layout.InspectionRois` and sets `roi.Enabled = false` to ensure blank/incomplete layouts never preload enabled inspection ROIs. 
- These changes ensure real layouts keep their persisted `Enabled` values while blank or invalid-loaded layouts do not show any inspection ROI by default. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696658710d7c832b9df6a4988572d253)