### PR TITLE
Keep left nav icons from inheriting selection foreground

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -175,8 +175,8 @@
                                      Path="(local:NavSelection.Key)" />
                         </MultiBinding>
                     </DataTrigger.Binding>
-                    <Setter Property="Foreground" Value="{DynamicResource LeftNavSelectedForeground}" />
                     <Setter Property="Effect" Value="{StaticResource LeftNavSelectedShadow}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                 </DataTrigger>
             </Style.Triggers>
         </Style>
@@ -1889,7 +1889,7 @@
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                         <TextBlock Text="Layout Setup"
                                    VerticalAlignment="Center" />
                     </StackPanel>
@@ -1901,7 +1901,7 @@
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Crop24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                         <TextBlock Text="ROI Management"
                                    VerticalAlignment="Center" />
                     </StackPanel>
@@ -1916,7 +1916,7 @@
                             <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Target24}"
                                            FontSize="18"
                                            Margin="0,0,10,0"
-                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                           Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                             <TextBlock Text="Master ROIs"
                                        VerticalAlignment="Center" />
                         </StackPanel>
@@ -1932,7 +1932,7 @@
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Settings24}"
                                                FontSize="18"
                                                Margin="0,0,10,0"
-                                               Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                               Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                                 <TextBlock Text="Advanced"
                                            VerticalAlignment="Center" />
                             </StackPanel>
@@ -1943,10 +1943,10 @@
                                Style="{StaticResource LeftNavButtonStyle}"
                                local:NavSelection.Key="InspectionRois">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="22,0,0,0">
-                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
-                                           FontSize="18"
-                                           Margin="0,0,10,0"
-                                           Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                        <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Scan24}"
+                                       FontSize="18"
+                                       Margin="0,0,10,0"
+                                       Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                             <TextBlock Text="Inspection ROIs"
                                        VerticalAlignment="Center" />
                         </StackPanel>
@@ -1960,7 +1960,7 @@
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}"
                                                FontSize="18"
                                                Margin="0,0,10,0"
-                                               Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                               Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                                 <TextBlock Text="Dataset"
                                            VerticalAlignment="Center" />
                             </StackPanel>
@@ -1974,7 +1974,7 @@
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlayCircle24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                         <TextBlock Text="Batch Inspection"
                                    VerticalAlignment="Center" />
                     </StackPanel>
@@ -1987,7 +1987,7 @@
                         <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}"
                                        FontSize="18"
                                        Margin="0,0,10,0"
-                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType={x:Type ui:Button}}}"/>
+                                       Foreground="{DynamicResource UI.Brush.ButtonForeground}"/>
                         <TextBlock Text="Comms"
                                    VerticalAlignment="Center" />
                     </StackPanel>


### PR DESCRIPTION
### Motivation
- Left navigation selection was changing icon color because nav icons inherited the `Button.Foreground`, which made the persistent selection shadow also recolor icons. 
- The intent is to make selection visible only via shadow (and an optional subtle background) while keeping text and icons color constant.

### Description
- Removed the `Foreground` setter from the `LeftNavButtonStyle` selected `DataTrigger` so selection no longer recolors content and kept the selected shadow `Effect`. 
- Added a subtle selected background via `Background = {DynamicResource UI.Brush.ButtonBackgroundHover}` in the selected `DataTrigger` to increase contrast without changing foreground color. 
- Replaced per-button icon bindings that used `Button.Foreground` with a fixed brush by setting each left-nav `ui:SymbolIcon` `Foreground` to `"{DynamicResource UI.Brush.ButtonForeground}"` so icons stay a constant color independent of the button state. 
- Did not modify click logic, `SelectedLeftNavKey` binding, or shared templates beyond left-nav instances to avoid global side effects.

### Testing
- Attempted to build with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, but the build could not run because `dotnet` is not available in this environment (failed). 
- No automated tests were executed in this environment due to the missing SDK, changes were limited to XAML styling and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966c6273cb8832b8f6cb2bad0459951)