### PR TITLE
Realign inspection dataset paths to current layout

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -657,7 +657,14 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
         public void AlignDatasetPathsWithCurrentLayout()
         {
-            _log("[dataset] align skipped: dataset source of truth is backend");
+            if (_layout == null)
+            {
+                _log("[dataset] align skipped: no layout loaded");
+                return;
+            }
+
+            var recipeRoot = RecipePathHelper.GetLayoutFolder(_currentLayoutName);
+            MasterLayoutManager.AlignInspectionDatasetPaths(_layout, recipeRoot, null);
         }
 
         public ObservableCollection<DatasetSample> OkSamples { get; }


### PR DESCRIPTION
### Motivation
- Ensure inspection ROI `DatasetPath` always points to the canonical dataset folder for the active layout to avoid stale paths when loading, switching or "Save As" layouts. 
- Create the expected `ok`/`ng` subfolders for inspection slots to avoid missing-folder errors and keep on-disk layout consistent with GUI state.

### Description
- Reworked layout path normalization to accept a recipe root and extracted the layout name from it, keeping the existing `Recipes/last` repair logic intact while adding stronger inspection ROI handling. 
- Added `AlignInspectionDatasetPaths` to deterministically set each inspection ROI `DatasetPath` to `Path.Combine(RecipePathHelper.GetDatasetFolder(layoutName), "Inspection_<n>")`, create `ok`/`ng` subfolders, and log every realignment with `GuiLog.Info`. 
- Invoked the normalization during layout load and load-or-new flows using `RecipePathHelper.GetLayoutFolder(layoutName)`, and during `SaveAs` before writing the JSON so persisted layouts contain canonical dataset paths. 
- Rewired `WorkflowViewModel.AlignDatasetPathsWithCurrentLayout()` to call the shared normalization helper so UI-triggered layout switches also update inspection ROI dataset paths (and log when no layout is loaded).

### Testing
- No automated tests were run as part of this change (manual validation checklist provided in design notes); compilation and basic file edits were applied and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a2f236190832eacf016ff1d89bf9f)