### PR TITLE
Add persistent backend diagnostics logging to GUI logs folder

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -193,6 +193,18 @@ class ModelStore:
         create: bool = True,
     ) -> Path:
         return self.resolve_models_dir(recipe_id, model_key, create=create) / f"{self._base_name(role_id, roi_id)}_calib.json"
+
+    def expected_memory_path(
+        self,
+        role_id: str,
+        roi_id: str,
+        *,
+        recipe_id: Optional[str] = None,
+        model_key: Optional[str] = None,
+        create: bool = False,
+    ) -> Path:
+        model_key_effective = model_key or roi_id
+        return self._memory_path(role_id, roi_id, recipe_id, model_key_effective, create=create)
     # --- Resolve existing artifact paths (recipe-aware with fallback) ---
 
     def resolve_memory_path_existing(


### PR DESCRIPTION
### Motivation

- Provide a persistent JSONL diagnostics log written to the same folder the WPF GUI writes logs to, to aid diagnosing the "pide fit_ok de nuevo tras reiniciar" issue. 
- Keep the existing stdout JSON logging (`slog`) unchanged and continue to emit it as before.

### Description

- Add `resolve_gui_logs_dir()` which resolves the GUI log folder using the `BDI_GUI_LOG_DIR` env override or Windows `LOCALAPPDATA` path and falls back to a safe per-user path on non-Windows systems, and create the directory if missing. 
- Initialize a JSONL diagnostics logger (`backend_diagnostics.jsonl`) using `RotatingFileHandler` (5MB, 5 backups) and a `diag(...)` helper that writes one JSON object per line and swallows write errors. 
- Emit a `startup` event on FastAPI `startup` with `cwd`, `resolved_log_dir`, `models_dir` and relevant env vars, and add an HTTP middleware that logs an `http` event per request with `method`, `path`, `status_code`, `recipe_id`, `request_id` and `elapsed_ms`. 
- Instrument `infer` to emit `infer.memory_missing` with the exact expected `.npz` path, `exists`, `expected_dir` and a short `dir_listing` when memory is not found, and instrument `fit_ok` to emit `fit_ok.saved` with `expected_npz` and `exists` after saving; add `ModelStore.expected_memory_path()` helper used for those diagnostics. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968cf673250832b9b9d756409b10cde)