### PR TITLE
Annotate global ModelStore instance in backend/app.py

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -291,7 +291,7 @@ except Exception:
         }
     }
 ensure_dir(MODELS_DIR)
-store = ModelStore(MODELS_DIR)
+store: ModelStore = ModelStore(MODELS_DIR)
 
 MM_PER_PX_EPS = 1e-6
 


### PR DESCRIPTION
### Motivation
- Provide an explicit type for the global model store to improve static analysis (`pyright`/Pylance) and code readability.

### Description
- Add a type annotation to the global `store` instance making it `store: ModelStore = ModelStore(MODELS_DIR)` in `backend/app.py`.

### Testing
- No automated tests were run; this is a single-line type annotation that does not change runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968d1f6fbe0832b9aea4d627b3a25fb)