### PR TITLE
Fix ROI inspection shape bindings and Master role labels

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1065,7 +1065,7 @@
                                         <ComboBox x:Name="CmbShapeInspection1"
                                               Width="80"
                                               Tag="1"
-                                              ItemsSource="{Binding AvailableShapes}"
+                                              ItemsSource="{Binding AvailableShapes, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                               SelectedItem="{Binding DataContext.InspectionRois[0].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                                               SelectionChanged="InspectionShape_SelectionChanged" Margin="20,0,0,0" Padding="0,3,5,3" UseLayoutRounding="False"/>
                                         <ui:Button x:Name="BtnCreateInspection1"
@@ -1192,7 +1192,7 @@
                                         <ComboBox x:Name="CmbShapeInspection2"
                                           Width="80"
                                           Tag="2"
-                                          ItemsSource="{Binding AvailableShapes}"
+                                          ItemsSource="{Binding AvailableShapes, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                           SelectedItem="{Binding DataContext.InspectionRois[1].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                                           SelectionChanged="InspectionShape_SelectionChanged" Margin="20,0,0,0" Padding="0,3,5,3"/>
                                         <ui:Button x:Name="BtnCreateInspection2"
@@ -1319,7 +1319,7 @@
                                         <ComboBox x:Name="CmbShapeInspection3"
                                           Width="80"
                                           Tag="3"
-                                          ItemsSource="{Binding AvailableShapes}"
+                                          ItemsSource="{Binding AvailableShapes, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                           SelectedItem="{Binding DataContext.InspectionRois[2].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                                           SelectionChanged="InspectionShape_SelectionChanged" Margin="20,0,0,0" Padding="0,3,5,3"/>
                                         <ui:Button x:Name="BtnCreateInspection3"
@@ -1446,7 +1446,7 @@
                                         <ComboBox x:Name="CmbShapeInspection4"
                                           Width="80"
                                           Tag="4"
-                                          ItemsSource="{Binding AvailableShapes}"
+                                          ItemsSource="{Binding AvailableShapes, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
                                           SelectedItem="{Binding DataContext.InspectionRois[3].Shape, ElementName=WorkflowHost, Mode=TwoWay}"
                                           SelectionChanged="InspectionShape_SelectionChanged" Margin="20,0,0,0" Padding="0,3,5,3"/>
                                         <ui:Button x:Name="BtnCreateInspection4"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4902,7 +4902,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private void InitUI()
         {
             ComboFeature.SelectedIndex = 0;
-            ComboMasterRoiRole.ItemsSource = new[] { "ROI Master 1", "ROI Inspección Master 1" };
+            ComboMasterRoiRole.ItemsSource = new[] { "ROI Master 1", "ROI Inspection Master 1" };
             ComboMasterRoiRole.SelectedIndex = 0;
 
 
@@ -4916,7 +4916,7 @@ namespace BrakeDiscInspector_GUI_ROI
             ComboM2Shape.SelectedIndex = 0;
 
 
-            ComboM2Role.ItemsSource = new[] { "ROI Master 2", "ROI Inspección Master 2" };
+            ComboM2Role.ItemsSource = new[] { "ROI Master 2", "ROI Inspection Master 2" };
             ComboM2Role.SelectedIndex = 0;
 
             InitRoiVisibilityControls();


### PR DESCRIPTION
### Motivation
- Inspection ROI shape ComboBoxes did not populate because their ItemsSource binding did not resolve to the window-level list, and Master role labels contained Spanish text causing inconsistent English UI wording.

### Description
- Bind `CmbShapeInspection1`–`CmbShapeInspection4` `ItemsSource` to the window-level `AvailableShapes` using `RelativeSource={RelativeSource AncestorType={x:Type Window}}` to ensure the shape list is populated.
- Replace Spanish role labels in the Master role dropdowns by updating `ComboMasterRoiRole` and `ComboM2Role` items to English (`"ROI Inspection Master 1"` / `"ROI Inspection Master 2"`).
- Changes applied to `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml` and `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.

### Testing
- No automated tests were run because this is a view/binding-only change; manual verification is required in the running WPF UI to confirm ComboBoxes now show the expected shape items and Master role labels appear in English.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69680b40fc20832ba012cf911142abfc)