### PR TITLE
Enable Delete Selected for Inspection Dataset previews

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
@@ -22,6 +22,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow.DesignTime
             CalibrateSelectedRoiCommand = new NoOpCommand();
             EvaluateSelectedRoiCommand = new NoOpCommand();
             RemoveSelectedCommand = new NoOpCommand();
+            RemoveSelectedPreviewCommand = new NoOpCommand();
             InferEnabledRoisCommand = new NoOpCommand();
 
             InspectionRois = new ObservableCollection<InspectionRoiConfig>
@@ -66,6 +67,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow.DesignTime
         public ICommand EvaluateSelectedRoiCommand { get; }
 
         public ICommand RemoveSelectedCommand { get; }
+
+        public ICommand RemoveSelectedPreviewCommand { get; }
 
         public ICommand InferEnabledRoisCommand { get; }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
@@ -130,7 +130,7 @@
             </ui:Button>
             <ui:Button Padding="12,4"
                        Margin="0,0,8,0"
-                      Command="{Binding DataContext.RemoveSelectedCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
+                      Command="{Binding DataContext.RemoveSelectedPreviewCommand, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type w:InspectionDatasetTabsControl}}}">
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                     <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Delete24}" Margin="0,0,8,0"/>
                     <TextBlock Text="Delete Selected" VerticalAlignment="Center"/>


### PR DESCRIPTION
### Motivation
- The "Delete Selected" button in the Inspection Dataset tab was disabled because the existing command only considered legacy sample selections (`SelectedOkSample`/`SelectedNgSample`) while the UI preview lists use preview selections (`SelectedOkPreviewItem`/`SelectedNgPreviewItem`).
- The goal is to enable and perform deletion for the preview-selected thumbnail(s) without changing backend contracts or other dataset flows.
- Keep scope minimal: wire the button to a preview-aware command and implement the deletion flow using the existing backend client.

### Description
- Changed the XAML binding for the Delete Selected button to point to a new command `RemoveSelectedPreviewCommand` instead of the legacy `RemoveSelectedCommand` (`InspectionDatasetTabView.xaml`).
- Added `RemoveSelectedPreviewCommand`, `CanRemoveSelectedPreview()` and `RemoveSelectedPreviewAsync()` to `WorkflowViewModel.cs`, which detect whether a preview OK/NG item is selected, call `_client.DeleteDatasetFileAsync(...)` with the filename (derived via `Path.GetFileName(...)`), clear the preview selection on success, and refresh previews and dataset state for the ROI.
- Hooked `RaiseCanExecuteChanged()` for the new command when `SelectedInspectionRoi` changes, when preview selection properties change (`SelectedOkPreviewItem`/`SelectedNgPreviewItem`) and when busy state changes, and exposed the new command in the design-time VM (`DesignWorkflowViewModel.cs`).
- Error handling: deletion failures log and show a snackbar message and do not clear the selection.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69678b5a49ac832b996ab756a961f9eb)