### PR TITLE
Fix IsImageLoaded name collision in MainWindow

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4910,7 +4910,6 @@ namespace BrakeDiscInspector_GUI_ROI
         private bool GetShowMaster2Pattern() => ViewModel?.ShowMaster2Pattern ?? true;
         private bool GetShowMaster2Inspection() => ViewModel?.ShowMaster2Inspection ?? true;
         private bool GetShowInspectionRoi() => ViewModel?.ShowInspectionRoi ?? true;
-        private bool IsImageLoaded() => ViewModel?.IsImageLoaded == true;
 
         private bool IsInspectionRoiEnabled(int index)
         {
@@ -5936,7 +5935,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
-            if (!IsImageLoaded())
+            if (!IsImageLoaded)
             {
                 ClearPersistedRoisFromCanvas();
                 return;
@@ -7891,7 +7890,7 @@ namespace BrakeDiscInspector_GUI_ROI
             int count = 0;
             RoiHudStack.Children.Clear();
 
-            if (!IsImageLoaded())
+            if (!IsImageLoaded)
             {
                 RoiHudOverlay.Visibility = Visibility.Collapsed;
                 return;


### PR DESCRIPTION
### Motivation
- The project reported a CS0102 error due to a duplicate definition for `IsImageLoaded` in `MainWindow.xaml.cs`. 
- The duplicate helper method conflicted with the existing `IsImageLoaded` property and could lead to ambiguous calls and maintenance problems. 
- The change aims to remove the redundant implementation and standardize on the single property accessor for image-loaded checks. 

### Description
- Removed the private helper method `IsImageLoaded()` from `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`. 
- Updated call sites that used `IsImageLoaded()` to reference the `IsImageLoaded` property directly (e.g., in `RedrawOverlay` and `UpdateRoiHud`). 
- The modification is local to `MainWindow.xaml.cs` and maintains the existing public property semantics. 

### Testing
- No automated tests were executed as part of this change. 
- A compile-time duplicate-definition error (CS0102) that motivated this change should be resolved by these edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966637ec99c832b996f3e1f0c04dd58)