### PR TITLE
Fix FormattableString usage in master analysis failure log

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -11185,9 +11185,7 @@ namespace BrakeDiscInspector_GUI_ROI
             AppendLog(detail);
             GuiLog.Warn(detail);
             VisConfLog.AnalyzeMaster(FormattableString.Invariant(
-                $"[VISCONF][ANALYZE_MASTER][FAIL] reason='{reason}' " +
-                $"M1_center='{FormatCenter(m1Center)}' M1_angle={FormatAngle(angle1)} M1_score={score1:0.###} M1_thr={thrM1:0.###} " +
-                $"M2_center='{FormatCenter(m2Center)}' M2_angle={FormatAngle(angle2)} M2_score={score2:0.###} M2_thr={thrM2:0.###}"));
+                $"[VISCONF][ANALYZE_MASTER][FAIL] reason='{reason}' M1_center='{FormatCenter(m1Center)}' M1_angle={FormatAngle(angle1)} M1_score={score1:0.###} M1_thr={thrM1:0.###} M2_center='{FormatCenter(m2Center)}' M2_angle={FormatAngle(angle2)} M2_score={score2:0.###} M2_thr={thrM2:0.###}"));
 
             var message =
                 "No se detectaron los Masters (M1/M2) correctamente; revisa ROIs de patrón y búsqueda y los thresholds " +


### PR DESCRIPTION
### Motivation
- Fix a `CS1503` type mismatch where a concatenated `string` was being passed to `FormattableString.Invariant` when logging a master analysis failure in the GUI.

### Description
- Pass a single interpolated `FormattableString` to `VisConfLog.AnalyzeMaster` by consolidating the pieces into one interpolated string in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` (`ShowMasterDetectionFailure`).

### Testing
- No automated tests were run for this small logging/type fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967db8220e4832b9e939b11e255f45d)