### PR TITLE
Add Enabled CheckBoxes for Inspection ROIs in MainWindow.xaml

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1176,6 +1176,15 @@
                                                 </Style>
                                             </ui:Button.Style>
                                         </ui:Button>
+                                        <CheckBox Width="20"
+                                                  Height="20"
+                                                  Margin="6,0,0,0"
+                                                  VerticalAlignment="Center"
+                                                  ToolTip="Enable/disable Inspection ROI 1"
+                                                  IsChecked="{Binding DataContext.InspectionRois[0].Enabled,
+                                                                      ElementName=WorkflowHost,
+                                                                      Mode=TwoWay,
+                                                                      UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,4,0,4" VerticalAlignment="Center">
@@ -1294,6 +1303,15 @@
                                                 </Style>
                                             </ui:Button.Style>
                                         </ui:Button>
+                                        <CheckBox Width="20"
+                                                  Height="20"
+                                                  Margin="6,0,0,0"
+                                                  VerticalAlignment="Center"
+                                                  ToolTip="Enable/disable Inspection ROI 2"
+                                                  IsChecked="{Binding DataContext.InspectionRois[1].Enabled,
+                                                                      ElementName=WorkflowHost,
+                                                                      Mode=TwoWay,
+                                                                      UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,4,0,4" VerticalAlignment="Center">
@@ -1412,6 +1430,15 @@
                                                 </Style>
                                             </ui:Button.Style>
                                         </ui:Button>
+                                        <CheckBox Width="20"
+                                                  Height="20"
+                                                  Margin="6,0,0,0"
+                                                  VerticalAlignment="Center"
+                                                  ToolTip="Enable/disable Inspection ROI 3"
+                                                  IsChecked="{Binding DataContext.InspectionRois[2].Enabled,
+                                                                      ElementName=WorkflowHost,
+                                                                      Mode=TwoWay,
+                                                                      UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" Margin="0,4,0,12" Width="446" HorizontalAlignment="Left">
@@ -1530,6 +1557,15 @@
                                                 </Style>
                                             </ui:Button.Style>
                                         </ui:Button>
+                                        <CheckBox Width="20"
+                                                  Height="20"
+                                                  Margin="6,0,0,0"
+                                                  VerticalAlignment="Center"
+                                                  ToolTip="Enable/disable Inspection ROI 4"
+                                                  IsChecked="{Binding DataContext.InspectionRois[3].Enabled,
+                                                                      ElementName=WorkflowHost,
+                                                                      Mode=TwoWay,
+                                                                      UpdateSourceTrigger=PropertyChanged}"/>
                                     </StackPanel>
 
                                     <workflow:WorkflowControl x:Name="WorkflowHost"


### PR DESCRIPTION
### Motivation
- Provide a per-inspection toggle in the default inspection panel to enable/disable each Inspection ROI (Inspection 1..4) from the main UI. 
- Keep bindings consistent with existing row bindings by explicitly targeting the host `WorkflowHost` DataContext so the new controls synchronize with the same `Enabled` boolean used elsewhere.

### Description
- Inserted a 20x20 `<CheckBox>` immediately after the delete button in each Inspection row (1..4) inside `InspectionDefaultPanel` in `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml`.
- Each checkbox uses `VerticalAlignment="Center"` and `Margin="6,0,0,0"` and binds `IsChecked` to `DataContext.InspectionRois[n].Enabled` via `ElementName=WorkflowHost`, `Mode=TwoWay`, and `UpdateSourceTrigger=PropertyChanged` (indices 0..3 for inspections 1..4).
- No new styles, ViewModel, commands, or other files were added or modified; the project’s existing CheckBox style will be inherited.

### Testing
- No automated tests were run for this UI-only XAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968029e55f4832b8f99787a55a53c35)