### PR TITLE
Highlight selected left navigation items

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -140,6 +140,7 @@
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Setter Property="HorizontalContentAlignment" Value="Left" />
             <Setter Property="Padding" Value="12,8" />
@@ -1858,73 +1859,177 @@
                 Background="{DynamicResource BrushAppBackground}"
                 Margin="0">
             <StackPanel Margin="8">
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                           Click="NavLayoutSetup_Click">
+                <ui:Button Click="NavLayoutSetup_Click">
+                    <ui:Button.Style>
+                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                             Value="LayoutSetup">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:Button.Style>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
+                                       FontSize="18"
+                                       Margin="0,0,10,0"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Layout Setup" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                           Click="NavRoiManagement_Click">
+                <ui:Button Click="NavRoiManagement_Click">
+                    <ui:Button.Style>
+                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                             Value="RoiManagement">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:Button.Style>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}" FontSize="18" Margin="0,0,10,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}"
+                                       FontSize="18"
+                                       Margin="0,0,10,0"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
                 <!-- Submenú colapsable: mismo tamaño/estilo que el resto, con tabulación -->
                 <StackPanel x:Name="RoiNavSubmenu" Visibility="Collapsed" Margin="0">
-                    <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectMaster_Click">
+                    <ui:Button Click="RoiManagementSelectMaster_Click">
+                        <ui:Button.Style>
+                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                                <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                 Value="MasterRois">
+                                        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ui:Button.Style>
                         <!-- Tabulación: indentamos SOLO el contenido para mantener mismo ancho/alineación del botón -->
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}" FontSize="18" Margin="0,0,10,0"/>
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}"
+                                           FontSize="18"
+                                           Margin="0,0,10,0"
+                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
 
                     <!-- Sub-submenú: visible solo cuando se selecciona Master ROIs -->
                     <StackPanel x:Name="MasterRoiSubmenu" Visibility="Collapsed" Margin="0">
-                        <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="NavMasterAdvanced_Click">
+                        <ui:Button Click="NavMasterAdvanced_Click">
+                            <ui:Button.Style>
+                                <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                     Value="MasterAdvanced">
+                                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ui:Button.Style>
                             <!-- tabulación para subnivel -->
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="40,0,0,0">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}" FontSize="18" Margin="0,0,10,0"/>
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
+                                               FontSize="18"
+                                               Margin="0,0,10,0"
+                                               Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                                 <TextBlock Text="Advanced" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
 
-                    <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                               Click="RoiManagementSelectInspection_Click">
+                    <ui:Button Click="RoiManagementSelectInspection_Click">
+                        <ui:Button.Style>
+                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                                <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                 Value="InspectionRois">
+                                        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ui:Button.Style>
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}" FontSize="18" Margin="0,0,10,0"/>
+                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
+                                           FontSize="18"
+                                           Margin="0,0,10,0"
+                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
                         </StackPanel>
                     </ui:Button>
 
                     <StackPanel x:Name="InspectionRoiSubmenu" Visibility="Collapsed" Margin="0">
-                        <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                                   Click="RoiManagementInspectionDataset_Click">
+                        <ui:Button Click="RoiManagementInspectionDataset_Click">
+                            <ui:Button.Style>
+                                <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                                     Value="InspectionDataset">
+                                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ui:Button.Style>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="40,0,0,0">
-                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" FontSize="18" Margin="0,0,10,0"/>
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}"
+                                               FontSize="18"
+                                               Margin="0,0,10,0"
+                                               Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                                 <TextBlock Text="Dataset" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
                 </StackPanel>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                           Click="NavBatchInspection_Click">
+                <ui:Button Click="NavBatchInspection_Click">
+                    <ui:Button.Style>
+                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                             Value="BatchInspection">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:Button.Style>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}" FontSize="18" Margin="0,0,10,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}"
+                                       FontSize="18"
+                                       Margin="0,0,10,0"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Batch Inspection" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Style="{StaticResource LeftNavButtonStyle}"
-                           Click="NavComms_Click"
+                <ui:Button Click="NavComms_Click"
                            Margin="0">
+                    <ui:Button.Style>
+                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
+                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                             Value="Comms">
+                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:Button.Style>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}" FontSize="18" Margin="0,0,10,0"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}"
+                                       FontSize="18"
+                                       Margin="0,0,10,0"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Comms" VerticalAlignment="Center"/>
                     </StackPanel>
                 </ui:Button>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -194,6 +194,24 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
