### PR TITLE
Realign Inspection ROI `DatasetPath` to current layout in `EnsureInspectionDatasetStructure`

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -4689,8 +4689,12 @@ namespace BrakeDiscInspector_GUI_ROI
                 Directory.CreateDirectory(Path.Combine(roiDir, "ng"));
                 Directory.CreateDirectory(Path.Combine(roiDir, "Model"));
 
-                if (string.IsNullOrWhiteSpace(roi.DatasetPath))
+                var current = DatasetPathHelper.NormalizeDatasetPath(roi.DatasetPath);
+                var expected = DatasetPathHelper.NormalizeDatasetPath(roiDir);
+                if (!string.IsNullOrWhiteSpace(expected)
+                    && !string.Equals(current, expected, StringComparison.OrdinalIgnoreCase))
                 {
+                    AppendLog($"[dataset:path] realign ROI '{roi.ModelKey}' path '{roi.DatasetPath}' -> '{roiDir}' (layout='{GetCurrentLayoutName()}')");
                     roi.DatasetPath = roiDir;
                 }
             }


### PR DESCRIPTION
### Motivation
- Fix a regression where a guard (`if (string.IsNullOrWhiteSpace(roi.DatasetPath))`) prevented already-set inspection ROI `DatasetPath` values from being realigned to the dataset folder for the current layout when layouts change or are renamed.

### Description
- Updated `EnsureInspectionDatasetStructure()` in `MainWindow.xaml.cs` to compute normalized paths via `DatasetPathHelper.NormalizeDatasetPath` for the current ROI and the expected `roiDir`, and unconditionally realign `roi.DatasetPath = roiDir` when the normalized expected path differs from the normalized current path (case-insensitive comparison). 
- Added a single log line when a realignment occurs: `AppendLog(...)` with layout and ROI details. 
- Preserved the existing `Directory.CreateDirectory` calls and kept all other behavior unchanged.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a2b279bd4832e921aba15c950cbd8)