### PR TITLE
Add JSONL diagnostics logging, request-id propagation and artifact probes

### DIFF
--- a/backend/diagnostics.py
+++ b/backend/diagnostics.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+REQUEST_ID_CTX: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+_DIAG_LOGGER: logging.Logger | None = None
+_DIAG_LOG_PATH: Path | None = None
+
+
+def init_diagnostics_logger(log_dir: Path, *, filename: str = "backend_diagnostics.jsonl") -> Path | None:
+    global _DIAG_LOGGER, _DIAG_LOG_PATH
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / filename
+        handler = logging.FileHandler(log_path, encoding="utf-8")
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger = logging.getLogger("diagnostics")
+        logger.setLevel(logging.INFO)
+        if logger.handlers:
+            logger.handlers.clear()
+        logger.addHandler(handler)
+        logger.propagate = False
+        _DIAG_LOGGER = logger
+        _DIAG_LOG_PATH = log_path
+        return log_dir
+    except Exception:
+        _DIAG_LOGGER = None
+        _DIAG_LOG_PATH = None
+        return None
+
+
+def diagnostics_log_path() -> Path | None:
+    return _DIAG_LOG_PATH
+
+
+def bind_request_id(request_id: str) -> Any:
+    return REQUEST_ID_CTX.set(request_id)
+
+
+def reset_request_id(token: Any) -> None:
+    REQUEST_ID_CTX.reset(token)
+
+
+def diag_event(event: str, **fields: Any) -> None:
+    if _DIAG_LOGGER is None:
+        return
+    payload = {
+        "ts": time.time(),
+        "event": event,
+        "pid": os.getpid(),
+        "thread": threading.current_thread().name,
+    }
+    request_id = REQUEST_ID_CTX.get()
+    if request_id and "request_id" not in fields:
+        payload["request_id"] = request_id
+    payload.update(fields)
+    try:
+        _DIAG_LOGGER.info(json.dumps(payload, ensure_ascii=False))
+    except Exception:
+        return


### PR DESCRIPTION
### Motivation
- Provide a persistent, JSONL diagnostics trail (not console-only) so debugging why an ROI (e.g. `inspection-2`) shows “no fitted / run fit_ok first” after GUI restart is possible. 
- Correlate events across requests by propagating `X-Request-Id` and include artifact probes to show exact paths, fallback attempts and file metadata for memory/index/calib.
- Record structured request/response and business events for key endpoints (`/fit_ok`, `/infer`, `/state`, `/datasets/list`, `/calibrate_ng`) to surface reasons like missing files, recipe/model_key mismatches, or fallback decisions.

### Description
- Added `backend/diagnostics.py` with a `diagnostics` logger that writes JSON lines and a `ContextVar`-backed `request_id` helper (`bind_request_id`, `reset_request_id`, `diag_event`).
- Integrated diagnostics into `backend/app.py`: initialize diagnostics to write `backend_diagnostics.jsonl` under the resolved `log_dir`, bind/generate `request_id` in middleware, return `X-Request-Id` response header, and replace ad-hoc console prints with structured `diag_event` calls.
- Implemented artifact probing helpers in `backend/app.py`: `probe_artifacts(...)`, `_file_probe(...)`, and `_faiss_available()` plus `_read_image_file_with_len(...)` to include `image_bytes_len` in logs; added `timings_ms` in `InferenceEngine` (in `backend/infer.py`).
- Instrumented endpoints to emit structured events: `*.request` and `*.response` (and error cases) now include `request_id`, `recipe_id`, `role_id`, `roi_id`, `model_key`, dataset summaries, artifact probe results (expected vs resolved paths, exists/size/mtime), `why_not_fitted` reasons and decision/timings for inference; added dataset listing details to `/datasets/list` logs.
- Enhanced `ModelStore` (`backend/storage.py`) `resolve_*_path_existing` methods to record the ordered list of probed paths and emit `storage.resolve_*.not_found` events when resolution fails, exposing fallback order (case-insensitive recipe dir, default recipe, legacy layouts).
- Minor robustness: avoid `print()` for warnings, surface warnings via logger, and ensure the diagnostics file is created under the same `log_dir` used by the GUI.

### Testing
- No automated tests were executed on the modified code in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696911fd9bc0832bbf41b5cdb0a85339)