### PR TITLE
Persist left-nav selection styling

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Converters/NavKeyEqualsConverter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Converters/NavKeyEqualsConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace BrakeDiscInspector_GUI_ROI.Converters
+{
+    public sealed class NavKeyEqualsConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            var selected = values != null && values.Length > 0 ? values[0] as string : null;
+            var key = values != null && values.Length > 1 ? values[1] as string : null;
+
+            if (string.IsNullOrWhiteSpace(selected) || string.IsNullOrWhiteSpace(key))
+            {
+                return false;
+            }
+
+            return string.Equals(selected, key, StringComparison.Ordinal);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => throw new NotSupportedException();
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Helpers/NavSelection.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Helpers/NavSelection.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+
+namespace BrakeDiscInspector_GUI_ROI
+{
+    public static class NavSelection
+    {
+        public static readonly DependencyProperty KeyProperty =
+            DependencyProperty.RegisterAttached(
+                "Key",
+                typeof(string),
+                typeof(NavSelection),
+                new PropertyMetadata(default(string)));
+
+        public static void SetKey(DependencyObject element, string value) => element.SetValue(KeyProperty, value);
+
+        public static string GetKey(DependencyObject element) => (string)element.GetValue(KeyProperty);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -24,7 +24,20 @@
         <conv:BoolToBrushConverter x:Key="BoolToBrush" />
         <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
         <conv:RoiPanelModeToVisibilityConverter x:Key="RoiPanelModeToVisibility" />
+        <conv:NavKeyEqualsConverter x:Key="NavKeyEquals" />
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+
+        <DropShadowEffect x:Key="LeftNavSelectedShadow"
+                          ShadowDepth="0"
+                          BlurRadius="8"
+                          Opacity="0.28"
+                          Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" />
+
+        <DropShadowEffect x:Key="LeftNavHoverShadow"
+                          ShadowDepth="0"
+                          BlurRadius="12"
+                          Opacity="0.35"
+                          Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" />
 
         <Style x:Key="TitleTextStyle" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Header}" />
@@ -147,14 +160,22 @@
             <Setter Property="Margin" Value="0,0,0,8" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
-                    <Setter Property="Effect">
-                        <Setter.Value>
-                            <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.35"
-                                              Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" />
-                        </Setter.Value>
-                    </Setter>
+                    <Setter Property="Effect" Value="{StaticResource LeftNavHoverShadow}" />
+                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
                 </Trigger>
+
+                <DataTrigger Value="True">
+                    <DataTrigger.Binding>
+                        <MultiBinding Converter="{StaticResource NavKeyEquals}">
+                            <Binding RelativeSource="{RelativeSource AncestorType={x:Type Window}}"
+                                     Path="SelectedLeftNavKey" />
+                            <Binding RelativeSource="{RelativeSource Self}"
+                                     Path="(local:NavSelection.Key)" />
+                        </MultiBinding>
+                    </DataTrigger.Binding>
+                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+                    <Setter Property="Effect" Value="{StaticResource LeftNavSelectedShadow}" />
+                </DataTrigger>
             </Style.Triggers>
         </Style>
 
@@ -1859,178 +1880,122 @@
                 Background="{DynamicResource BrushAppBackground}"
                 Margin="0">
             <StackPanel Margin="8">
-                <ui:Button Click="NavLayoutSetup_Click">
-                    <ui:Button.Style>
-                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                             Value="LayoutSetup">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ui:Button.Style>
+                <ui:Button Click="NavLayoutSetup_Click"
+                           Style="{StaticResource LeftNavButtonStyle}"
+                           local:NavSelection.Key="LayoutSetup">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                        <TextBlock Text="Layout Setup" VerticalAlignment="Center"/>
+                        <TextBlock Text="Layout Setup"
+                                   VerticalAlignment="Center"
+                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                     </StackPanel>
                 </ui:Button>
-                <ui:Button Click="NavRoiManagement_Click">
-                    <ui:Button.Style>
-                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                             Value="RoiManagement">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ui:Button.Style>
+                <ui:Button Click="NavRoiManagement_Click"
+                           Style="{StaticResource LeftNavButtonStyle}"
+                           local:NavSelection.Key="RoiManagement">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                        <TextBlock Text="ROI Management" VerticalAlignment="Center"/>
+                        <TextBlock Text="ROI Management"
+                                   VerticalAlignment="Center"
+                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                     </StackPanel>
                 </ui:Button>
                 <!-- Submenú colapsable: mismo tamaño/estilo que el resto, con tabulación -->
                 <StackPanel x:Name="RoiNavSubmenu" Visibility="Collapsed" Margin="0">
-                    <ui:Button Click="RoiManagementSelectMaster_Click">
-                        <ui:Button.Style>
-                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                                <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                 Value="MasterRois">
-                                        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ui:Button.Style>
+                    <ui:Button Click="RoiManagementSelectMaster_Click"
+                               Style="{StaticResource LeftNavButtonStyle}"
+                               local:NavSelection.Key="MasterRois">
                         <!-- Tabulación: indentamos SOLO el contenido para mantener mismo ancho/alineación del botón -->
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
                             <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}"
                                            FontSize="18"
                                            Margin="0,0,10,0"
                                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                            <TextBlock Text="Master ROIs" VerticalAlignment="Center"/>
+                            <TextBlock Text="Master ROIs"
+                                       VerticalAlignment="Center"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         </StackPanel>
                     </ui:Button>
 
                     <!-- Sub-submenú: visible solo cuando se selecciona Master ROIs -->
                     <StackPanel x:Name="MasterRoiSubmenu" Visibility="Collapsed" Margin="0">
-                        <ui:Button Click="NavMasterAdvanced_Click">
-                            <ui:Button.Style>
-                                <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                     Value="MasterAdvanced">
-                                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ui:Button.Style>
+                        <ui:Button Click="NavMasterAdvanced_Click"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   local:NavSelection.Key="MasterAdvanced">
                             <!-- tabulación para subnivel -->
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="40,0,0,0">
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
                                                FontSize="18"
                                                Margin="0,0,10,0"
                                                Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                                <TextBlock Text="Advanced" VerticalAlignment="Center"/>
+                                <TextBlock Text="Advanced"
+                                           VerticalAlignment="Center"
+                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
 
-                    <ui:Button Click="RoiManagementSelectInspection_Click">
-                        <ui:Button.Style>
-                            <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                                <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                 Value="InspectionRois">
-                                        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ui:Button.Style>
+                    <ui:Button Click="RoiManagementSelectInspection_Click"
+                               Style="{StaticResource LeftNavButtonStyle}"
+                               local:NavSelection.Key="InspectionRois">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
                             <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
                                            FontSize="18"
                                            Margin="0,0,10,0"
                                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                            <TextBlock Text="Inspection ROIs" VerticalAlignment="Center"/>
+                            <TextBlock Text="Inspection ROIs"
+                                       VerticalAlignment="Center"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         </StackPanel>
                     </ui:Button>
 
                     <StackPanel x:Name="InspectionRoiSubmenu" Visibility="Collapsed" Margin="0">
-                        <ui:Button Click="RoiManagementInspectionDataset_Click">
-                            <ui:Button.Style>
-                                <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                                    <Style.Triggers>
-                                        <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                                     Value="InspectionDataset">
-                                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                        </DataTrigger>
-                                    </Style.Triggers>
-                                </Style>
-                            </ui:Button.Style>
+                        <ui:Button Click="RoiManagementInspectionDataset_Click"
+                                   Style="{StaticResource LeftNavButtonStyle}"
+                                   local:NavSelection.Key="InspectionDataset">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="40,0,0,0">
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}"
                                                FontSize="18"
                                                Margin="0,0,10,0"
                                                Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                                <TextBlock Text="Dataset" VerticalAlignment="Center"/>
