### PR TITLE
Left nav: keep label text color constant while changing icon color + selection shadow

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -156,6 +156,7 @@
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Setter Property="HorizontalContentAlignment" Value="Left" />
             <Setter Property="Padding" Value="12,8" />
@@ -163,7 +164,6 @@
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
                     <Setter Property="Effect" Value="{StaticResource LeftNavHoverShadow}" />
-                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
                 </Trigger>
 
                 <DataTrigger Value="True">
@@ -1891,8 +1891,7 @@
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Layout Setup"
-                                   VerticalAlignment="Center"
-                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </ui:Button>
                 <ui:Button Click="NavRoiManagement_Click"
@@ -1904,8 +1903,7 @@
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="ROI Management"
-                                   VerticalAlignment="Center"
-                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </ui:Button>
                 <!-- Submenú colapsable: mismo tamaño/estilo que el resto, con tabulación -->
@@ -1920,8 +1918,7 @@
                                            Margin="0,0,10,0"
                                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             <TextBlock Text="Master ROIs"
-                                       VerticalAlignment="Center"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       VerticalAlignment="Center" />
                         </StackPanel>
                     </ui:Button>
 
@@ -1937,8 +1934,7 @@
                                                Margin="0,0,10,0"
                                                Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                                 <TextBlock Text="Advanced"
-                                           VerticalAlignment="Center"
-                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                           VerticalAlignment="Center" />
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
@@ -1952,8 +1948,7 @@
                                            Margin="0,0,10,0"
                                            Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                             <TextBlock Text="Inspection ROIs"
-                                       VerticalAlignment="Center"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       VerticalAlignment="Center" />
                         </StackPanel>
                     </ui:Button>
 
@@ -1967,8 +1962,7 @@
                                                Margin="0,0,10,0"
                                                Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                                 <TextBlock Text="Dataset"
-                                           VerticalAlignment="Center"
-                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                           VerticalAlignment="Center" />
                             </StackPanel>
                         </ui:Button>
                     </StackPanel>
@@ -1982,8 +1976,7 @@
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Batch Inspection"
-                                   VerticalAlignment="Center"
-                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </ui:Button>
                 <ui:Button Click="NavComms_Click"
@@ -1996,8 +1989,7 @@
                                        Margin="0,0,10,0"
                                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
                         <TextBlock Text="Comms"
-                                   VerticalAlignment="Center"
-                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                   VerticalAlignment="Center" />
                     </StackPanel>
                 </ui:Button>
             </StackPanel>


### PR DESCRIPTION
### Motivation
- Fix left navigation labels becoming lighter or changing color when hovered or selected while preserving the desired icon color change and persistent selection shadow.

### Description
- Add `TextElement.Foreground` setter to `LeftNavButtonStyle` with `UI.Brush.ButtonForeground` so `TextBlock` labels inherit a constant text color via `TextElement.Foreground`.
- Remove the `Foreground` setter from the `IsMouseOver` trigger so hover only applies shadow/effect and does not change text color.
- Preserve the selected `DataTrigger` behavior that sets the button `Foreground` to `LeftNavSelectedForeground` and applies `LeftNavSelectedShadow`, so the `SymbolIcon` (which still binds to the button `Foreground`) changes color while text remains unchanged.
- Remove `TextBlock` `Foreground` bindings in the left nav button content so labels inherit `TextElement.Foreground`, while keeping `ui:SymbolIcon` `Foreground` bindings intact so icons follow the button `Foreground`.

### Testing
- No automated tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966bd90b9a8832b94cfb06d2bd7935f)