+        public static readonly DependencyProperty SelectedLeftMenuKeyProperty =
+            DependencyProperty.Register(
+                nameof(SelectedLeftMenuKey),
+                typeof(string),
+                typeof(MainWindow),
+                new PropertyMetadata(string.Empty));
+
+        public string SelectedLeftMenuKey
+        {
+            get => (string)GetValue(SelectedLeftMenuKeyProperty);
+            set => SetValue(SelectedLeftMenuKeyProperty, value);
+        }
+
+        private void SelectLeftMenu(string key)
+        {
+            SelectedLeftMenuKey = key ?? string.Empty;
+        }
+
         public RoiPanelMode RoiPanelMode
         {
             get => _roiPanelMode;
@@ -3728,6 +3746,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("LayoutSetup");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3739,6 +3758,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavRoiManagement_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("RoiManagement");
             var expand = RoiNavSubmenu.Visibility != Visibility.Visible;
             RoiNavSubmenu.Visibility = expand ? Visibility.Visible : Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3761,6 +3781,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("MasterRois");
             RoiPanelMode = RoiPanelMode.Master;
             MasterRoiSubmenu.Visibility = Visibility.Visible;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3770,6 +3791,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("InspectionRois");
             RoiPanelMode = RoiPanelMode.Inspection;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Visible;
@@ -3780,18 +3802,21 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementInspectionDataset_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("InspectionDataset");
             var open = InspectionDatasetPanel?.Visibility != Visibility.Visible;
             SetInspectionDatasetView(open);
         }
 
         private void NavMasterAdvanced_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("MasterAdvanced");
             var show = MasterAdvancedOptionsPanel?.Visibility != Visibility.Visible;
             SetMasterAdvancedOpen(show);
         }
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("BatchInspection");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3803,6 +3828,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavComms_Click(object sender, RoutedEventArgs e)
         {
+            SelectLeftMenu("Comms");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -9237,6 +9263,23 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             InitComms();
+
+            if (LayoutSetupPanel?.Visibility == Visibility.Visible)
+            {
+                SelectLeftMenu("LayoutSetup");
+            }
+            else if (RoiManagementPanel?.Visibility == Visibility.Visible)
+            {
+                SelectLeftMenu("RoiManagement");
+            }
+            else if (BatchInspectionPanel?.Visibility == Visibility.Visible)
+            {
+                SelectLeftMenu("BatchInspection");
+            }
+            else if (CommsPanel?.Visibility == Visibility.Visible)
+            {
+                SelectLeftMenu("Comms");
+            }
 
             RefreshCreateButtonsEnabled();
             GuiLog.Info($"[BOOT] MainWindow_Loaded EXIT"); // CODEX: string interpolation compatibility.


### PR DESCRIPTION
### Motivation
- Ensure the LEFT navigation panel maintains a persistent selection so only one menu or submenu item appears selected (Accent foreground) until another is clicked.
- Use theme resources rather than hard-coded colors so the selected and normal foregrounds follow the app theme (`UI.Brush.Accent` and `UI.Brush.ButtonForeground`).
- Make icons inherit the same Foreground as their parent button so icon and text color change together when selected.
- Keep existing navigation behavior and layout unchanged, only add selection state and styling.

### Description
- Added a `SelectedLeftMenuKey` `DependencyProperty` and helper `SelectLeftMenu(string)` to `MainWindow` to store the currently selected left-menu key.
- Updated all left-nav click handlers to call `SelectLeftMenu("<Key>")` at the start so selection state is set before other logic runs.
- Set a default `Foreground` in `LeftNavButtonStyle` and added per-button `Style` wrappers with a `DataTrigger` that compares `SelectedLeftMenuKey` and sets `Foreground` to `UI.Brush.Accent` when matched.
- Bound each `ui:SymbolIcon` `Foreground` to the button `Foreground` so icons visually follow selection state.

### Testing
- No automated tests were executed for this change because it is a UI-only behavior update.
- The change is confined to `MainWindow.xaml` and `MainWindow.xaml.cs` and does not change layout, margins, or existing click behavior.
- Manual UI validation is recommended to confirm the selection persists after mouse leave, icons/text color switch to `UI.Brush.Accent`, and only one item is selected at a time.
- If desired, run the application and interact with the left nav to verify selection behavior visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966a20d89b8832b8b98913fd68a5cec)