+                                <TextBlock Text="Dataset"
+                                           VerticalAlignment="Center"
+                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
                 </StackPanel>
-                <ui:Button Click="NavBatchInspection_Click">
-                    <ui:Button.Style>
-                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                             Value="BatchInspection">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ui:Button.Style>
+                <ui:Button Click="NavBatchInspection_Click"
+                           Style="{StaticResource LeftNavButtonStyle}"
+                           local:NavSelection.Key="BatchInspection">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                        <TextBlock Text="Batch Inspection" VerticalAlignment="Center"/>
+                        <TextBlock Text="Batch Inspection"
+                                   VerticalAlignment="Center"
+                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                     </StackPanel>
                 </ui:Button>
                 <ui:Button Click="NavComms_Click"
-                           Margin="0">
-                    <ui:Button.Style>
-                        <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource LeftNavButtonStyle}">
-                            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SelectedLeftMenuKey, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
-                                             Value="Comms">
-                                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Accent}" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ui:Button.Style>
+                           Margin="0"
+                           Style="{StaticResource LeftNavButtonStyle}"
+                           local:NavSelection.Key="Comms">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
-                        <TextBlock Text="Comms" VerticalAlignment="Center"/>
+                        <TextBlock Text="Comms"
+                                   VerticalAlignment="Center"
+                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                     </StackPanel>
                 </ui:Button>
             </StackPanel>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -194,22 +194,22 @@ namespace BrakeDiscInspector_GUI_ROI
             }
         }
 
-        public static readonly DependencyProperty SelectedLeftMenuKeyProperty =
+        public static readonly DependencyProperty SelectedLeftNavKeyProperty =
             DependencyProperty.Register(
-                nameof(SelectedLeftMenuKey),
+                nameof(SelectedLeftNavKey),
                 typeof(string),
                 typeof(MainWindow),
                 new PropertyMetadata(string.Empty));
 
