### PR TITLE
Use ControlLightColorKey for left nav selected foreground

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -26,6 +26,8 @@
         <conv:RoiPanelModeToVisibilityConverter x:Key="RoiPanelModeToVisibility" />
         <conv:NavKeyEqualsConverter x:Key="NavKeyEquals" />
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
+        <SolidColorBrush x:Key="LeftNavSelectedForeground"
+                         Color="{DynamicResource {x:Static SystemColors.ControlLightColorKey}}" />
 
         <DropShadowEffect x:Key="LeftNavSelectedShadow"
                           ShadowDepth="0"
@@ -173,7 +175,7 @@
                                      Path="(local:NavSelection.Key)" />
                         </MultiBinding>
                     </DataTrigger.Binding>
-                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+                    <Setter Property="Foreground" Value="{DynamicResource LeftNavSelectedForeground}" />
                     <Setter Property="Effect" Value="{StaticResource LeftNavSelectedShadow}" />
                 </DataTrigger>
             </Style.Triggers>


### PR DESCRIPTION
### Motivation
- Make the selected left navigation button foreground slightly darker by switching from the very bright `ControlLightLightColorKey` to `ControlLightColorKey` so selected items (main + submenu) are a bit darker and more legible.

### Description
- Added a `SolidColorBrush` resource `LeftNavSelectedForeground` in `MainWindow.xaml` with `Color="{DynamicResource {x:Static SystemColors.ControlLightColorKey}}"`.
- Updated the `LeftNavButtonStyle` selected `DataTrigger` to use `LeftNavSelectedForeground` for the `Foreground` so all selected left-nav items adopt the new color.
- No changes made to triggers, handlers, layout, or selection logic beyond swapping the color resource.

### Testing
- Attempted to build the GUI with `dotnet build BrakeDiscInspector_GUI_ROI.sln` but the build failed in this environment because `dotnet` is not available (no further automated tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966badad568832bac91e2d0edbb4374)