### PR TITLE
Switch heatmaps to green-only overlay and fix opacity slider

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -10,6 +10,7 @@
         xmlns:conv="clr-namespace:BrakeDiscInspector_GUI_ROI.Converters"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         x:Class="BrakeDiscInspector_GUI_ROI.MainWindow"
+        x:Name="RootWindow"
         Title="BrakeDiscInspector"
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
@@ -2206,7 +2207,7 @@
                       Maximum="1"
                       TickFrequency="0.05"
                       IsSnapToTickEnabled="True"
-                      Value="{Binding HeatmapOverlayOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                      Value="{Binding HeatmapOverlayOpacity, ElementName=RootWindow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                     </StackPanel>
                 </Border>
             </Grid>


### PR DESCRIPTION
### Motivation
- Users reported large red rectangles and noisy red masks in heatmap overlays which are not useful and should be removed in favor of a single green-only gradient matching the OK badge color `#2ECC71`.
- The heatmap opacity slider binding targeted the ViewModel DataContext and did not update the window-level `HeatmapOverlayOpacity` property, so the slider had no live effect.
- Batch heatmap code injected region-mask PNG overrides and a red palette, which must be removed to avoid dead/slow code and to keep a consistent green overlay.

### Description
- Fixed opacity slider binding by naming the window root (`x:Name="RootWindow"`) and changing the slider binding to `Value="{Binding HeatmapOverlayOpacity, ElementName=RootWindow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"` in `MainWindow.xaml` and added a guarded `ValueChanged` handler registration in `WireExistingHeatmapControls()` so slider moves now update `HeatmapOverlayOpacity` at runtime (added `_heatmapOpacityEventsHooked`).
- Replaced the red/turbo color paths in `MainWindow.xaml.cs`: `ShowHeatmapOverlayAsync` now resets heatmap scale to `1.00` per session, keeps the NG gating (no overlay for OK), and calls `RebuildHeatmapOverlayFromCache()`; `RebuildHeatmapOverlayFromCache()` was rewritten to produce a BGRA32 `WriteableBitmap` that paints pixels only in the green base color `#2ECC71` with a light→intense alpha gradient shaped by `_heatmapNormMax`, `_heatmapGain`, and `_heatmapGamma`, and removed the old Turbo LUT / red mask helpers.
- Updated batch logic in `WorkflowViewModel.cs` to stop overriding payloads with region masks, to gate showing batch heatmaps when a valid threshold exists and the result is NG, and to replace `ApplyRedGreenPalette` with `ApplyGreenPalette` which paints green `#2ECC71` with cutoff-controlled alpha gradient (retains cutoff slider semantics); removed the unused region-mask helper.

### Testing
- Attempted to build the GUI with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` but the command failed in the environment because `dotnet` is not available (build not executed here).
- Performed repository static checks and searches to ensure removed helpers (`TurboLUT`, red mask builders, `ApplyHeatmapLut`) are no longer referenced and updated call sites to the new `ApplyGreenPalette`.
- Verified via code inspection that `Heatmap Scale` is forced to `1.00` when a new heatmap is shown and that the opacity slider now updates `HeatmapOverlayOpacity` through the new `ElementName` binding and `ValueChanged` handler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ac2aae9f8832e93e0fe29e476da52)