### PR TITLE
Show red-only NG heatmaps, square OK/NG badge, and Batch ROI outline

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1687,6 +1687,12 @@
                                 VerticalAlignment="Center"
                                 IsHitTestVisible="False"
                                 Panel.ZIndex="1">
+                            <Rectangle x:Name="BatchRoiOutline"
+                                       StrokeThickness="2"
+                                       Stroke="White"
+                                       Fill="Transparent"
+                                       Visibility="Collapsed"
+                                       SnapsToDevicePixels="True"/>
                             <!-- Heatmap del ROI: se posiciona y escala desde código -->
                             <Image x:Name="HeatmapImage"
                                    Stretch="Fill"
@@ -2150,16 +2156,21 @@
               Visibility="Collapsed"
               IsHitTestVisible="False">
                 <Border x:Name="DiskStatusPanel"
-                  Background="#CC000000"
-                  BorderBrush="#39FF14"
-                  BorderThickness="1.5"
+                  Width="48"
+                  Height="48"
+                  Background="Transparent"
+                  BorderBrush="Transparent"
+                  BorderThickness="0"
                   CornerRadius="0"
-                  Padding="8">
+                  Padding="0">
                     <TextBlock x:Name="DiskStatusText"
                        Text=""
                        FontFamily="Segoe UI"
-                       FontWeight="Bold"
-                       FontSize="22"
+                       FontWeight="Black"
+                       FontSize="20"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center"
+                       TextAlignment="Center"
                        Foreground="White"/>
                 </Border>
             </Grid>


### PR DESCRIPTION
### Motivation
- Enforce that heatmap overlays only highlight the regions that caused an NG decision and remain hidden for OK cases across Manual and Batch flows.
- Replace the emoji/pill disk status with a compact, square `OK`/`NG` badge to match UI guidance.
- Ensure the currently selected ROI is visually indicated in the Batch view even when heatmap is hidden to fix ROI visibility regressions (e.g. ROI2 disappearing after first image).

### Description
- UI: changed the disk status control into a true square badge by setting fixed `Width`/`Height` and adjusting `DiskStatusText` style in `MainWindow.xaml` and updated `UpdateGlobalBadge(bool? ok)` to set a green/red background and `OK`/`NG` text in `MainWindow.xaml.cs`.
- Batch ROI outline: added `Rectangle x:Name="BatchRoiOutline"` to the `Overlay` canvas in `MainWindow.xaml` and updated `TryPlaceBatchHeatmap` to always update/show/hide and position that outline using `vm.GetInspectionRoiCanvasRect(roiIndex)` so the selected ROI is visible even when the heatmap is absent.
- Manual heatmap (analysis view): modified `ShowHeatmapOverlayAsync` in `MainWindow.xaml.cs` to hide the overlay when the last inference is OK, and when NG build a red-only overlay from `WorkflowViewModel.Regions` using a new helper `BuildRedMaskFromRegions`; if `Regions` is empty the method falls back to applying a red-only threshold mask from the cached gray heatmap.
- Batch heatmap logic: updated `WorkflowViewModel.UpdateHeatmapFromResult` to classify NG/OK from `result.score` vs `result.threshold`, to skip showing any heatmap for OK, and to prefer building a region mask PNG (via new `BuildRegionMaskPngBytes`) when `result.regions` are present before calling `SetBatchHeatmapForRoi`.
- Palette change: changed `ApplyRedGreenPalette` in `WorkflowViewModel` to emit only red (opaque red for values >= cutoff, transparent otherwise) to remove green/multi-color palettes.
- Files changed: `MainWindow.xaml`, `MainWindow.xaml.cs`, and `Workflow/WorkflowViewModel.cs` with minimal, self-contained helpers added to each implementation file.

### Testing
- No automated tests were executed as part of this change.
- The changes are limited to UI/overlay logic and heatmap rendering paths in the three modified files; please run application/manual validation to confirm the acceptance checklist (OK hides overlay, NG shows red-only region masks, Batch ROI outline always visible, badge shows square `OK`/`NG`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69680ee5ede8832b91a6322a27844f2a)