### PR TITLE
Fix: preserve dataset thumbnails when saving an Inspection ROI

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4689,7 +4689,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 Directory.CreateDirectory(Path.Combine(roiDir, "ng"));
                 Directory.CreateDirectory(Path.Combine(roiDir, "Model"));
 
-                if (!string.Equals(roi.DatasetPath, roiDir, StringComparison.OrdinalIgnoreCase))
+                if (string.IsNullOrWhiteSpace(roi.DatasetPath))
                 {
                     roi.DatasetPath = roiDir;
                 }
@@ -8374,7 +8374,6 @@ namespace BrakeDiscInspector_GUI_ROI
 
             RefreshInspectionRoiSlots();
             SetActiveInspectionIndex(index);
-            EnsureInspectionDatasetStructure();
             TryPersistLayout();
 
             DumpUiShapesMap($"save-slot:{index}");

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -2499,8 +2499,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             {
                 _roiDatasetCache.Remove(roiChanged);
                 roiChanged.DatasetStatus = "Syncing dataset...";
-                roiChanged.OkPreview = new ObservableCollection<DatasetPreviewItem>();
-                roiChanged.NgPreview = new ObservableCollection<DatasetPreviewItem>();
+                _log($"[dataset:path] changed roi={roiChanged.ModelKey} path='{roiChanged.DatasetPath}'");
                 _ = RefreshDatasetPreviewsForRoiAsync(roiChanged);
                 _ = RefreshRoiDatasetStateAsync(roiChanged);
 


### PR DESCRIPTION
### Motivation
- Saving an inspection ROI caused dataset thumbnails shown in the UI to be cleared immediately because `DatasetPath` got updated during save and `InspectionRoiPropertyChanged` wiped previews when that property changed.
- The true source of dataset thumbnails is the backend, so changing the local `DatasetPath` on every save should not erase the UI previews.
- The expected behavior is that saving a ROI must not blank the OK/NG thumbnails and refreshes can run in background without clearing the current UI.

### Description
- Stop forcing dataset-path realignment during slot save by removing the call to `EnsureInspectionDatasetStructure()` from `SaveCurrentInspectionToSlot` in `MainWindow.xaml.cs`.
- Make `EnsureInspectionDatasetStructure()` create `ok/ng/Model` directories but only set `roi.DatasetPath` when it is empty, preserving any existing paths in `MainWindow.xaml.cs`.
- Prevent immediate clearing of preview collections by removing the lines that reassign `OkPreview` and `NgPreview` in `InspectionRoiPropertyChanged`, and add a debug log for path changes while keeping the async refresh calls in `WorkflowViewModel.cs`.
- Modified files: `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs` and `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a211a5b98832eb7ca27c1d33def13)