### PR TITLE
Add persistent bottom-right HUD showing current layout name

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -2012,6 +2012,23 @@
                     </Border>
                 </Grid>
 
+                <Border x:Name="LayoutNameHud"
+                        Grid.Row="1"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Margin="0,0,12,12"
+                        Padding="8,4"
+                        CornerRadius="4"
+                        Background="#7F000000"
+                        IsHitTestVisible="False"
+                        Panel.ZIndex="950">
+                    <TextBlock Text="{Binding LayoutNameDisplay}"
+                               FontSize="12"
+                               FontWeight="SemiBold"
+                               Foreground="White"
+                               TextTrimming="CharacterEllipsis"/>
+                </Border>
+
                 <StackPanel Grid.Row="2"
                             Orientation="Horizontal"
                             HorizontalAlignment="Left"

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -294,11 +294,28 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         private bool _isInitializing;
         private string? _annotatedOutputDir;
         private string _currentLayoutName = "DefaultLayout";
+        private bool _hasLoadedLayout;
         private int _layoutIoDepth;
         private readonly SemaphoreSlim _captureGate = new(1, 1);
         private bool _sharedHeatmapGuardLogged;
 
         public string CurrentLayoutName => _currentLayoutName;
+
+        public bool HasLoadedLayout
+        {
+            get => _hasLoadedLayout;
+            private set
+            {
+                if (_hasLoadedLayout != value)
+                {
+                    _hasLoadedLayout = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(LayoutNameDisplay));
+                }
+            }
+        }
+
+        public string LayoutNameDisplay => HasLoadedLayout ? CurrentLayoutName : "Layout not loaded";
 
         public int AnchorScoreMin { get; set; } = 85;
 
@@ -608,11 +625,18 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             var isReservedLast = string.Equals(normalized, "last", StringComparison.OrdinalIgnoreCase);
 
             _currentLayoutName = normalized;
+            OnPropertyChanged(nameof(CurrentLayoutName));
+            OnPropertyChanged(nameof(LayoutNameDisplay));
 
             // Si es "last", no mandamos header (backend resolverá 'default').
             _client.RecipeId = isReservedLast ? null : _currentLayoutName;
 
             InvalidateMasterPatternCache();
+        }
+
+        public void SetLayoutLoadedState(bool hasLoadedLayout)
+        {
+            HasLoadedLayout = hasLoadedLayout;
         }
 
         public void AlignDatasetPathsWithCurrentLayout()


### PR DESCRIPTION
### Motivation
- Provide a small persistent HUD on the main canvas that shows either the loaded layout name or `Layout not loaded` so users always see recipe context.
- Ensure the HUD does not interfere with canvas interactions (ROI editing, zoom/pan) by keeping it non-interactive and on a top visual layer.
- Keep the display in sync with layout lifecycle events (load, save, clear) and respect the existing semantics for ephemeral `last` layouts.
- Surface a single ViewModel property that is easy to bind from XAML and updates when layout state/name change.

### Description
- Added `HasLoadedLayout` and `LayoutNameDisplay` properties to `WorkflowViewModel` and added change notifications in `SetLayoutName` so the UI updates when the layout name changes (`gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs`).
- Added `SetLayoutLoadedState(bool)` on the ViewModel to allow the host to indicate whether a valid layout is loaded and updated `LayoutNameDisplay` accordingly.
- Implemented `UpdateLayoutLoadedState(MasterLayout?, string?)` in `MainWindow.xaml.cs` and invoked it when initializing the workflow, applying/loading/saving layouts, and when clearing the canvas so the HUD reflects lifecycle changes (`gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`).
- Inserted a bottom-right HUD element in `MainWindow.xaml` (`Border` + `TextBlock`) bound to `LayoutNameDisplay` with `IsHitTestVisible="False"` and high `Panel.ZIndex` so it is visually on top but does not capture input (`gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696683c4ac74832ba5139af20c7bf29a)