### PR TITLE
Enforce dataset-only training, min OK samples and recipe mm_per_px lock

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -27,6 +27,10 @@ DEFAULTS: Dict[str, Any] = {
         "score_percentile": int(_env("BDI_SCORE_PERCENTILE", "BRAKEDISC_SCORE_PERCENTILE", "99")),
         "area_mm2_thr": float(_env("BDI_AREA_MM2_THR", "BRAKEDISC_AREA_MM2_THR", "1.0")),
     },
+    "training": {
+        "min_ok_samples": int(_env("BDI_MIN_OK_SAMPLES", None, "10")),
+        "dataset_only": _env("BDI_TRAIN_DATASET_ONLY", None, "1"),
+    },
 }
 
 def load_settings(config_path: str | os.PathLike[str] | None = None) -> Dict[str, Any]:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -14,8 +14,11 @@ This checklist is derived from the current GUI/Backend code.
 
 ## Backend-side issues
 - **`400` with "Memoria no encontrada":** `/infer` could not load the model artefact stored under `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/<role>__<roi>.npz`. Run `/fit_ok` again via the GUI or copy the expected file into that folder.
+- **Error: Insufficient OK samples:** `/fit_ok` refuses to train from dataset when fewer than 10 OK samples are present (configurable via `BDI_MIN_OK_SAMPLES`). Add more OK samples and refresh the dataset list before retrying.
+- **Error: mm_per_px mismatch:** the recipe is locked to the first `mm_per_px` value seen. Ensure the GUI `MmPerPx` value matches the dataset metadata for the active recipe, or clear the recipe metadata to reinitialize the lock.
 - **Token grid mismatch:** `/infer` returns `error` mentioning `Token grid mismatch`. The embedding grid stored during `/fit_ok` does not match the new input resolution. Rebuild the memory by running `/fit_ok` on crops with the current size.
 - **Calibration missing:** The GUI will still display scores even if `threshold` is `null`. Either run `/calibrate_ng` (button **Calibrate**) or set `InspectionRoiConfig.ThresholdDefault` to a conservative value.
+- **Error: No NG samples available for calibration:** `/calibrate_dataset` requires at least one NG sample when `require_ng=true` (default). Add NG samples and retry.
 - **Slow inference:** Heatmaps are generated with Gaussian blur (`blur_sigma=1.0`). If using CPU only, consider reducing image size in the GUI, ensuring `torch` is compiled for CPU and that the Docker image has enough CPU shares.
 
 ## Logs to inspect


### PR DESCRIPTION
### Motivation
- Prevent training from ad-hoc image uploads (use dataset-only training by default) and avoid mixing different physical scales by locking `mm_per_px` per recipe. 
- Ensure calibration always has NG when required and surface clear errors for insufficient dataset contents. 
- Make minimal, consistent changes in backend and GUI to enforce these operational rules without breaking existing HTTP contracts.

### Description
- Backend: add config/env options `BDI_MIN_OK_SAMPLES` and `BDI_TRAIN_DATASET_ONLY` in `backend/config.py` and read via `SETTINGS` in `backend/app.py` to drive behavior. 
- Backend: add recipe metadata helpers in `ModelStore` (`_recipe_dir`, `_recipe_meta_path`, `load_recipe_meta`, `save_recipe_meta`, `ensure_recipe_mm_per_px`) and expose a tolerance check to lock `mm_per_px` per recipe in `backend/storage.py`. 
- Backend: validate and enforce `mm_per_px` on `POST /datasets/ok/upload`, `POST /datasets/ng/upload`, `POST /fit_ok` and `POST /infer`; return HTTP 409 on mismatch and include `request_id`/`recipe_id` in error payloads; add dataset-only training guard and minimum-OK-samples check in `/fit_ok` (default min=10). 
- GUI: update `WorkflowViewModel` guards and user flows to require >=10 OK samples to enable Train and Calibrate and require >=1 NG for calibrate, to show messages when conditions are unmet, and to prefer `/fit_ok` from dataset (`FitOkFromDatasetAsync`) for auto-fit paths. 
- Tests & docs: extend `backend/tests/test_app_fastapi.py` with cases for minimum-OK and `mm_per_px` mismatch; update `docs/API_CONTRACTS.md`, `docs/BACKEND.md` and `docs/TROUBLESHOOTING.md` to document new env vars, errors and recipe lock behavior. 
- Files modified: `backend/app.py`, `backend/storage.py`, `backend/config.py`, `backend/tests/test_app_fastapi.py`, `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs`, `docs/API_CONTRACTS.md`, `docs/BACKEND.md`, `docs/TROUBLESHOOTING.md`.

### Testing
- Ran the backend unit tests with `pytest backend/tests/test_app_fastapi.py` and all tests passed (`7 passed`).
- Verified new tests cover: dataset `POST /fit_ok` with `use_dataset=true` succeeds with >=10 OK samples, fails with <10 OK samples, and `mm_per_px` mismatch during dataset upload then `/fit_ok` produces HTTP 409. 
- No new dependencies were added; changes are configuration-driven via env vars and default values are provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69677a6a9f08832b8e882719bcec0b9c)