### PR TITLE
Remove HasFitOk persistence and query backend /state

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -13939,7 +13939,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 AnchorMaster = cfg.AnchorMaster,
                 BaseImgW = cfg.BaseImgW,
                 BaseImgH = cfg.BaseImgH,
-                HasFitOk = cfg.HasFitOk,
                 DatasetReady = cfg.DatasetReady,
                 Threshold = cfg.Threshold,
                 LastScore = cfg.LastScore,

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
@@ -42,8 +42,9 @@ namespace BrakeDiscInspector_GUI_ROI.Models
         private ObservableCollection<DatasetPreviewItem> _ngPreview = new();
         private DatasetPreviewItem? _selectedOkPreviewItem;
         private DatasetPreviewItem? _selectedNgPreviewItem;
-        private bool _hasFitOk;
         private MasterAnchorChoice _anchorMaster = MasterAnchorChoice.Master1;
+        private bool _backendMemoryFitted;
+        private bool _backendCalibPresent;
 
         public InspectionRoiConfig(int index)
         {
@@ -131,7 +132,6 @@ namespace BrakeDiscInspector_GUI_ROI.Models
                 if (string.Equals(_modelKey, newValue, StringComparison.Ordinal)) return;
                 _modelKey = newValue;
                 OnPropertyChanged();
-                HasFitOk = false;
             }
         }
 
@@ -145,7 +145,6 @@ namespace BrakeDiscInspector_GUI_ROI.Models
                 _datasetPath = normalized;
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(HasDatasetPath));
-                HasFitOk = false;
             }
         }
 
@@ -233,13 +232,26 @@ namespace BrakeDiscInspector_GUI_ROI.Models
             }
         }
 
-        public bool HasFitOk
+        [JsonIgnore]
+        public bool BackendMemoryFitted
         {
-            get => _hasFitOk;
+            get => _backendMemoryFitted;
             set
             {
-                if (_hasFitOk == value) return;
-                _hasFitOk = value;
+                if (_backendMemoryFitted == value) return;
+                _backendMemoryFitted = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [JsonIgnore]
+        public bool BackendCalibPresent
+        {
+            get => _backendCalibPresent;
+            set
+            {
+                if (_backendCalibPresent == value) return;
+                _backendCalibPresent = value;
                 OnPropertyChanged();
             }
         }
@@ -431,7 +443,6 @@ namespace BrakeDiscInspector_GUI_ROI.Models
                 DatasetStatus = DatasetStatus,
                 DatasetOkCount = DatasetOkCount,
                 DatasetKoCount = DatasetKoCount,
-                HasFitOk = HasFitOk,
                 AnchorMaster = AnchorMaster,
                 BaseImgW = BaseImgW,
                 BaseImgH = BaseImgH,

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/DesignTime/DesignWorkflowViewModel.cs
@@ -81,7 +81,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow.DesignTime
                 DatasetKoCount = 6,
                 ThresholdDefault = 0.5,
                 CalibratedThreshold = 0.72,
-                HasFitOk = true
+                BackendMemoryFitted = true
             };
 
             roi.OkPreview = CreatePreviewCollection("ok", okBase);


### PR DESCRIPTION
### Motivation
- The persisted `HasFitOk` boolean caused stale UI gating and could be reset by local normalization (e.g. `ModelKey`), making the GUI incorrectly block inference after restart.
- The GUI must stop relying on a persisted flag and instead reflect the real trained/calibrated state from the backend `GET /state` endpoint.

### Description
- Removed the `HasFitOk` backing field and property from `InspectionRoiConfig` and eliminated any writes/reads from cloning and saving, and replaced it with two runtime-only, non-serialized flags: `BackendMemoryFitted` and `BackendCalibPresent` (annotated with `[JsonIgnore]`).
- Stopped persisting `HasFitOk` in layout snapshots by removing the assignment in `CloneInspectionConfigForSave` (`MainWindow.xaml.cs`) and adjusted design-time ROIs to use `BackendMemoryFitted`.
- Added `BackendStateInfo` DTO and implemented `GetStateAsync(...)` in `BackendClient` to call `GET state?role_id=...&roi_id=...[&model_key=...]`, and updated `EnsureFittedAsync` to use `GetStateAsync` as the primary check (fallback to `fit_ok` unchanged when samples are provided).
- Reworked workflow logic in `WorkflowViewModel`: removed the `HasFitOk` gating in `ValidateInferenceInputs`, added `RefreshBackendStateForRoiAsync(...)` to fetch `/state` and set the runtime flags, invoked the refresh on ROI selection and `ModelKey` changes, and require `BackendMemoryFitted==true` (or show a clear message) before calling `/infer`; training and reset flows now update the runtime flags instead of `HasFitOk`.
- Implemented layout migration in `MasterLayout.LoadFromFile`: detect legacy files containing `"HasFitOk"`, run sanitize/normalization, reserialize and overwrite the same file without the legacy field (errors are logged but do not abort load).
- No backend endpoints were added or changed and the `X-Recipe-Id` header logic was preserved.

### Testing
- Automated tests were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a1465cc84832e942e1fe1b473815d)