### PR TITLE
Masters: make analysis local-only and block backend Fit/Infer for masters

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -22,10 +22,9 @@ namespace BrakeDiscInspector_GUI_ROI
             if (ViewModel != null)
             {
                 VisConfLog.AnalyzeMaster(FormattableStringFactory.Create(
-                    "[VISCONF][ANALYZE_MASTER][BACKEND] image='{0}'",
+                    "[VISCONF][ANALYZE_MASTER][LOCAL] image='{0}'",
                     _currentImagePathWin));
-                await ViewModel.RepositionMastersAsync(_currentImagePathWin);
-                await ViewModel.RepositionInspectionRoisAsync(_currentImagePathWin);
+                await AnalyzeMastersAsync(showFailureDialog: true);
             }
 
             await Dispatcher.InvokeAsync(() => RedrawOverlay(), DispatcherPriority.Render);


### PR DESCRIPTION
### Motivation
- Masters (M1/M2) must work independently from the backend and must not trigger `/state`, `/fit_ok`, `/infer` calls or any "Fit OK" dialogs during master detection or manual "Force Analyze Master" flows.
- When master detection fails, the UI should block repositioning and present a clear local-only message (Option 1) instead of offering backend fit/retry flows.

### Description
- Re-routed the existing analyze entrypoint to the local-only flow by changing `AnalyzeMastersViaBackend()` to call the local analyzer (`AnalyzeMastersAsync(showFailureDialog: true)`) and updated its visconf tag to `[VISCONF][ANALYZE_MASTER][LOCAL]` (`gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs`).
- Converted `AnalyzeMastersAsync`/`AnalyzeMastersCoreAsync` to a local-only path (added `showFailureDialog` parameter) and removed/fenced all backend fallback/auto-fit behavior for masters; the code no longer calls backend `Infer`/`EnsureFitted`/`FitOk` for Master roles (`gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`).
- Implemented `ShowMasterDetectionFailure(...)` to centralize the clear user message and logging (writes to `AppendLog`, `GuiLog.Warn` and `VisConfLog.AnalyzeMaster`) and to avoid any "Fit OK" dialogs for master failures.
- Updated batch master detection (`DetectMastersForImageAsync`) to skip backend fallback and to skip detection if the local matcher is disabled (masters are local-only), with explicit logs when detection is skipped or fails (`gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`).
- Added checks enforcing score thresholds before accepting a detection and, on failure, blocking repositioning and showing the new local-only message (Opción 1).

### Testing
- No automated tests were executed as part of this change (no unit/integration tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967ae846de0832b89ca33b70264b3ab)