-        public string SelectedLeftMenuKey
+        public string SelectedLeftNavKey
         {
-            get => (string)GetValue(SelectedLeftMenuKeyProperty);
-            set => SetValue(SelectedLeftMenuKeyProperty, value);
+            get => (string)GetValue(SelectedLeftNavKeyProperty);
+            set => SetValue(SelectedLeftNavKeyProperty, value);
         }
 
-        private void SelectLeftMenu(string key)
+        private void SetSelectedLeftNav(string key)
         {
-            SelectedLeftMenuKey = key ?? string.Empty;
+            SelectedLeftNavKey = key ?? string.Empty;
         }
 
         public RoiPanelMode RoiPanelMode
@@ -3746,7 +3746,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavLayoutSetup_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("LayoutSetup");
+            SetSelectedLeftNav("LayoutSetup");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3758,7 +3758,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavRoiManagement_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("RoiManagement");
+            SetSelectedLeftNav("RoiManagement");
             var expand = RoiNavSubmenu.Visibility != Visibility.Visible;
             RoiNavSubmenu.Visibility = expand ? Visibility.Visible : Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3781,7 +3781,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementSelectMaster_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("MasterRois");
+            SetSelectedLeftNav("MasterRois");
             RoiPanelMode = RoiPanelMode.Master;
             MasterRoiSubmenu.Visibility = Visibility.Visible;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3791,7 +3791,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementSelectInspection_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("InspectionRois");
+            SetSelectedLeftNav("InspectionRois");
             RoiPanelMode = RoiPanelMode.Inspection;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Visible;
@@ -3802,21 +3802,21 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void RoiManagementInspectionDataset_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("InspectionDataset");
+            SetSelectedLeftNav("InspectionDataset");
             var open = InspectionDatasetPanel?.Visibility != Visibility.Visible;
             SetInspectionDatasetView(open);
         }
 
         private void NavMasterAdvanced_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("MasterAdvanced");
+            SetSelectedLeftNav("MasterAdvanced");
             var show = MasterAdvancedOptionsPanel?.Visibility != Visibility.Visible;
             SetMasterAdvancedOpen(show);
         }
 
         private void NavBatchInspection_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("BatchInspection");
+            SetSelectedLeftNav("BatchInspection");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -3828,7 +3828,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void NavComms_Click(object sender, RoutedEventArgs e)
         {
-            SelectLeftMenu("Comms");
+            SetSelectedLeftNav("Comms");
             RoiNavSubmenu.Visibility = Visibility.Collapsed;
             MasterRoiSubmenu.Visibility = Visibility.Collapsed;
             InspectionRoiSubmenu.Visibility = Visibility.Collapsed;
@@ -9266,19 +9266,19 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (LayoutSetupPanel?.Visibility == Visibility.Visible)
             {
-                SelectLeftMenu("LayoutSetup");
+                SetSelectedLeftNav("LayoutSetup");
             }
             else if (RoiManagementPanel?.Visibility == Visibility.Visible)
             {
-                SelectLeftMenu("RoiManagement");
+                SetSelectedLeftNav("RoiManagement");
             }
             else if (BatchInspectionPanel?.Visibility == Visibility.Visible)
             {
-                SelectLeftMenu("BatchInspection");
+                SetSelectedLeftNav("BatchInspection");
             }
             else if (CommsPanel?.Visibility == Visibility.Visible)
             {
-                SelectLeftMenu("Comms");
+                SetSelectedLeftNav("Comms");
             }
 
             RefreshCreateButtonsEnabled();


### PR DESCRIPTION
### Motivation
- Left navigation buttons only had an `IsMouseOver` hover trigger so selection was not persistent after click.  
- The UI should show a persistent selected state (light-gray foreground + subtle fluent shadow) that changes only when another nav/submenu is clicked.  
- Implement a key-driven selection mechanism so styles can react to a selected key stored on the window and per-button keys.

### Description
- Added an attached property `NavSelection.Key` at `gui/BrakeDiscInspector_GUI_ROI/Helpers/NavSelection.cs` to assign a selection key to each nav button.  
- Added `NavKeyEqualsConverter` at `gui/BrakeDiscInspector_GUI_ROI/Converters/NavKeyEqualsConverter.cs` to compare the window-selected key with a button key via `MultiBinding`.  
- Introduced a `SelectedLeftNavKey` dependency property and `SetSelectedLeftNav(...)` helper in `MainWindow.xaml.cs`, and updated left-nav click handlers to call `SetSelectedLeftNav(...)` to keep selection in sync.  
- Updated `MainWindow.xaml` to register the converter, add reusable hover/selected `DropShadowEffect` resources, modify `LeftNavButtonStyle` to include a `DataTrigger` that uses the converter to apply the persistent selected visual, and replaced per-button ad-hoc style blocks by assigning `local:NavSelection.Key` and using the shared `LeftNavButtonStyle`; icons/text now bind to the button `Foreground`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966b31c3b48832bbc8951fd89dbc801)