### PR TITLE
Refresh and unify repository documentation (README, docs, logging, onboarding)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,32 +3,30 @@
 Thank you for helping improve BrakeDiscInspector. Follow these rules to stay aligned with the current codebase and the constraints listed in `agents.md`.
 
 ## 1. Before you start
-- Read `README.md`, `docs/ARCHITECTURE.md`, `docs/FRONTEND.md`, `docs/BACKEND.md` and `docs/API_CONTRACTS.md` to understand the active workflows.
-- Ensure you can run the backend locally (`uvicorn backend.app:app`) and build the GUI (Visual Studio 2022, .NET 8).
+- Read `docs/INDEX.md` for the documentation map.
+- Use `LOGGING.md` as the source of truth for logs.
+- Ensure you can run the backend locally and build the GUI.
 
 ## 2. Branching and coding standards
 - Create topic branches from `main` (`git checkout -b feature/<name>`).
-- GUI: keep network calls async (`async/await`), do not touch adorners or ROI transforms without approval, and respect the canonical ROI export pipeline.
-- Backend: follow PEP8 + type hints, keep endpoint names and payloads stable.
-- Documentation: update the relevant `.md` file when you change a workflow.
+- GUI: keep network calls async (`async/await`), do not touch adorners or ROI transforms without approval, and reuse the canonical ROI export pipeline.
+- Backend: keep endpoint names and payloads stable.
+- Documentation: update or add `.md` files for workflow changes and mark unverified statements as **TODO**.
 
 ## 3. Pull requests
 Every PR must include:
-1. A description of the change plus affected ROI slots/endpoints if applicable.
+1. A description of changes and affected ROI slots/endpoints.
 2. Evidence of testing (backend `pytest`, GUI screenshots or log excerpts for manual/batch flows).
-3. Updates to docs/logging instructions when necessary (e.g. if you add a new dataset field).
+3. Documentation updates (especially `docs/API_CONTRACTS.md`, `docs/BACKEND.md`, `docs/FRONTEND.md`).
 
 ## 4. Tests
-- Backend: run `pytest` before opening a PR.
-- GUI: manual checklist (load image, edit ROI, run `/fit_ok`, `/calibrate_ng`, `/infer`, batch folder). Capture `gui.log` snippets for regressions.
+- Backend: run `pytest` if you change backend logic.
+- GUI: manual checklist (load image, edit ROI, run `fit_ok`, `calibrate`, `infer`, batch folder).
 
 ## 5. Contracts
 - Do not rename `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` or their fields without updating `docs/API_CONTRACTS.md` and the GUI client.
-- Dataset folders must keep the `Inspection_<n>/ok|ng` structure unless `WorkflowViewModel` is updated accordingly.
+- The backend is the source of truth for datasets and models.
 
 ## 6. Communication
-- Report issues with steps to reproduce, relevant log excerpts (`gui.log`, backend stdout) and screenshots if heatmaps are involved.
-- When in doubt about ROI geometry or backend payloads, consult the owner listed in `agents.md`.
-
-## Tooling notes
-- The GUI targets `.NET 8 (net8.0-windows)`. Building from VS Code requires a **.NET SDK** installed on the machine; Visual Studio installs it automatically. The VS Code Dev Kit logs “No installed .NET SDK was found” when only the runtime is present.
+- Report issues with steps to reproduce and relevant log excerpts.
+- For ROI geometry questions, consult `docs/ROI_AND_HEATMAP_FLOW.md` and `agents.md`.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,45 +1,47 @@
 # Deployment guide
 
-The goal of this document is to explain how to run the checked-in backend in realistic environments. Only features present in the repository are covered.
+This document covers how to run the **backend** and connect the GUI.
 
 ## Modes of operation
-### Standalone (PC with GUI + backend)
-1. Install Python 3.11+, CUDA/cuDNN if you plan to use GPU acceleration.
-2. Follow the *Launch the backend* steps in `README.md` (run `uvicorn backend.app:app --host 0.0.0.0 --port 8000`).
-3. Start the GUI from Visual Studio or publish it. Configure `Backend.BaseUrl` to `http://127.0.0.1:8000` or set `BDI_BACKEND_BASEURL`.
+
+### Standalone (GUI + backend on one machine)
+1. Install Python 3.11+ and (optionally) CUDA.
+2. Run the backend (`uvicorn backend.app:app --host 0.0.0.0 --port 8000`).
+3. Launch the GUI and point `Backend.BaseUrl` to `http://127.0.0.1:8000`.
 
 ### Separate backend server
-1. Provision a Linux host with NVIDIA drivers if GPU is needed.
-2. Clone this repository and run the backend in a virtual environment **or** build the provided Docker image:
-   ```bash
-   docker build -t brakedisc-backend -f docker/Dockerfile .
-   docker run --gpus all -p 8000:8000 -v /data/brakedisc/models:/app/models brakedisc-backend
-   ```
-3. Point each GUI workstation to `http://<server-ip>:8000` by editing `appsettings.json` or the environment variable `BDI_BACKEND_BASEURL`.
+1. Provision a Linux host with NVIDIA drivers if GPU is required.
+2. Build or run the Docker image (see `docker/README.md`).
+3. Point GUI workstations to `http://<server>:8000`.
 
-## Environment variables
-The backend honours the variables defined in `backend/app.py` and `backend/config.py`:
-- `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT` – only relevant when running `uvicorn` programmatically.
-- `BDI_MODELS_DIR` – where `.npz`/`.faiss`/`_calib.json` files are stored.
-- `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR` – inference defaults.
-There is no API-key enforcement or TLS termination inside the app; use a reverse proxy if you need those features.
+## Environment variables (backend)
+- `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`
+- `BDI_MODELS_DIR`
+- `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`
+- `BDI_MIN_OK_SAMPLES`, `BDI_TRAIN_DATASET_ONLY`
+- `BDI_REQUIRE_CUDA`
+- `BDI_CACHE_MAX_ENTRIES`
+- `BDI_CORS_ORIGINS`
+- `BDI_GUI_LOG_DIR` (optional diagnostics log directory)
 
-## GUI configuration
-- The executable reads `config/appsettings.json` first, then `appsettings.json`, then environment overrides (see `AppConfigLoader`).
-- Dataset root is derived from the current layout name and always expands to `<exe>/Recipes/<LayoutName or DefaultLayout>/`; `BDI_DATASET_ROOT` is parsed by `AppConfig` but not used by the current recipe pipeline.
-- The GUI sends HTTP requests asynchronously; no additional services are required. Each inference/training call includes `role_id`, `roi_id`, `mm_per_px` and the ROI `shape`, so make sure the backend address is reachable from the workstation to keep overlays aligned with backend heatmaps/regions.
+## Storage and volumes
+- Model artifacts and datasets are stored under `BDI_MODELS_DIR`.
+- For Docker or multi-worker deployments, mount a shared volume for `BDI_MODELS_DIR`.
+
+## Logs
+- GUI logs: `%LOCALAPPDATA%\BrakeDiscInspector\logs\`.
+- Backend diagnostics: `backend_diagnostics.jsonl` (see `LOGGING.md`).
 
 ## Verification checklist
-1. Start the backend and run `curl http://<host>:8000/health`.
-2. From the GUI, open **Tools → Health** (or whichever control is bound to `RefreshHealthCommand`). The status bar shows the backend model and device.
-3. Run a manual inference on a known OK sample and confirm `gui.log` contains `[eval] done ... OK`.
-4. Optional: run a small batch folder to confirm anchor alignment and dataset counters behave as expected.
+1. `curl http://<host>:8000/health` returns `status=ok`.
+2. GUI can add samples to the backend dataset.
+3. `fit_ok`, `calibrate`, and `infer` succeed for a test ROI.
 
-## Running with multiple workers
-Example (Linux):
+## Multiple Uvicorn workers
+Example:
 ```bash
 uvicorn backend.app:app --host 0.0.0.0 --port 8000 --workers 2
 ```
 Notes:
-- Each worker is a separate process (its own in-memory caches).
-- Persisted artifacts (memory/index/calibration/datasets) are stored under `BDI_MODELS_DIR`. If you use `--workers` or multiple containers, `BDI_MODELS_DIR` must point to a shared, writable volume.
+- Each worker has its own in-memory cache.
+- `BDI_MODELS_DIR` must be shared across workers.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # BrakeDiscInspector
 
-BrakeDiscInspector is a two-part inspection cell: a WPF front-end (`gui/BrakeDiscInspector_GUI_ROI`, target framework `net8.0-windows`) that lets an operator draw ROIs, run manual or batch analysis and manage datasets, and a Python FastAPI backend (`backend/`) that serves PatchCore+DINOv2 inference. The code in this repository is the current implementation described in `agents.md`.
+BrakeDiscInspector is a two-part inspection system:
 
-## What the system does
-- **Manual inspection:** `WorkflowViewModel` exports a *canonical ROI* from the currently loaded image via `RoiCropUtils` and sends it to the backend using `BackendClient.InferAsync`. Heatmaps and regions are re-projected on top of the canvas (`MainWindow.xaml.cs`). Analyze options (rotation range, scale min/max, matcher thresholds) stay in sync between the active layout and the preset UI so manual runs reuse the same search parameters that were stored with the layout.
-- **Batch inspection:** the view-model iterates over every image under the selected folder, repositions each inspection ROI according to its chosen anchor (`InspectionRoiConfig.AnchorMaster`) with `InspectionAlignmentHelper.MoveInspectionTo` and the detected Master 1/2 centers, exports each ROI and evaluates it asynchronously while tracking per-row status (`BatchRow`, `BatchCellStatus`).
-- **Dataset management:** the backend is the source of truth (`BDI_MODELS_DIR/recipes/<recipe_id>/datasets/...`). The GUI uploads ROI crops + metadata via `/datasets/{ok|ng}/upload`, refreshes counts via `/datasets/list`, and caches thumbnails under `%LOCALAPPDATA%\\BrakeDiscInspector\\cache\\datasets\\...`. The **Clear canvas** action wipes masters, inspection slots, cached baselines and disables all inspection ROIs so the next edits start from a clean recipe without lingering inspection geometry.
-- **Backend inference:** `backend/app.py` exposes `GET /health`, `POST /fit_ok`, `POST /calibrate_ng`, `POST /calibrate_dataset`, `POST /infer`, `POST /infer_dataset` plus `/manifest` and dataset helper routes (`/datasets/*`). Images are decoded with OpenCV, features are extracted with `DinoV2Features`, PatchCore coreset is persisted through `ModelStore`, and responses include `request_id`/`recipe_id` for correlation along with `{score, threshold?, token_shape, heatmap_png_base64?, regions[]}`. `BackendClient` always sends `role_id`, `roi_id`, per-sample `mm_per_px` and the ROI mask (`shape` JSON) so the backend evaluates the same canonical crop that the GUI rendered.
+- **GUI (WPF)** under `gui/` for ROI drawing, canonical ROI export (crop + rotation), master patterns, batch visualization, and operator workflows.
+- **Backend (FastAPI)** under `backend/` for dataset storage, model persistence, `fit_ok`, calibration, inference, and heatmap generation.
+
+The GUI is the **source of truth for ROI geometry and canonical crops**; the backend is the **source of truth for datasets, models, and calibration artifacts**. See `docs/ARCHITECTURE.md` for a full data-flow overview and `docs/FRONTEND.md` / `docs/BACKEND.md` for details.
+
+## What the system does (high level)
+- **ROI drawing and export (GUI):** ROIs are drawn in WPF and exported as canonical crops (post-rotation) with a `shape` JSON mask that matches the exported image space.
+- **Dataset management (backend):** OK/NG samples are uploaded to the backend dataset endpoints and persisted under `BDI_MODELS_DIR` (see `docs/BACKEND.md`). The GUI caches previews locally under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
+- **Training and inference (backend):** The backend runs PatchCore + DINOv2, stores model artifacts per `recipe_id` and `model_key`, and returns `score`, `threshold`, optional `heatmap_png_base64`, and `regions`.
 
 ## Quick start
+
 ### Prerequisites
-- **GUI:** Windows 10/11 x64, Visual Studio 2022 or newer (VS 2026 is fine) with *Desktop development with C#* and the .NET 8 SDK.
-- **Backend:** Python 3.11+ with CUDA GPU required by default. Set `BDI_REQUIRE_CUDA=0` to allow CPU-only startup for tests/CI (the provided Dockerfile already targets `pytorch/pytorch:2.2.2-cuda12.1-cudnn8-runtime`).
+- **GUI:** Windows 10/11, Visual Studio 2022+, .NET 8 SDK.
+- **Backend:** Python 3.11+; CUDA GPU is required by default (`BDI_REQUIRE_CUDA=1`). Set `BDI_REQUIRE_CUDA=0` for CPU-only startup.
 
 ### Launch the backend
 ```bash
@@ -21,42 +26,32 @@ source .venv/bin/activate      # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 uvicorn backend.app:app --host 0.0.0.0 --port 8000
 ```
-Environment variables such as `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODELS_DIR`, `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`, and `BDI_REQUIRE_CUDA` can override defaults (see `backend/config.py`).
+Config keys are defined in `backend/config.py` and `backend/app.py` (see `docs/BACKEND.md`).
 
 ### Launch the GUI
 1. Open `gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` in Visual Studio.
-2. Ensure `appsettings.json` or environment variables define `Backend.BaseUrl` if you are not using `http://127.0.0.1:8000`.
-3. Run the app. The dataset is stored in the backend under `BDI_MODELS_DIR` and the GUI caches thumbnails under `%LOCALAPPDATA%\\BrakeDiscInspector\\cache\\datasets\\...`.
+2. Update `config/appsettings.json` or set `BDI_BACKEND_BASEURL` if the backend is not running on `http://127.0.0.1:8000`.
+3. Run the app. Layouts and master patterns are stored under `<exe>/Recipes/<LayoutName>/`.
 
 ### Minimal end-to-end run
-1. Load a demo image, draw Master 1/2 anchors and one inspection ROI, then freeze it.
-2. Press **Add to OK** to upload the ROI PNG + metadata JSON to the backend dataset.
-3. Use **Train memory fit** (calls `/fit_ok` with `use_dataset=true`) and **Calibrate** (calls `/calibrate_dataset`).
-4. Run **Evaluate** for manual inspection or select a batch folder and press **Start Batch** to analyze many files; the view refreshes per-row heatmaps while anchoring ROI positions from the masters.
+1. Load an image, define Master 1/2 ROIs and at least one inspection ROI.
+2. Add OK/NG samples (uploads the canonical ROI to the backend dataset).
+3. Run **fit_ok** and **calibrate** from the dataset tab (backend operations).
+4. Evaluate a single image or run batch analysis.
 
 ## Documentation map
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): component diagram and data flow across manual vs batch modes.
-- [`docs/FRONTEND.md`](docs/FRONTEND.md): GUI structure, dataset layout, ROI editing and command catalogue.
-- [`docs/BACKEND.md`](docs/BACKEND.md): FastAPI modules, persistence layout and configuration knobs.
-- [`docs/API_CONTRACTS.md`](docs/API_CONTRACTS.md): canonical definitions for `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, plus dataset/file contracts.
-- [`docs/ROI_AND_HEATMAP_FLOW.md`](docs/ROI_AND_HEATMAP_FLOW.md): ROI anchoring, canonical cropping, shape JSON and heatmap overlays.
-- [`LOGGING.md`](LOGGING.md): file locations and fields written by `GuiLog` and `backend/app.py`.
-- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md): operational checklist based on real error paths handled in code.
-- [`DEPLOYMENT.md`](DEPLOYMENT.md) & [`docker/README.md`](docker/README.md): how to run the backend outside of Visual Studio.
+- [`docs/INDEX.md`](docs/INDEX.md) — complete documentation index.
+- [`docs/AI_ONBOARDING.md`](docs/AI_ONBOARDING.md) — 10-minute onboarding + glossary.
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — component boundaries and data flow.
+- [`docs/FRONTEND.md`](docs/FRONTEND.md) — WPF UI behavior, ROI workflows, UI specs.
+- [`docs/BACKEND.md`](docs/BACKEND.md) — FastAPI configuration, persistence, failure modes.
+- [`docs/API_CONTRACTS.md`](docs/API_CONTRACTS.md) — exact HTTP contracts.
+- [`LOGGING.md`](LOGGING.md) — **source of truth** for logs and diagnostics.
 
-When working on this repository remember the guardrails in `agents.md`: do not modify adorners, keep HTTP contracts intact and reuse the canonical ROI export pipeline.
+## Recipe ids (backend)
+- `recipe_id` can be passed via payload or `X-Recipe-Id`. It is normalized to lowercase and validated against `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- `last` is **reserved** and rejected with HTTP 400.
+- Artifacts are stored under `BDI_MODELS_DIR/recipes/<recipe_id>/...` (see `docs/BACKEND.md`).
 
-## Recipes, request context, and reserved ids (backend)
-- The backend is **recipe-aware**: models/memory/calibration and dataset helpers are stored per recipe under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
-- The GUI’s on-disk “recipe” folder is **separate**: it uses `<exe>/Recipes/<LayoutName>/...` for local datasets and layout persistence.
-- The backend accepts recipe context in two ways:
-  - Explicit `recipe_id` field (form/query/JSON depending on endpoint), or
-  - `X-Recipe-Id` request header (case-insensitive header match).
-- Reserved recipe ids:
-  - `last` is **reserved** (used by the GUI for layout state like `last.layout.json`) and MUST NOT be used as a backend recipe id. If sent, the backend returns **HTTP 400**.
-- Normalization and compatibility:
-  - The backend normalizes recipe ids for storage (sanitization and lowercase). Treat recipe ids as **case-insensitive**; do not create two recipes that differ only by casing.
-
-## Deployment note: multiple Uvicorn workers
-- The backend supports `uvicorn --workers N` (multiple processes).
-- Important: in-memory caches are per-worker; persisted artifacts live in `BDI_MODELS_DIR`. Use a **shared volume** for `BDI_MODELS_DIR` if you run multiple workers/containers.
+## Logging
+Use [`LOGGING.md`](LOGGING.md) as the single source of truth for log locations and fields.

--- a/agents.md
+++ b/agents.md
@@ -1,294 +1,88 @@
+# Project Playbook (GUI + Backend)
 
-# 📌 Actualización — 2025-10-07
+This file defines **roles, scope, constraints, workflows, and acceptance criteria** for assistants working in this repository.
 
-**Cambios clave (GUI):**
-- Corrección de salto del frame al clicar adorner (círculo/annulus): cálculo y propagación del centro reales en `SyncModelFromShape` y sincronización `X,Y = CX,CY` en `CreateLayoutShape`.
-- Bbox SIEMPRE cuadrado para circle/annulus; overlay heatmap alineado.
-- Decisiones del proyecto y parámetros vigentes documentados.
+> **Context**: WPF GUI for ROI drawing/export + Python FastAPI backend for PatchCore + DINOv2 inference.
 
-**Cambios clave (Backend):**
-- PatchCore + DINOv2 ViT-S/14; endpoints `/health`, `/fit_ok`, `/calibrate_ng`, `/infer`; persistencia por `(role_id, roi_id)`.
+## 0) Quick index
+- [Source of truth](#1-source-of-truth)
+- [Critical constraints](#2-critical-constraints)
+- [Backend contract](#3-backend-contract)
+- [Persistence layout](#4-persistence-layout)
+- [Logging](#5-logging)
+- [UI specs (heatmap/badge)](#6-ui-specs-heatmapbadge)
+- [Master patterns](#7-master-patterns)
+- [ROI enable/disable](#8-roi-enabled-vs-fitted)
+- [Testing](#9-testing)
 
-# agents.md — Project Playbook (GUI + Backend Anomaly Detection)
+## 1) Source of truth
+- **GUI** is the source of truth for **ROI geometry** and **canonical ROI export**.
+- **Backend** is the source of truth for **datasets, models, calibration, and inference**.
 
-This document defines **roles, scope, constraints, workflows, and acceptance criteria** for assistants/agents (e.g., GitHub Copilot/Codex) collaborating on this repository.
+The backend **does not** crop or rotate images; it trusts the GUI crop + `shape` mask.
 
-> **Context**: The project consists of a WPF GUI for **ROI drawing and export** (crop + rotation) and a Python FastAPI backend implementing an **anomaly detection pipeline (PatchCore + DINOv2)**.
-> The GUI is responsible for **canonical ROI** generation; the backend **does not** crop/rotate images.
+## 2) Critical constraints
+1. **Do not modify** adorner/overlay geometry classes (`RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`, `RoiOverlay`) without explicit approval.
+2. Preserve the canonical ROI export pipeline (crop + rotation). Reuse existing utilities.
+3. Keep endpoint names and required fields stable.
+4. Do not invent new coordinate transforms between GUI and backend.
 
----
+## 3) Backend contract
+Endpoints implemented in `backend/app.py`:
+- `GET /health`
+- `POST /fit_ok`
+- `POST /calibrate_ng`
+- `POST /calibrate_dataset`
+- `POST /infer`
+- `POST /infer_dataset`
+- `GET /manifest`, `GET /state`
+- `/datasets/*` helpers (upload/list/file/meta/delete/clear)
 
-## Quick index
+See `docs/API_CONTRACTS.md` for exact payloads and responses.
 
-- [Repository layout](#0-repository-layout-expected)
-- [Roles](#1-roles-agents)
-- [Critical constraints](#2-critical-constraints-non-regression)
-- [Backend contract](#3-backend-contract-stable)
-- [GUI workflows](#4-gui-workflows)
-- [Shape JSON](#5-shape-json-canonical-image-coordinates)
-- [Coding standards & UX](#6-coding-standards--ux-gui)
-- [Acceptance criteria](#7-acceptance-criteria)
-- [Test plan](#8-test-plan-qa)
-- [Do / Don’t](#9-do--dont-quick-reference)
-- [Open questions](#10-open-questions-ask-before-coding-if-unclear)
-- [Backend quick-start](#11-backend-quick-start-for-local-dev)
-- [Glossary](#12-glossary)
-- [Contact points](#13-contact-points)
-
----
-
-## 0) Repository layout (expected)
-
+## 4) Persistence layout
+Backend artifacts live under `BDI_MODELS_DIR` (default `models/`):
 ```
-/backend/
-  app.py
-  features.py
-  patchcore.py
-  infer.py
-  calib.py
-  roi_mask.py
-  storage.py
-  utils.py
-  requirements.txt
-  README_backend.md
-
-/gui/   (name may vary: e.g., BrakeDiscInspector_GUI_ROI/)
-  # WPF (C#) solution/projects live here.
-  # Important classes (names may differ slightly):
-  # - MainWindow.xaml / MainWindow.xaml.cs
-  # - RoiOverlay.cs, RoiAdorner.cs, ResizeAdorner.cs, RoiRotateAdorner.cs
-  # - MasterLayout.cs, PathUtils.cs, RoiCropUtils.cs, ROI.cs, ROIShape.cs, AnnulusShape.cs, etc.
+<BDI_MODELS_DIR>/
+  recipes/<recipe_id>/<model_key>/
+    <base_name>.npz
+    <base_name>_index.faiss
+    <base_name>_calib.json
+  recipes/<recipe_id>/datasets/<base_name>/{ok,ng}/*
 ```
+- `base_name = base64(role_id) + "__" + base64(roi_id)` (urlsafe, no padding).
+- `recipe_id` is lowercased, validated by `^[a-z0-9][a-z0-9_-]{0,63}$`, and must not be `last`.
+- Legacy fallbacks exist (flat files and `models/datasets/<role>/<roi>`).
 
-If any folder names differ, agents must **detect** and **adapt** paths without changing design intent.
+## 5) Logging
+- GUI logs are plain text under `%LOCALAPPDATA%\BrakeDiscInspector\logs\`.
+- Backend diagnostics are JSONL in `backend_diagnostics.jsonl`.
+- **Source of truth:** `LOGGING.md`.
 
----
+## 6) UI specs (heatmap/badge)
+> Spec only; if implementation diverges, mark TODO and update UI later.
 
-## 1) Roles (Agents)
+- Heatmap overlay: show **red** zones **only** when result is **NG** and heatmap is the NG cause.
+- OK/NG badge: square badge, white bold `OK`/`NG` on green/red background.
 
-### Agent A — **GUI Integrator (WPF)**
-- Add dataset management, training, calibration, and inference flows to the WPF app.
-- **Must not modify** adorner/overlay geometry or coordinate transforms.
-- **Reuses** the existing canonical ROI export path (crop + rotation).
+## 7) Master patterns
+- GUI-only; never uploaded to backend.
+- Saved as `master1_pattern.png` / `master2_pattern.png` under `<exe>/Recipes/<LayoutName>/Master/`.
+- Older versions are moved to `Master/obsolete/`.
+- Cache invalidation relies on **path + mtime + size**; change any to avoid stale cache.
 
-### Agent B — **Backend Maintainer (FastAPI)**
-- Keep endpoints **stable**: `/fit_ok`, `/calibrate_ng`, `/infer`, `/health`.
-- Ensure persistence per `(role_id, roi_id)` in `models/`.
-- No new breaking parameters or renamed routes.
+## 8) ROI Enabled vs fitted
+- **Enabled** is a GUI-only toggle (checkbox in inspection panels and dataset tab).
+- Backend fitted state is independent and comes from `/state` or `/manifest`.
+- Legacy `HasFitOk` fields in layout files are ignored and considered **stale**.
 
-### Agent C — **Data Curator**
-- Organize datasets per `(role_id, roi_id)`:
-  - GUI recipes: `Recipes/<LayoutName>/Dataset/Inspection_<n>/ok|ng` for inspection slots (`inspection-1..4`) or `Recipes/<LayoutName>/Dataset/<roi_id>/ok|ng` for other ROIs.
-  - Backend helpers (`/datasets/*`): `BDI_MODELS_DIR/datasets/<role>/<roi>/ok|ng`.
+## 9) Testing
+- Backend: run `pytest` when logic changes.
+- GUI: manual check for ROI export, dataset upload, `fit_ok`, calibration, and batch alignment.
 
-### Agent D — **QA/Validation**
-- Build & run tests to verify no regressions in ROI placement, scaling, or overlay alignment.
-- Validate backend responses and GUI overlays visually and via logs.
-
----
-
-## 2) Critical Constraints (Non‑Regression)
-
-1. **Do not touch** adorner codepaths: `RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`, `RoiOverlay`.
-2. **Do not alter** canvas/image letterboxing or coordinate systems.
-3. **Canonical ROI export** (crop + rotation) must follow the **existing** pipeline (e.g., `TryBuildRoiCropInfo(...)`, `TryGetRotatedCrop(...)`).  
-   The same pipeline used by “Save Master/Pattern” should be reused.
-4. The backend **does not** crop/rotate; it expects the canonical ROI image as input.
-5. Preserve public method signatures used elsewhere (avoid breaking events/commands).
-6. All network I/O must be **async** (no UI thread blocking).
-
----
-
-## 3) Backend Contract (stable)
-
-**FastAPI service** (Python) in `/backend/`:
-
-- `GET /health` → `{ status, device, model, version, request_id, recipe_id, reason? }`
-- `POST /fit_ok` (multipart):
-  - fields: `role_id`, `roi_id`, `mm_per_px`, `images[]` (one or many PNG/JPG of canonical ROI), optional `recipe_id`, `model_key`
-  - returns: `{ n_embeddings, coreset_size, token_shape, coreset_rate_requested, coreset_rate_applied, request_id, recipe_id }`
-- `POST /calibrate_ng` (JSON):
-  - body: `{ role_id, roi_id, mm_per_px, ok_scores[], ng_scores?[], area_mm2_thr?, score_percentile? }`
-  - returns: `{ threshold, ok_mean, ng_mean?, p99_ok?, p5_ng?, mm_per_px, area_mm2_thr, score_percentile, request_id, recipe_id }`
-- `POST /infer` (multipart):
-  - fields: `role_id`, `roi_id`, `mm_per_px`, `image`, `shape?` (JSON string), optional `recipe_id`, `model_key`
-  - returns: `{ score, threshold, heatmap_png_base64, regions[], token_shape, request_id, recipe_id }`
-- `GET /manifest` and dataset helpers (`/datasets/ok/upload`, `/datasets/ng/upload`, `/datasets/list`, `/datasets/file`, `/datasets/clear`) are implemented for inspecting/syncing datasets.
-
-> **Note**: `shape` masks the heatmap and supports `rect`, `circle`, `annulus` (see §5).
-
----
-
-## 4) GUI Workflows
-
-### 4.1 Dataset (per role/ROI)
-- UI controls:
-  - `RoleId`, `RoiId`, numeric `MmPerPx`
-  - Lists (thumbnails): **OK samples**, **NG samples** (optional)
-  - Buttons:
-    - “Add OK from Current ROI”
-    - “Add NG from Current ROI” (optional)
-    - “Remove Selected”, “Open Dataset Folder”
-- On add:
-  1. **Canonicalize** ROI via existing pipeline (crop + rotation).
-  2. Save PNG → `Recipes/<LayoutName>/Dataset/Inspection_<n>/<ok|ng>/SAMPLE_yyyyMMdd_HHmmssfff.png` for inspection slots (or `Recipes/<LayoutName>/Dataset/<roi_id>/<ok|ng>/` for other ROIs).
-  3. Save metadata JSON (same base name):
-     ```json
-     {
-       "role_id": "Master1",
-       "roi_id": "Pattern",
-       "mm_per_px": 0.20,
-       "shape": { "kind": "circle", "cx": 192, "cy": 192, "r": 180 },
-       "source_path": "C:\images\raw.png",
-       "angle": 32.0,
-       "timestamp": "2025-09-28T12:34:56.789Z"
-     }
-     ```
-
-### 4.2 Train (fit_ok)
-- Gather all OK PNGs for current `(role, roi)`.
-- POST `/fit_ok` with all images.
-- Display `{ n_embeddings, coreset_size, token_shape }` and mark model as trained (store a `model_version` timestamp if desired).
-
-### 4.3 Calibrate (optional, with or without NG)
-- If NG exist, compute `scores` for OK/NG by temporarily calling `/infer` (without threshold) and collect returned `score`.
-- POST `/calibrate_ng` with arrays and show returned `threshold`.
-- Persist calibration info through `ModelStore` and surface it via `GET /manifest`.
-
-### 4.4 Inference
-- Canonicalize current ROI → PNG
-- Build `shape` JSON (see §5) in **canonical image space**.
-- POST `/infer`
-- Decode `heatmap_png_base64`, overlay on ROI preview (opacity slider).
-- Show `score`, `threshold`, and `regions` with areas in px/mm².
-- Provide a **local threshold slider** for exploration (does not change backend threshold unless user clicks “Save Threshold”).
-
----
-
-## 5) Shape JSON (canonical image coordinates)
-
-- **Rectangle**:
-  ```json
-  {"kind":"rect","x":0,"y":0,"w":W,"h":H}
-  ```
-
-- **Circle**:
-  ```json
-  {"kind":"circle","cx":CX,"cy":CY,"r":R}
-  ```
-
-- **Annulus**:
-  ```json
-  {"kind":"annulus","cx":CX,"cy":CY,"r":R_OUTER,"r_inner":R_INNER}
-  ```
-
-All numbers are in **pixels** of the **canonical ROI image** (post crop+rotation).
-
----
-
-## 6) Coding Standards & UX (GUI)
-
-- C# 10+, **async/await** for all HTTP operations (`HttpClient`, `MultipartFormDataContent`).
-- MVVM: Commands + ViewModels; minimize code-behind.
-- Use `ObservableCollection<>` for sample lists; generate thumbnails off the UI thread.
-- Provide progress and logs (reuse `AppendLog(...)`).
-- Disable actions while a request is running.
-- Use `Path.Combine(...)`; avoid hard-coded separators.
-- Localize UI strings if the project already uses resources.
-
----
-
-## 7) Acceptance Criteria
-
-- Can add ≥50 OK samples and see them listed (with thumbnails and metadata).
-- `/fit_ok` returns positive `n_embeddings` and `coreset_size`.
-- `/calibrate_ng` (if used) returns a valid `threshold`.
-- `/infer` returns a non-empty heatmap (base64) and a numeric score.
-- Heatmap overlay aligns with ROI visualization (no drift on resize/reload).
-- **No regressions** in adorner behavior or ROI placement after window maximization or image reload.
-
----
-
-## 8) Test Plan (QA)
-
-1. **Startup**: call `/health`; show device/model/version in status bar.
-2. **Dataset**: add 5 OK samples from different areas; verify PNG+JSON files exist.
-3. **Train**: run `/fit_ok`; check counts > 0. Add more samples and retrain.
-4. **Calibrate**: if NG available, compute scores via `/infer` and call `/calibrate_ng`; verify `threshold` persists.
-5. **Infer**: run on current ROI; verify visual overlay; test local threshold slider.
-6. **Resize/Reload**: after maximize + reload image, overlays remain aligned (verify logs and visual).
-7. **Error paths**: disconnect backend / invalid input; GUI shows readable errors, no crashes.
-
----
-
-## 9) Do / Don’t (Quick Reference)
-
-- ✅ **Do** reuse **existing** canonical ROI export (crop + rotation).
-- ✅ **Do** keep adorner/overlay code untouched.
-- ✅ **Do** send `shape` in canonical coordinates when calling `/infer`.
-- ✅ **Do** run HTTP on background (`async`) and log actions/results.
-- ❌ **Don’t** change backend route names or required fields.
-- ❌ **Don’t** invent new coordinate transforms or DPI scaling in overlays.
-- ❌ **Don’t** block UI thread during uploads/inference.
-
----
-
-## 10) Open Questions (ask before coding if unclear)
-
-- Which exact methods return the **canonical ROI** in the current branch? (e.g., `TryBuildRoiCropInfo(...)`, `TryGetRotatedCrop(...)` names may vary).
-- Where is `mm_per_px` sourced in the GUI (camera config, layout, or per-ROI)?
-- Desired **canonical ROI size** (e.g., 384×384 or 448×448). Consistency is beneficial.
-- Should the GUI persist a per-ROI summary (counts, threshold) in addition to backend `/manifest`?
-
----
-
-## 11) Backend quick-start (for local dev)
-
-```bash
-cd backend
-python -m venv .venv
-# Windows: .venv\Scripts\activate
-# Linux/macOS: source .venv/bin/activate
-pip install -r requirements.txt
-uvicorn backend.app:app --reload
-# http://127.0.0.1:8000/docs
-```
-
----
-
-## 12) Glossary
-
-- **Canonical ROI**: The cropped and rotated image patch that exactly corresponds to the drawn ROI on the GUI, in its own pixel space.
-- **Shape JSON**: A JSON object describing the mask (rect/circle/annulus) **in canonical ROI coordinates**.
-- **Coreset**: A compact subset of embeddings selected by k-center greedy to approximate the full OK distribution.
-- **Score (percentile)**: A robust statistic (e.g., p99) computed on the masked heatmap to summarize anomaly intensity.
-- **Threshold**: A scalar decided via calibration to classify ROIs.
-- **Letterboxing**: The black/empty areas added around an image to fit aspect ratio; coordination must be preserved between image and overlay.
-
----
-
-## 13) Contact points
-
-- For ROI alignment issues (drift after maximize/reload): consult the GUI logs and the `SyncOverlayToImage` scheduling/debounce logic. **Do not** modify adorners without explicit approval.
-- For backend model behavior: `backend/README_backend.md`, `app.py` endpoints, and `features.py`/`patchcore.py` explain internals.
-
----
-
-## 14) Actualización Octubre 2025 — Contrato consolidado
-
-- **Frontend ↔ Backend**:
-  - `GET /health` → `{ status, device, model, version, request_id, recipe_id, reason? }`.
-  - `POST /fit_ok` → multipart con `role_id`, `roi_id`, `mm_per_px`, `images[]`, opcional `recipe_id`, `model_key`.
-  - `POST /calibrate_ng` → JSON con `ok_scores`, `ng_scores?`, `score_percentile`, `area_mm2_thr`, opcional `recipe_id`.
-  - `POST /infer` → multipart con `image`, `shape` (`rect|circle|annulus`), `mm_per_px`, opcional `recipe_id`, `model_key`.
-  - Todas las respuestas incluyen `request_id` y `recipe_id` en el JSON (no headers).
-- **Persistencia**: `datasets/<role>/<roi>/ok|ng` (ModelStore datasets) y `recipes/<recipe_id>/<model_key>/<role>__<roi>.npz` + `<role>__<roi>_calib.json` bajo `BDI_MODELS_DIR` (con compatibilidad legacy para rutas antiguas).
-- **Escala física**: `mm_per_px` obligatorio en todas las operaciones.
-- **Shape JSON**: siempre en coordenadas de ROI canónica (post-rotación).
-- **Logging**: correlacionar `request_id` entre GUI y backend.
-- **Pruebas**: ejecutar `pytest` (backend) + validación manual GUI tras cambios en contrato.
-
-## Recipe guardrails (backend)
-- `last` is a **reserved** recipe id and MUST NOT be used for backend artifacts. Any backend change must keep this invariant (400 on `last`).
-- The backend uses the `X-Recipe-Id` header for recipe context. Treat recipe ids as case-insensitive; backend storage normalizes/sanitizes them.
-- When documenting or testing, prefer using `default` or a simple lowercase id like `layout_a`.
+## References
+- `docs/INDEX.md` (documentation map)
+- `docs/AI_ONBOARDING.md` (quickstart + glossary)
+- `docs/ARCHITECTURE.md`
+- `docs/FRONTEND.md`
+- `docs/BACKEND.md`

--- a/backend/README_backend.md
+++ b/backend/README_backend.md
@@ -1,6 +1,10 @@
 # Backend quick reference
 
-This folder implements the FastAPI service described in [`docs/BACKEND.md`](../docs/BACKEND.md) and [`docs/API_CONTRACTS.md`](../docs/API_CONTRACTS.md). Use those files for full details; the summary below only covers local setup.
+This folder implements the FastAPI service described in:
+- `docs/BACKEND.md`
+- `docs/API_CONTRACTS.md`
+
+Use those docs for full details; the summary below focuses on local setup.
 
 ## Local run
 ```bash
@@ -10,13 +14,20 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 uvicorn backend.app:app --host 0.0.0.0 --port 8000
 ```
-Environment variables such as `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODELS_DIR`, `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE` and `BDI_AREA_MM2_THR` override defaults (see `app.py`/`config.py`).
 
-## Endpoints
-`/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, `/manifest` and the dataset helper routes — payloads and responses exactly match [`docs/API_CONTRACTS.md`](../docs/API_CONTRACTS.md). The GUI always supplies `role_id`, `roi_id`, `mm_per_px` and the ROI `shape` mask so `roi_mask.py` can apply the same crop geometry used on the WPF side.
+## Common env vars
+- `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`
+- `BDI_MODELS_DIR`
+- `BDI_REQUIRE_CUDA`
+- `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`
+- `BDI_MIN_OK_SAMPLES`, `BDI_TRAIN_DATASET_ONLY`
+- `BDI_CACHE_MAX_ENTRIES`
+- `BDI_CORS_ORIGINS`
+- `BDI_GUI_LOG_DIR`
+
+## Logging
+Backend diagnostics are written as JSONL to `backend_diagnostics.jsonl` in the resolved log directory. See `LOGGING.md`.
 
 ## Recipes and reserved ids
-- The backend is recipe-aware for artifacts stored under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
-- Recipe context comes from `recipe_id` (when provided) or `X-Recipe-Id`.
-- `last` is reserved and invalid as a backend recipe id (HTTP 400).
-- Recipe ids are normalized (sanitized + lowercase) for storage; treat them as case-insensitive.
+- `recipe_id` is normalized and validated; `last` is reserved and rejected with HTTP 400.
+- Artifacts live under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.

--- a/backend/agents_for_backend.md
+++ b/backend/agents_for_backend.md
@@ -1,72 +1,63 @@
-# Backend Playbook — Octubre 2025
+# Backend Playbook
 
-Este playbook orienta a asistentes que modifican el backend FastAPI. Mantiene las restricciones de `agents.md` y resalta el contrato con la GUI.
+Este playbook orienta a asistentes que modifican el backend FastAPI. Mantiene las restricciones de `agents.md` y el contrato con la GUI.
 
 ## 1. Layout
 ```
 backend/
-  app.py              # FastAPI: /health, /fit_ok, /calibrate_ng, /infer, /manifest, /datasets/*
-  infer.py            # Orquestación de inferencia PatchCore
+  app.py              # FastAPI routes
+  infer.py            # Orquestación de inferencia
   calib.py            # Lógica de calibración
   patchcore.py        # Memoria PatchCore + coreset
   features.py         # Extractor DINOv2 ViT-S/14
   storage.py          # Persistencia datasets/modelos
-  roi_mask.py         # Generación de máscaras rect/circle/annulus
-  utils.py            # Utilidades (logging, timers, base64)
+  roi_mask.py         # Máscaras rect/circle/annulus
+  diagnostics.py      # Logs JSONL
   requirements.txt
   README_backend.md
 ```
 
 ## 2. Contrato API (estable)
-- `GET /health` → `{ status, device, model, version, request_id, recipe_id, reason? }`
-- `POST /fit_ok` (multipart) → campos `role_id`, `roi_id`, `mm_per_px`, `images[]`, opcional `memory_fit`, `recipe_id`, `model_key`
-- `POST /calibrate_ng` (JSON) → `{ role_id, roi_id, mm_per_px, ok_scores[], ng_scores?[], score_percentile?, area_mm2_thr?, recipe_id? }`
-- `POST /infer` (multipart) → `role_id`, `roi_id`, `mm_per_px`, `image`, `shape`, opcional `recipe_id`, `model_key`
-- Respuestas incluyen `request_id` y `recipe_id` **en el JSON** (no headers). Campos detallados en `docs/API_CONTRACTS.md`.
-- `/manifest` y `/datasets/*` existen para inspeccionar el estado y gestionar datasets.
+- `GET /health`
+- `POST /fit_ok`
+- `POST /calibrate_ng`
+- `POST /calibrate_dataset`
+- `POST /infer`
+- `POST /infer_dataset`
+- `GET /manifest`, `GET /state`
+- `/datasets/*` (upload/list/file/meta/delete/clear)
+
+Detalles completos en `docs/API_CONTRACTS.md`.
 
 ## 3. Persistencia
-- Directorio raíz configurable vía `BDI_MODELS_DIR` (legacy `BRAKEDISC_MODELS_DIR`).
-- Estructura:
+- `BDI_MODELS_DIR` define la raíz.
+- Layout actual (recipe-aware):
 ```
 <BDI_MODELS_DIR>/
   recipes/<recipe_id>/<model_key>/
-    <role>__<roi>.npz          # embeddings + token grid (+metadata)
-    <role>__<roi>_index.faiss  # índice FAISS opcional
-    <role>__<roi>_calib.json   # salida de /calibrate_ng
-  datasets/<role>/<roi>/ok|ng  # imágenes de dataset (si se usan los helpers /datasets/*)
+    <base_name>.npz
+    <base_name>_index.faiss
+    <base_name>_calib.json
+  recipes/<recipe_id>/datasets/<base_name>/{ok,ng}/*
 ```
-- `ModelStore.manifest` devuelve memoria, calibración y resumen de datasets (compatibilidad legacy incluida).
+- `base_name` = `base64(role_id) + "__" + base64(roi_id)` (urlsafe, sin padding).
+- Legacy fallback sigue existiendo (`models/datasets/<role>/<roi>`, `models/<role>_<roi>.*`).
 
-## 4. Pipeline de inferencia
-1. Validar existencia de memoria y la grilla de tokens.
-2. Procesar imagen (normalización + DINOv2).
-3. Calcular distancias kNN con coreset.
-4. Upsample del mapa a tamaño ROI.
-5. Aplicar máscara `shape`.
-6. Calcular `score` y detectar `regions`.
-7. Serializar heatmap (PNG base64) y responder JSON con `request_id`/`recipe_id`.
+## 4. Recipe ids
+- `recipe_id` debe cumplir `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- `last` es **reservado** y debe responder 400.
+- Los ids son case-insensitive (se normalizan a minúsculas).
 
-## 5. Calibración
-- Si `ng_scores` presente: umbral = punto medio entre `p99_ok` y `p5_ng`.
-- Si solo hay OK: usar percentil (`score_percentile`, por defecto 99).
-- Guardar calibración en `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/<role>__<roi>_calib.json`.
+## 5. Logging
+- Logs estructurados JSONL en `backend_diagnostics.jsonl`.
+- Directorio: `BDI_GUI_LOG_DIR` o `%LOCALAPPDATA%` (fallback a `backend/logs`).
+- Ver `LOGGING.md`.
 
-## 6. Configuración
-- Variables: `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`, `BDI_MODELS_DIR`, `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`, `BDI_CORS_ORIGINS`.
-- Config YAML opcional (`configs/app.yaml`) para overrides.
-- Logs: `slog` imprime JSON con `request_id`, `recipe_id`, `role_id`, `roi_id`.
+## 6. Validaciones y errores
+- `400`: memoria inexistente, token mismatch, inputs inválidos.
+- `409`: `mm_per_px` mismatch.
+- `500`: errores inesperados.
 
-## 7. Validaciones
-- `400` si falta memoria (`/infer`) o hay token grid mismatch.
-- `500` ante excepciones inesperadas con `{error, trace, request_id, recipe_id}`.
-
-## 8. QA
-- Ejecutar `pytest` antes de PR.
-- Usar `docs/API_CONTRACTS.md` para validar manualmente.
-- Revisar `docs/BACKEND.md` para detalles extendidos.
-
-## Notas sobre recipes (enero 2026)
-- El backend es *recipe-aware*: persiste memoria/índice/calibración/datasets bajo `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
-- `last` está **reservado** y NO puede usarse como `recipe_id` en el backend (debe responder 400 si se envía por header o payload).
-- El backend normaliza `recipe_id` (sanitizado + lowercase) antes de usarlo como clave en disco. Los clientes deben tratarlo como identificador *case-insensitive*.
+## 7. QA
+- Ejecutar `pytest` si aplica.
+- Validar manualmente con `docs/API_CONTRACTS.md`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,30 +1,34 @@
 # Docker instructions
 
-This directory only contains a single `Dockerfile` that builds the FastAPI backend on top of `pytorch/pytorch:2.2.2-cuda12.1-cudnn8-runtime`. It mirrors what the source code actually supports.
+This directory contains a Dockerfile for the **FastAPI backend**.
 
 ## Build image
 ```bash
 cd docker
 docker build -t brakedisc-backend ..
 ```
-The resulting image includes CUDA-enabled PyTorch, installs `backend/requirements.txt` (with any CPU-only torch indexes removed) and copies the `backend/` package.
 
 ## Run container
 ```bash
 docker run --gpus all -p 8000:8000 \
   -v /data/brakedisc/models:/app/models \
+  -e BDI_MODELS_DIR=/app/models \
+  -e BDI_GUI_LOG_DIR=/app/logs \
+  -v /data/brakedisc/logs:/app/logs \
   --name brakedisc-backend brakedisc-backend
 ```
-- The container executes `python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000`.
-- Logs are written to stdout (see `LOGGING.md`).
-- Mount a volume for `/app/models` if you want model persistence.
+
+- The container runs `python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000`.
+- Diagnostics logs are written to `BDI_GUI_LOG_DIR` as `backend_diagnostics.jsonl` (see `LOGGING.md`).
+- Mount volumes for `/app/models` and `/app/logs` to persist data and logs.
 
 ## Configure the GUI
-Point `Backend.BaseUrl` to the host/port exposed above (for example `http://server-ip:8000`). No additional headers or API keys are required.
+Point `Backend.BaseUrl` to the host/port exposed above (e.g. `http://server-ip:8000`).
 
 ## Multiple workers in Docker
-The default container command may start a single worker. To run multiple workers, override the command, for example:
+Override the command to increase workers:
 ```bash
-docker run --rm -p 8000:8000 -v "$(pwd)/models:/app/models" brakedisc-backend   python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000 --workers 2
+docker run --rm -p 8000:8000 -v "$(pwd)/models:/app/models" brakedisc-backend \
+  python -m uvicorn backend.app:app --host 0.0.0.0 --port 8000 --workers 2
 ```
-Ensure the mounted models directory is shared across workers/containers.
+Ensure `BDI_MODELS_DIR` points to a shared volume.

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -1,0 +1,88 @@
+# AI Onboarding (10-minute quickstart)
+
+This guide is optimized for new contributors and other AI agents. It is aligned with current code and avoids unverifiable claims.
+
+## 10-minute quickstart
+
+### 1) Start the backend
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn backend.app:app --host 0.0.0.0 --port 8000
+```
+
+### 2) Start the GUI
+1. Open `gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` in Visual Studio.
+2. Verify `config/appsettings.json` points to `http://127.0.0.1:8000` or set `BDI_BACKEND_BASEURL`.
+3. Run the app.
+
+### 3) Minimal flow
+1. Load an image and draw Master 1/2 and at least one inspection ROI.
+2. Add OK/NG samples (uploads to backend dataset).
+3. Run **fit_ok** (train from dataset) and **calibrate**.
+4. Run **Evaluate** (single image) or **Batch**.
+
+## Architecture: GUI vs backend
+- **GUI (WPF)**: ROI drawing, canonical crop/warp, layout persistence, master patterns, batch visualization.
+- **Backend (FastAPI)**: dataset/model storage, `fit_ok`, calibration, inference, heatmaps.
+
+The backend does **not** crop or rotate images; it consumes the canonical crop and `shape` JSON that the GUI produces.
+
+## Flow: dataset → fit_ok → calibrate → evaluate → batch
+1. **Dataset**: GUI uploads ROI crops to `/datasets/ok/upload` or `/datasets/ng/upload`.
+2. **fit_ok**: GUI calls `/fit_ok` with `use_dataset=true`.
+3. **Calibrate**: GUI calls `/calibrate_dataset` (or `/calibrate_ng` if using precomputed scores).
+4. **Evaluate**: GUI sends a single ROI crop to `/infer`.
+5. **Batch**: GUI aligns ROIs with master anchors and repeats `/infer` per ROI per image.
+
+## Persistence (backend)
+Artifacts are stored under `BDI_MODELS_DIR` (default `models/`):
+```
+<BDI_MODELS_DIR>/
+  recipes/<recipe_id>/<model_key>/
+    <base_name>.npz
+    <base_name>_index.faiss
+    <base_name>_calib.json
+  recipes/<recipe_id>/datasets/<base_name>/{ok,ng}/*
+```
+- `base_name = base64(role_id) + "__" + base64(roi_id)` (urlsafe, no padding).
+- `model_key` defaults to `roi_id`.
+
+### Recipe id rules
+- Valid: `^[a-z0-9][a-z0-9_-]{0,63}$`.
+- Reserved: `last` (HTTP 400 if used).
+- Stored case-insensitively (normalized to lowercase).
+
+## Debugging cookbook
+
+### HasFitOk (legacy)
+- `HasFitOk` may appear in old layout files.
+- It is removed during layout load and should be treated as **stale**.
+- Backend state (via `/state` or `/manifest`) is authoritative.
+
+### ROI2 batch heatmap missing
+- Known issue: ROI2 may not show after the first batch image.
+- Check `gui.log` and `gui_heatmap.log` for ROI2 placement messages.
+- TODO: verify and fix placement guard if ROI2 shares ROI1 geometry.
+
+### mm_per_px mismatch (HTTP 409)
+- The backend locks `mm_per_px` per `recipe_id` when training or dataset metadata includes it.
+- Fix by aligning GUI `mm_per_px` to the recipe, or reset recipe metadata if needed.
+
+### Logs and correlation
+- GUI logs: `%LOCALAPPDATA%\BrakeDiscInspector\logs\`.
+- Backend JSONL: `backend_diagnostics.jsonl` (see `LOGGING.md`).
+- Backend responses include `request_id` and `recipe_id` for correlation.
+
+## Glossary
+- **recipe_id**: backend namespace for datasets/models; validated and normalized.
+- **role_id**: logical role (Master1, Master2, Inspection).
+- **roi_id**: logical ROI identifier (often `inspection-<n>`).
+- **model_key**: backend model slot, defaults to `roi_id`.
+- **dataset**: OK/NG samples stored in the backend under `BDI_MODELS_DIR`.
+- **fit_ok**: PatchCore training step (OK-only memory/coreset).
+- **calibrate**: threshold selection using OK/NG scores or dataset sampling.
+- **evaluate**: run `/infer` on a single ROI crop.
+- **Enabled**: GUI-only toggle for whether a ROI participates in evaluation.

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -1,200 +1,163 @@
 # API contracts
 
-This document describes the backend HTTP contracts used by the GUI, and the recipe-aware behavior implemented in the FastAPI backend (`backend/app.py`).
+This document describes the **current FastAPI HTTP contracts** implemented in `backend/app.py`.
 
 ## Common headers
-
-- `X-Request-Id` (optional): opaque request correlation id. If missing, the backend generates one.
-- `X-Recipe-Id` (optional): recipe context for recipe-aware artifacts (memory, index, calibration, datasets).
+- `X-Request-Id` (optional): client-provided request correlation id.
+- `X-Recipe-Id` (optional): recipe context for artifact routing.
 
 ### Recipe resolution precedence
-
-For endpoints that accept `recipe_id` in the payload/query/form:
-
-1. Explicit `recipe_id` field/query parameter (if provided), else
-2. Header `X-Recipe-Id` (standard HTTP header; case-insensitive match), else
-3. `"default"`.
+For endpoints that accept `recipe_id` in payload/query/form:
+1. Explicit `recipe_id` in payload/query/form (if provided).
+2. `X-Recipe-Id` header.
+3. `default`.
 
 ### Reserved recipe ids
+- `last` is **reserved** and rejected with HTTP 400.
 
-The following values are reserved and MUST NOT be used as recipes by clients:
-
-- `last` — reserved for GUI layout state (e.g., `last.layout.json`). If provided as `X-Recipe-Id` or `recipe_id`, the backend will return **HTTP 400**.
-
-### Artifact fallback (recipe -> default)
-
-For recipe-aware artifacts (`memory`, `index`, `calib`, `datasets`), when `recipe_id != "default"` and the artifact does **not** exist for that recipe, the backend falls back to `"default"` (and finally to legacy layouts when applicable).
-
-This allows new recipes to inherit baseline models/calibration/datasets until they are trained.
+### Artifact fallback (recipe → default → legacy)
+When `recipe_id != "default"` and a recipe-specific artifact does not exist, the backend attempts:
+1. the requested recipe,
+2. the `default` recipe (for memory/index/calib and datasets),
+3. legacy layouts (flat or legacy directories).
 
 ---
 
 ## `GET /health`
-
-- **Request:** none (optional headers above).
-- **Response (200):**
+**Response (200):**
 ```json
 {
   "status": "ok",
   "device": "cuda",
   "model": "vit_small_patch14_dinov2.lvd142m",
   "version": "0.1.0",
-  "request_id": "a9d1f7d7-6b94-4e1c-9b6b-acde0a0b9c0d",
+  "request_id": "...",
   "recipe_id": "default",
   "reason": "cuda_not_available"
 }
 ```
-- `reason` is only present when CUDA is unavailable.
+`reason` is only present when CUDA is unavailable.
 
 ---
 
 ## `POST /fit_ok`
-
 Fits/updates PatchCore memory for a given `(role_id, roi_id)`.
 
-- **Content type:** `multipart/form-data`.
+- **Content type:** `multipart/form-data`
 - **Fields:**
   - `role_id` (string, required)
   - `roi_id` (string, required)
-  - `mm_per_px` (float, required) – currently informational; stored in calibration.
-  - `images` (file[], optional) – ROI crops (PNG/JPG). Required when `use_dataset=false`.
-  - `memory_fit` (bool-string, optional) – when `true`, disables coreset subsampling (`coreset_rate = 1.0`).
-  - `use_dataset` (bool-string, optional) – when `true`, train from backend dataset storage (no images required).
-  - `recipe_id` (string, optional) – overrides recipe context.
-  - `model_key` (string, optional) – logical model slot under the recipe. If omitted, defaults to `roi_id`.
-- **Notes:**
-  - By default, training is only allowed from datasets (`BDI_TRAIN_DATASET_ONLY=1`); set the env var to `0` to re-enable image uploads.
-  - `mm_per_px` is locked per recipe; mismatches return HTTP 409.
-  - When `use_dataset=true`, the dataset must contain at least 10 OK samples (configurable via `BDI_MIN_OK_SAMPLES`).
-- **Response (200):**
+  - `mm_per_px` (float, required)
+  - `images` (file[], optional) — required when `use_dataset=false`
+  - `memory_fit` (bool-string, optional) — set `true` to use full coreset
+  - `use_dataset` (bool-string, optional) — train from backend dataset
+  - `recipe_id` (string, optional)
+  - `model_key` (string, optional; defaults to `roi_id`)
+
+**Notes:**
+- If `BDI_TRAIN_DATASET_ONLY=1`, the backend rejects image uploads and requires `use_dataset=true`.
+- When `use_dataset=true`, `BDI_MIN_OK_SAMPLES` is enforced.
+- `mm_per_px` is locked per `recipe_id`; mismatches return HTTP 409.
+
+**Response (200):**
 ```json
 {
   "n_embeddings": 1234,
   "coreset_size": 120,
   "token_shape": [32, 32],
-  "coreset_rate_requested": 0.10,
-  "coreset_rate_applied": 0.0972,
-  "request_id": "…",
+  "coreset_rate_requested": 0.1,
+  "coreset_rate_applied": 0.097,
+  "request_id": "...",
   "recipe_id": "default"
 }
 ```
-- **Error responses:**
-  - `400` for malformed requests (e.g., no images, token grid mismatch across images), insufficient OK samples, or dataset-only deployments.
-  - `409` when `mm_per_px` does not match the recipe lock.
-  - `500` for unexpected failures.
 
 ---
 
 ## `POST /calibrate_ng`
+Computes and stores a calibration threshold for `(role_id, roi_id)`.
 
-Computes and stores a calibration JSON for a given `(role_id, roi_id)`.
-
-- **Content type:** `application/json`.
+- **Content type:** `application/json`
 - **Body:**
   - `role_id` (string, required)
   - `roi_id` (string, required)
-  - `model_key` (string, optional) – defaults to `roi_id`
+  - `model_key` (string, optional; defaults to `roi_id`)
   - `recipe_id` (string, optional)
   - `mm_per_px` (float, optional, default `0.2`)
   - `ok_scores` (float[], required)
-  - `ng_scores` (float[] | null, optional) – **null is accepted** and treated as "no NG".
-  - `score_percentile` (int, optional, default from config, typically 99)
-  - `area_mm2_thr` (float, optional, default from config)
-- **Response (200):**
+  - `ng_scores` (float[] or null, optional)
+  - `score_percentile` (int, optional)
+  - `area_mm2_thr` (float, optional)
+
+**Response (200):**
 ```json
 {
   "threshold": 12.34,
+  "ok_mean": 0.12,
+  "ng_mean": 1.23,
+  "p99_ok": 0.98,
+  "p5_ng": 0.05,
+  "mm_per_px": 0.2,
   "area_mm2_thr": 1.0,
   "score_percentile": 99,
-  "mm_per_px": 0.2,
-  "recipe_id": "default",
-  "model_key": "Pattern",
-  "request_id": "…"
+  "request_id": "...",
+  "recipe_id": "default"
 }
 ```
-- **Error responses:**
-  - `400` when required fields are missing or values are invalid.
-  - `500` for unexpected failures.
 
 ---
 
 ## `POST /infer`
-
 Runs inference on a single ROI crop.
 
-- **Content type:** `multipart/form-data`.
+- **Content type:** `multipart/form-data`
 - **Fields:**
   - `role_id` (string, required)
   - `roi_id` (string, required)
   - `mm_per_px` (float, required)
-  - `image` (file, required) – ROI crop (PNG/JPG)
-  - `shape` (string, optional) – JSON string for ROI shape/mask (see Shape schema).
+  - `image` (file, required)
+  - `shape` (string, optional) — JSON shape mask in canonical ROI coordinates
   - `recipe_id` (string, optional)
-  - `model_key` (string, optional) – defaults to `roi_id`
-- **Response (200):**
+  - `model_key` (string, optional; defaults to `roi_id`)
+
+**Response (200):**
 ```json
 {
   "score": 0.123,
   "threshold": 12.34,
   "token_shape": [32, 32],
-  "heatmap_png_base64": "iVBORw0K…",
-  "regions": [
-    {
-      "bbox": [10, 20, 30, 40],
-      "area_px": 123.0,
-      "area_mm2": 4.92,
-      "contour": [[…],[…]]
-    }
-  ],
-  "request_id": "…",
+  "heatmap_png_base64": "iVBORw0K...",
+  "regions": [{"bbox": [10, 20, 30, 40], "area_px": 123.0, "area_mm2": 4.92}],
+  "request_id": "...",
   "recipe_id": "default"
 }
 ```
-- `regions` are provided for visualization only.
-- **Error responses:**
-  - `400` if memory is missing, token grid mismatches, or inputs are invalid.
-  - `409` when `mm_per_px` does not match the recipe lock.
-  - `500` for unexpected failures.
+
+**Errors:**
+- `400` when memory is missing or token grid mismatches.
+- `409` when `mm_per_px` mismatches the recipe lock.
 
 ---
 
 ## `GET /manifest`
+Reports current memory/calibration/dataset status.
 
-Aggregates readiness information for a given `(role_id, roi_id)` in a recipe-aware manner.
-
-- **Query params:**
-  - `role_id` (string, required)
-  - `roi_id` (string, required)
-  - `recipe_id` (string, optional)
-  - `model_key` (string, optional; defaults to `roi_id`)
-- **Response (200):**
-```json
-{
-  "role_id": "Inspection",
-  "roi_id": "inspection-1",
-  "recipe_id": "default",
-  "model_key": "inspection-1",
-  "memory": true,
-  "calib": { "threshold": 12.34, "area_mm2_thr": 1.0, "score_percentile": 99, "mm_per_px": 0.2 },
-  "datasets": { "role_id": "Inspection", "roi_id": "inspection-1", "classes": { "ok": { "count": 10, "files": [...] } } },
-  "request_id": "…"
-}
-```
+- **Query params:** `role_id`, `roi_id` (required), `recipe_id`/`model_key` (optional).
+- **Response (200):** contains `memory` (bool), `calib` (object or null), and dataset summary.
 
 ---
 
 ## `GET /state`
+Lightweight readiness endpoint.
 
-Lightweight endpoint used by the GUI as an optional optimization (avoid re-fitting if already fitted).
-
-- **Query params:** `role_id`, `roi_id` (required), `recipe_id` (optional), `model_key` (optional).
+- **Query params:** `role_id`, `roi_id` (required), `recipe_id`/`model_key` (optional).
 - **Response (200):**
 ```json
 {
   "status": "ok",
   "memory_fitted": true,
   "calib_present": false,
-  "request_id": "…",
+  "request_id": "...",
   "recipe_id": "default",
   "role_id": "Inspection",
   "roi_id": "inspection-1",
@@ -206,172 +169,102 @@ Lightweight endpoint used by the GUI as an optional optimization (avoid re-fitti
 
 ## Dataset endpoints
 
-Datasets are stored recipe-aware under:
-`models/recipes/<recipe_id>/datasets/<base64(role_id + '|' + roi_id)>/<ok|ng>/*`
-
-Read/list operations apply recipe fallback to `"default"` when the recipe-specific dataset folder does not exist.
+### Storage layout
+Datasets are stored under:
+```
+<BDI_MODELS_DIR>/recipes/<recipe_id>/datasets/<base_name>/{ok,ng}/*
+```
+`base_name` is `base64(role_id) + "__" + base64(roi_id)` (urlsafe, no padding).
 
 ### `POST /datasets/ok/upload` and `POST /datasets/ng/upload`
-
-- **Content type:** `multipart/form-data`.
+- **Content type:** `multipart/form-data`
 - **Fields:**
-  - `role_id` (string, required)
-  - `roi_id` (string, required)
+  - `role_id`, `roi_id` (required)
   - `images` (file[], required)
-  - `metas` (string[], optional) – JSON strings aligned to `images[]`. Length must be `0` or `len(images)`.
+  - `metas` (string[], optional) — JSON strings aligned to `images`
   - `recipe_id` (string, optional)
-- **Notes:**
-  - If `metas[].mm_per_px` is provided, it is validated and locked per recipe; mismatches return HTTP 409.
-- **Response (200):**
-```json
-{ "status": "ok", "saved": ["20250101-120000-000001.png"], "request_id": "…", "recipe_id": "default" }
-```
+
+**Notes:**
+- If `metas[].mm_per_px` is present, it is validated and locked per recipe (HTTP 409 on mismatch).
 
 ### `GET /datasets/list`
-
 - **Query params:** `role_id`, `roi_id` (required), `recipe_id` (optional).
-- **Response (200):**
-```json
-{
-  "role_id": "Inspection",
-  "roi_id": "inspection-1",
-  "classes": {
-    "ok": { "count": 10, "files": [...], "meta": { "sample.png": true } },
-    "ng": { "count": 2, "files": [...], "meta": { "sample.png": false } }
-  },
-  "request_id": "…",
-  "recipe_id": "default"
-}
-```
+- **Response:** dataset classes, counts, and file lists.
 
 ### `GET /datasets/file`
-
-- **Query params:** `role_id`, `roi_id`, `label` (`ok|ng`), `filename` (required), `recipe_id` (optional).
-- **Response (200):** file download (image bytes).
+- **Query params:** `role_id`, `roi_id`, `label` (`ok|ng`), `filename`, `recipe_id` (optional).
+- **Response:** image bytes.
 
 ### `GET /datasets/meta`
-
-- **Query params:** `role_id`, `roi_id`, `label` (`ok|ng`), `filename` (required), `recipe_id` (optional).
-- **Response (200):**
-```json
-{
-  "role_id": "Inspection",
-  "roi_id": "inspection-1",
-  "label": "ok",
-  "filename": "sample.png",
-  "mm_per_px": 0.02,
-  "shape_json": {"kind":"circle","cx":200,"cy":200,"r":180},
-  "created_at_utc": "2025-01-01T12:00:00Z",
-  "request_id": "…",
-  "recipe_id": "default"
-}
-```
+- **Query params:** `role_id`, `roi_id`, `label`, `filename`, `recipe_id` (optional).
+- **Response:** per-sample metadata JSON.
 
 ### `DELETE /datasets/file`
-
-- **Query params:** `role_id`, `roi_id`, `label` (`ok|ng`), `filename` (required), `recipe_id` (optional).
-- **Response (200):**
-```json
-{ "deleted": true, "filename": "…", "request_id": "…", "recipe_id": "default" }
-```
+- **Query params:** `role_id`, `roi_id`, `label`, `filename`, `recipe_id` (optional).
+- **Response:** `{ "deleted": true|false, ... }`.
 
 ### `DELETE /datasets/clear`
-
 - **Query params:** `role_id`, `roi_id`, `label` (`ok|ng`), `recipe_id` (optional).
-- **Response (200):**
-```json
-{ "cleared": 10, "label": "ok", "request_id": "…", "recipe_id": "default" }
-```
+- **Response:** `{ "cleared": <count>, ... }`.
 
 ---
 
 ## `POST /infer_dataset`
+Runs inference over backend dataset files.
 
-Runs inference over the backend dataset with per-sample `mm_per_px` from metadata.
-
-- **Content type:** `application/json`.
+- **Content type:** `application/json`
 - **Body:**
-  - `role_id` (string, required)
-  - `roi_id` (string, required)
-  - `recipe_id` (string, optional)
-  - `model_key` (string, optional; defaults to `roi_id`)
-  - `labels` (string[], optional; defaults to `["ok","ng"]`)
-  - `include_heatmap` (bool, optional; defaults to `false`)
-  - `default_mm_per_px` (float, optional; used when metadata lacks `mm_per_px`)
-- **Response (200):**
+  - `role_id`, `roi_id` (required)
+  - `recipe_id`, `model_key` (optional)
+  - `labels` (optional; default `[
+    "ok",
+    "ng"
+  ]`)
+  - `include_heatmap` (bool, optional; default `false`)
+  - `default_mm_per_px` (float, optional)
+
+**Response:**
 ```json
 {
   "status": "ok",
-  "role_id": "Inspection",
-  "roi_id": "inspection-1",
-  "recipe_id": "default",
-  "model_key": "inspection-1",
-  "request_id": "…",
   "n_total": 3,
   "n_errors": 0,
-  "items": [
-    {
-      "label": "ok",
-      "filename": "sample.png",
-      "mm_per_px": 0.02,
-      "score": 1.23,
-      "threshold": 0.9,
-      "regions": [],
-      "n_regions": 0,
-      "error": null
-    }
-  ]
+  "items": [{"label": "ok", "score": 1.23, "error": null}]
 }
 ```
 
 ---
 
 ## `POST /calibrate_dataset`
+Calibrates threshold using backend datasets.
 
-Calibrates the threshold using backend dataset samples (per-sample `mm_per_px`).
-
-NG samples are required by default (`require_ng=true`).
-
-- **Content type:** `application/json`.
+- **Content type:** `application/json`
 - **Body:**
-  - `role_id` (string, required)
-  - `roi_id` (string, required)
-  - `recipe_id` (string, optional)
-  - `model_key` (string, optional; defaults to `roi_id`)
-  - `score_percentile` (int, optional; default from config)
-  - `area_mm2_thr` (float, optional; default from config)
-  - `default_mm_per_px` (float, optional)
-  - `require_ng` (bool, optional; defaults to `true`)
-- **Response (200):**
+  - `role_id`, `roi_id` (required)
+  - `recipe_id`, `model_key` (optional)
+  - `score_percentile`, `area_mm2_thr` (optional)
+  - `default_mm_per_px` (optional)
+  - `require_ng` (bool, optional; default `true`)
+
+**Response:**
 ```json
 {
   "status": "ok",
   "threshold": 0.9,
-  "score_percentile": 99,
-  "area_mm2_thr": 1.0,
   "n_ok": 10,
   "n_ng": 2,
-  "request_id": "…",
-  "recipe_id": "default",
-  "role_id": "Inspection",
-  "roi_id": "inspection-1",
-  "model_key": "inspection-1"
+  "request_id": "...",
+  "recipe_id": "default"
 }
 ```
 
+---
+
 ## Shape JSON schema
-
-When present, the GUI sends the ROI mask to the backend in canonical ROI coordinates (448×448). The backend recognizes three shapes (see `backend/roi_mask.py`):
-
+The GUI sends a `shape` JSON string in **canonical ROI coordinates** matching the uploaded ROI crop. Supported shapes:
 ```json
 { "kind": "rect", "x": 0, "y": 0, "w": 448, "h": 448 }
 { "kind": "circle", "cx": 224, "cy": 224, "r": 210 }
 { "kind": "annulus", "cx": 224, "cy": 224, "r": 210, "r_inner": 150 }
 ```
-
-Unknown kinds fall back to a full mask.
-
-## Recipe id normalization (implementation note)
-- The backend normalizes recipe ids (sanitization and lowercase) before using them as on-disk keys under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
-- Clients should treat recipe ids as case-insensitive; do not create two recipes that differ only by casing.
-- `last` is reserved and invalid (HTTP 400) when provided via header or payload.
+**Important:** these coordinates must match the ROI crop size you send (do **not** assume a fixed 448×448 unless your GUI always exports that size).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,45 +1,68 @@
 # Architecture
 
-This document summarises how the current codebase is wired: which processes exist, how data flows between them and where the persistent artefacts live. All statements below reference concrete classes and files in this repository.
+This document summarizes **how the current codebase is wired** and where data lives. It only describes behavior that is visible in the repository.
 
 ## Components
-### WPF front-end (`gui/BrakeDiscInspector_GUI_ROI`)
-- `MainWindow` hosts the ROI canvas, dataset panes and batch grid. It loads `MasterLayout`/`InspectionRoiConfig` records from `Layouts/*.layout.json`, wires `WorkflowViewModel` to XAML commands and forwards log messages to `GuiLog`. Layout names double as recipe identifiers for on-disk folders under `<exe>/Recipes/`. The **Clear canvas** command now resets masters, inspection slots, cached baselines and overlays, disables every inspection ROI and reinitialises the wizard state before persisting the empty layout.
-- `WorkflowViewModel` coordinates user actions: exporting canonical ROIs (`_exportRoiAsync` delegates to `RoiCropUtils`), calling the backend through `Workflow.BackendClient`, refreshing dataset previews and driving manual/batch inference while keeping the active layout name in sync with `DatasetManager`. Analyze search options (rotation range, scale min/max, matcher thresholds) are synchronised from the layout back into the preset UI so the search sliders mirror what was persisted with the layout instead of reverting to defaults.
-- `RoiOverlay` plus the `RoiAdorner`/`ResizeAdorner`/`RoiRotateAdorner` family render and edit ROI shapes. `InspectionAlignmentHelper.MoveInspectionTo` transforms each inspection ROI using the detected Master 1/2 centers and the ROI’s configured anchor (`InspectionRoiConfig.AnchorMaster`), applying translation/rotation/scale per ROI instead of a single global transform.
 
-### Python backend (`backend/`)
-- `app.py` is the FastAPI entry point exposing `GET /health`, `POST /fit_ok`, `POST /calibrate_ng` and `POST /infer`.
-- `features.py` (DINOv2), `patchcore.py` (coreset and kNN) and `infer.py` (heatmap post-processing) make up the inference pipeline.
-- `ModelStore` (`storage.py`) persists embeddings as `.npz`, optional FAISS indices and calibration JSON files under `BDI_MODELS_DIR` (default `models/`).
+### WPF GUI (`gui/`)
+**Responsibilities (source of truth):**
+- ROI drawing and editing (rect/circle/annulus).
+- Canonical ROI export (crop + rotation) and `shape` JSON generation in canonical ROI coordinates.
+- Master patterns, inspection ROI layout, batch visualization.
+- UI state, layout persistence, and local previews.
 
-## Manual data flow
-1. The operator loads a single image; `WorkflowViewModel.BeginManualInspection` keeps track of the current file.
-2. When **Evaluate** is triggered, `WorkflowViewModel.EvaluateRoiAsync` calls `_exportRoiAsync`, which crops and rotates the ROI (`RoiCropUtils.TryBuildRoiCropInfo` + `TryGetRotatedCrop`) and serialises the ROI mask as JSON.
-3. The resulting PNG bytes, ROI-specific `role_id`/`roi_id` and `mm_per_px` are sent to `BackendClient.InferAsync`, which builds a multipart request for `/infer`. If the memory was not fitted yet, `EnsureFittedAsync` runs `/fit_ok` first using the OK samples already present for that ROI so manual evaluation can proceed without manual retries.
-4. `backend/app.py` loads the requested memory via `ModelStore`, reconstructs the coreset, runs `InferenceEngine.run` and returns `{score, threshold?, token_shape, regions[], heatmap_png_base64?}`.
-5. The GUI updates `Regions`, `InferenceScore` and repaints the overlay through `ShowHeatmapAsync`, which writes the decoded heatmap into the `HeatmapOverlay` image.
+**On-disk GUI artifacts:**
+- Layout and master assets live under `<exe>/Recipes/<LayoutName>/` (see `RecipePathHelper`).
+- Master patterns are saved under `<exe>/Recipes/<LayoutName>/Master/`.
+- Dataset *previews* are cached under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
 
-## Batch data flow
-1. The user selects a folder; `WorkflowViewModel.LoadBatchListFromFolder` enumerates every image recursively and creates `BatchRow` entries.
-2. `RunBatchAsync` loops through the snapshot. For each image it calls `RepositionInspectionRoisForImageAsync`, which invokes `InspectionAlignmentHelper` to align the saved inspection ROIs using Master 1/2 baselines. Each inspection slot uses its own anchor selection (`AnchorMaster`), and the transform derives scale/rotation from the vector between the detected master centers; when anchors are missing the ROI is left at its saved position.
-3. For each enabled inspection slot: `ExportRoiFromFileAsync` crops the ROI from the batch image, `BackendClient.EnsureFittedAsync` ensures `/fit_ok` was run at least once, and `/infer` is executed. `BatchCellStatus` is set to `Ok` or `Nok` based on the returned score vs. the calibrated threshold.
-4. Batch heatmaps share the same overlay control; `SetBatchHeatmapForRoi` and `UpdateBatchHeatmapIndex` keep manual and batch canvases aligned while logging placement metadata.
+### FastAPI backend (`backend/`)
+**Responsibilities (source of truth):**
+- Persistent storage of datasets, model artifacts, and calibration.
+- `fit_ok` training, calibration, inference, and heatmap generation.
+- Recipe-aware storage and artifact resolution with fallback to legacy layouts.
 
-## Datasets and persistence
-- Each layout name is a recipe stored at `<exe>/Recipes/<LayoutName or DefaultLayout>/`. `EnsureInspectionDatasetStructure` creates `Dataset/Inspection_<slot>/{ok,ng}` folders plus a per-slot `Dataset/Inspection_<slot>/Model/` directory. `DatasetManager.SaveSampleAsync` writes PNG+JSON samples into the recipe dataset tree, mapping backend-facing inspection IDs (`inspection-1..4`) to `Inspection_1..4` folder names (non-inspection ROIs use the ROI id directly).
-- The backend stores embeddings, indices and calibration files under `BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/` (default `models/`), using urlsafe base64 names for `<role>__<roi>`; legacy flat/legacy directory layouts are still read for backwards compatibility.
-- Batch results can be exported through whatever pipeline consumes the GUI logs; no intermediate CSV is written by the code.
+**Key modules:**
+- `app.py` — FastAPI routes and request validation.
+- `storage.py` — `ModelStore` persistence layout and recipe rules.
+- `features.py`, `patchcore.py`, `infer.py`, `calib.py` — PatchCore + DINOv2 pipeline.
+- `diagnostics.py` — structured JSONL diagnostics.
 
-## Configuration and contracts
-- GUI: `AppConfig` merges `config/appsettings.json`, `appsettings.json` and environment variables (`BDI_BACKEND_BASEURL`, `BDI_ANALYZE_*`, `BDI_HEATMAP_OPACITY`). Dataset roots are derived from the active layout name, not from `BDI_DATASET_ROOT`. Every backend call carries `role_id`, `roi_id`, `mm_per_px` and the ROI mask (`shape` JSON) so backend regions/heatmaps line up with the GUI overlay without extra transforms.
-- Backend: `_env_var` in `app.py` plus `backend/config.py` read the `BDI_*` environment variables. No API keys or `/metrics` routes are implemented in the checked-in code; `/manifest` is available for inspecting stored memory/calibration/dataset counts.
+## GUI ↔ backend boundary
+- **GUI** exports **canonical ROI crops** and supplies `shape` masks in the crop's coordinate system.
+- **Backend** **does not** crop or rotate images; it trusts the GUI-provided crop and `shape` mask.
 
-## Logging overview
-- GUI logs go to `%LocalAppData%/BrakeDiscInspector/logs/`: `gui.log` (general), `gui_heatmap.log`, `roi_load_coords.log`, `roi_analyze_master.log`. They are plain text with `yyyy-MM-dd HH:mm:ss.fff [LEVEL] message` format (see `Util/GuiLog.cs`).
-- Backend logs are emitted through `slog` in `app.py` and printed to stdout as JSON lines containing `ts`, `event`, `role_id`, `roi_id`, `request_id`, `recipe_id`, etc.
+This separation is fundamental for consistent overlays and debugging.
 
-## Recipe-aware backend artifacts
-- Backend artifacts are stored per recipe under `BDI_MODELS_DIR/recipes/<recipe_id>/...`.
-- Recipe context is resolved from an explicit `recipe_id` field (when present) or the `X-Recipe-Id` header.
-- `last` is reserved and invalid as a backend recipe id (400).
+## Data flow (high level)
+1. **Manual inspection**: GUI exports a canonical ROI crop → backend `/infer` → GUI overlays result.
+2. **Batch inspection**: GUI aligns ROIs using master anchors → exports crops per image → backend `/infer` per ROI.
+3. **Dataset management**: GUI uploads samples to backend `/datasets/*` → backend persists dataset → GUI downloads previews for display.
+
+## Persistence layout (backend)
+Artifacts are stored under `BDI_MODELS_DIR` (default `models/`).
+
+```
+<BDI_MODELS_DIR>/
+  recipes/<recipe_id>/<model_key>/
+    <base_name>.npz
+    <base_name>_index.faiss
+    <base_name>_calib.json
+  recipes/<recipe_id>/datasets/<base_name>/
+    ok/*.png
+    ng/*.png
+```
+
+Where:
+- `recipe_id` is validated, lowercased, and **must not** be `last`.
+- `model_key` defaults to `roi_id` and is sanitized for filesystem use.
+- `base_name` is `base64(role_id) + "__" + base64(roi_id)` (urlsafe base64 without `=` padding).
+
+Legacy fallbacks still exist for older layouts (`models/datasets/<role>/<roi>`, `models/<role>_<roi>.npz`, etc.).
+
+## Caching (current implementation)
+- **Backend caches** model memory and calibration per worker process. Cache size is capped by `BDI_CACHE_MAX_ENTRIES`.
+- **GUI caches** master patterns by path + `mtime` + size to avoid reloading identical images; stale caches are invalidated when files change.
+
+## Logging
+Logging is centralized in `LOGGING.md` and should be treated as the single source of truth.

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -1,75 +1,83 @@
 # Backend (FastAPI) reference
 
-The backend located in `backend/` exposes the same endpoints implemented in `backend/app.py`. This document describes what the code actually does.
+This document describes the backend in `backend/` as implemented in `backend/app.py` and related modules.
 
 ## Runtime overview
-- **Process:** FastAPI app served via `uvicorn backend.app:app`. Dependencies are listed in `backend/requirements.txt`; the provided Dockerfile already includes CUDA 12.1 + PyTorch 2.2.2.
-- **Modules:**
-  - `app.py`: HTTP layer, request validation, logging (`slog`).
-  - `features.py`: wraps the DINOv2 ViT-S/14 extractor (`DinoV2Features`).
-  - `patchcore.py`: PatchCore memory, coreset building, FAISS integration.
-  - `infer.py`: `InferenceEngine` running PatchCore, applying Gaussian blur, ROI masks (`roi_mask.py`) and generating regions.
-  - `calib.py`: `choose_threshold` helper used by `/calibrate_ng`.
-  - `storage.py`: `ModelStore` for `.npz` embeddings, FAISS blobs and calibration files.
+- **Server:** FastAPI, typically via `uvicorn backend.app:app`.
+- **Pipeline:** PatchCore + DINOv2 ViT-S/14 (`features.py`, `patchcore.py`, `infer.py`).
+- **Persistence:** `ModelStore` in `storage.py`.
+- **Diagnostics:** structured JSONL logs (`diagnostics.py`). See `LOGGING.md`.
 
 ## Configuration
-- Environment variables prefixed with `BDI_` (or legacy `BRAKEDISC_`) configure the server (see `_env_var` in `app.py` and `backend/config.py`). Relevant keys:
-  - `BDI_BACKEND_HOST`, `BDI_BACKEND_PORT`: default `127.0.0.1:8000`.
-  - `BDI_MODELS_DIR`: directory for embeddings/calibration (default `models`).
-  - `BDI_REQUIRE_CUDA`: when `1` (default), the backend fails to start if CUDA is unavailable. Set to `0` for CI/tests.
-  - `BDI_CORESET_RATE`, `BDI_SCORE_PERCENTILE`, `BDI_AREA_MM2_THR`: override inference defaults.
-  - `BDI_MIN_OK_SAMPLES`: minimum OK samples required when training from datasets (default `10`).
-  - `BDI_TRAIN_DATASET_ONLY`: when `1` (default), `/fit_ok` rejects image uploads and requires `use_dataset=true`.
-  - `BDI_CORS_ORIGINS`: comma-separated list for CORS (`*` by default).
-  - `BDI_BACKEND_BASEURL` is consumed by the GUI client, not the server.
-- Optional `configs/app.yaml` is parsed by `backend/config.py` if `pyyaml` is installed; it merges shallowly with the defaults.
-- There is **no API key or `/metrics` endpoint** in this codebase. A lightweight `/manifest` endpoint is implemented to inspect stored memory/calibration/dataset counts.
+Configuration is resolved from environment variables and optionally `configs/app.yaml` (if PyYAML is installed). Defaults live in `backend/config.py` and are used by `backend/app.py`.
+
+### Environment variables (current)
+- **Server:**
+  - `BDI_BACKEND_HOST` / `BDI_BACKEND_PORT` (legacy: `BRAKEDISC_BACKEND_HOST`, `BRAKEDISC_BACKEND_PORT`)
+- **Storage:**
+  - `BDI_MODELS_DIR` (legacy: `BRAKEDISC_MODELS_DIR`)
+- **Training / inference:**
+  - `BDI_CORESET_RATE`
+  - `BDI_SCORE_PERCENTILE`
+  - `BDI_AREA_MM2_THR`
+  - `BDI_MIN_OK_SAMPLES`
+  - `BDI_TRAIN_DATASET_ONLY`
+- **Runtime constraints:**
+  - `BDI_REQUIRE_CUDA` (default `1`; set to `0` for CPU-only)
+  - `BDI_CACHE_MAX_ENTRIES` (per-worker in-memory cache size)
+- **CORS:**
+  - `BDI_CORS_ORIGINS` (legacy: `BRAKEDISC_CORS_ORIGINS`)
+- **Logging:**
+  - `BDI_GUI_LOG_DIR` (optional override for diagnostics log directory)
 
 ## Persistence layout (`ModelStore`)
+`BDI_MODELS_DIR` defaults to `models/` relative to the backend.
+
 ```
 <BDI_MODELS_DIR>/
   recipes/<recipe_id>/<model_key>/
-    <role>__<roi>.npz          # embeddings + token grid (+metadata JSON string)
-    <role>__<roi>_index.faiss  # optional FAISS index (if faiss is installed)
-    <role>__<roi>_calib.json   # stored output of /calibrate_ng
-  recipes/<recipe_id>/datasets/<role>__<roi>/ok|ng
-    <uuid>.<ext>              # dataset images
-    <uuid>.json               # sidecar metadata (mm_per_px, shape_json, etc.)
+    <base_name>.npz
+    <base_name>_index.faiss
+    <base_name>_calib.json
+  recipes/<recipe_id>/datasets/<base_name>/
+    ok/*.png
+    ok/*.json
+    ng/*.png
+    ng/*.json
 ```
-File names use urlsafe base64 encoding of `role_id`/`roi_id` (`ModelStore._base_name`), so the exact ids sent by the GUI remain round-trippable even if they contain dashes. `recipe_id` and `model_key` (defaults to `roi_id`) are sanitized and used to namespace artefacts under `recipes/`. Legacy layouts (`models/<role>/<roi>/memory.npz`, or flat `<role>_<roi>.npz`) are still read for backward compatibility.
 
-## Endpoint behaviour
-- `GET /health`: returns `{status, device, model, version, request_id, recipe_id}`; device is `cuda` when `torch.cuda.is_available()`. Includes `reason: cuda_not_available` on CPU-only hosts.
+**Naming rules:**
+- `recipe_id` is lowercased, validated by `^[a-z0-9][a-z0-9_-]{0,63}$`, and **must not** be `last`.
+- `model_key` defaults to `roi_id` and is sanitized for filesystem use.
+- `base_name` is `base64(role_id) + "__" + base64(roi_id)` using urlsafe base64 without padding.
+
+**Legacy compatibility:**
+- Datasets: `models/datasets/<role>/<roi>`.
+- Memory/index/calibration: `models/<role>_<roi>.*` or `models/<role>/<roi>/...`.
+
+## Endpoint behavior (summary)
+See `docs/API_CONTRACTS.md` for exact request/response schemas.
+
+- `GET /health`: returns `{status, device, model, version, request_id, recipe_id}`.
 - `POST /fit_ok`:
-  - Input: multipart form with `role_id`, `roi_id`, `mm_per_px`, optional `memory_fit` flag, optional `use_dataset` flag, and multiple `images` (PNG/JPG ROI crops).
-  - Training from datasets enforces `BDI_MIN_OK_SAMPLES` and is the only allowed mode when `BDI_TRAIN_DATASET_ONLY=1`.
-  - `mm_per_px` is locked per recipe; mismatches return HTTP 409.
-  - For each image `_extractor.extract` is called; the embeddings are concatenated, a coreset is built via `PatchCoreMemory.build` and persisted through `ModelStore.save_memory`. If FAISS is installed its serialised index is also saved.
-  - Output: JSON with `n_embeddings`, `coreset_size`, `token_shape`, `coreset_rate_requested`, `coreset_rate_applied`, `request_id`, `recipe_id`.
-- `POST /calibrate_ng`:
-  - Input JSON: `{role_id, roi_id, mm_per_px?, ok_scores[], ng_scores?[], area_mm2_thr?, score_percentile?}`.
-  - Uses `choose_threshold`, writes the result via `ModelStore.save_calib` and returns `{threshold, ok_mean, ng_mean?, p99_ok?, p5_ng?, mm_per_px, area_mm2_thr, score_percentile, request_id, recipe_id}`.
-- `POST /infer`:
-  - Multipart form with `role_id`, `roi_id`, `mm_per_px`, single `image`, optional `shape` JSON string. The server decodes the image with OpenCV, verifies the token grid matches the stored memory, reconstructs the coreset (optionally loading FAISS) and runs `InferenceEngine.run`.
-  - `mm_per_px` is locked per recipe; mismatches return HTTP 409.
-  - Response: `{score, threshold?, token_shape, heatmap_png_base64?, regions[], request_id, recipe_id}`. `heatmap_png_base64` is the grayscale PNG produced by encoding `heatmap_u8`. The GUI always sends the ROI mask (`shape`) and `mm_per_px`, so `roi_mask.py` uses the exact crop geometry while `infer` converts `area_px` to `area_mm2` for the returned regions.
-  - Errors: `400` for missing memory or token mismatch (message in the `error` field); `500` responses include `{error, trace, request_id, recipe_id}`.
-- `GET /manifest`: query `role_id`, `roi_id` and returns `ModelStore` availability plus calibration and dataset counts.
-- `POST /infer_dataset`: runs inference over backend datasets using per-sample `mm_per_px` metadata.
-- `POST /calibrate_dataset`: calibrates threshold using backend datasets with per-sample `mm_per_px`.
-- Dataset utilities: `/datasets/ok/upload`, `/datasets/ng/upload` (accept `metas[]` JSON strings), `/datasets/list`, `/datasets/file` (GET/DELETE), `/datasets/meta`, `/datasets/clear` (DELETE).
+  - Can train from uploaded images or from datasets (`use_dataset=true`).
+  - When `BDI_TRAIN_DATASET_ONLY=1`, image uploads are rejected.
+  - Enforces `BDI_MIN_OK_SAMPLES` when using datasets.
+  - Locks `mm_per_px` per `recipe_id` and returns HTTP 409 on mismatches.
+- `POST /calibrate_ng`: computes and stores threshold using OK/NG score arrays.
+- `POST /infer`: runs inference on a single ROI crop; returns `score`, optional `threshold`, optional `heatmap_png_base64`, and `regions`.
+- `POST /infer_dataset` / `POST /calibrate_dataset`: operate on backend datasets.
+- `GET /manifest` and `GET /state`: report artifact availability and readiness.
+- `/datasets/*` endpoints: upload, list, download, delete, and clear dataset files.
+
+## Recipe id rules
+- Reserved id: `last` (HTTP 400 if provided).
+- Case-insensitive for storage; do **not** create two recipes with the same letters in different casing.
+
+## Failure modes (common)
+- **400**: missing memory, token grid mismatch, missing OK samples, invalid recipe id.
+- **409**: `mm_per_px` mismatch for a recipe.
+- **500**: unexpected server errors.
 
 ## Logging
-`app.py` uses the helper `slog(event, **kw)` which prints JSON lines to stdout/stderr. Fields include `ts`, the logical event (`fit_ok.request`, `fit_ok.response`, etc.), `role_id`, `roi_id`, `request_id`, `recipe_id`, `elapsed_ms`, and error information. Request/recipe IDs are returned in every JSON response and mirrored in log lines for correlation.
-
-## Running tests
-`pytest` is configured under `backend/tests/`. The suite expects a working Python environment with NumPy, Torch, etc. If you only need to validate HTTP contracts, use the real FastAPI server plus the curl snippets from `docs/API_CONTRACTS.md`.
-
-## Recipe ids and normalization
-- Recipe ids are sanitized for filesystem safety and normalized to lowercase for storage.
-- Treat recipe ids as case-insensitive identifiers; do not rely on casing differences.
-- `last` is reserved and MUST be rejected with HTTP 400.
-
-## Concurrency and multi-worker deployments
-- The backend can be deployed with multiple Uvicorn workers (`--workers N`).
-- Each worker has its own process memory; avoid relying on in-process caches for correctness. All durable state must be persisted under `BDI_MODELS_DIR`.
+The backend uses **structured JSONL diagnostics** (not stdout-only). See `LOGGING.md` for log locations and fields.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog (selected)
-## 2026-01
-- Recipe-aware backend artifacts and dataset helpers (per-recipe persistence + default fallback).
-- Reserved recipe id `last` rejected by backend (HTTP 400); GUI avoids sending it.
-- Type-safety cleanup to reduce Pylance errors; safer feature/token extraction and concurrency locks.
-- GUI batch inspection controls repositioned for better visibility.
+
+## Implemented
+- Recipe-aware backend storage under `BDI_MODELS_DIR/recipes/<recipe_id>/...` with legacy fallback.
+- Reserved `recipe_id` `last` rejected with HTTP 400.
+- Dataset-only training gate via `BDI_TRAIN_DATASET_ONLY` and minimum OK samples via `BDI_MIN_OK_SAMPLES`.
+- Backend diagnostics written as JSONL (`backend_diagnostics.jsonl`) in a resolved log directory.
+
+## Planned / Spec
+- Heatmap overlay rule: **only show red overlay when result is NG and heatmap is the cause of NG**.
+- OK/NG badge spec: square badge with bold white `OK`/`NG` on green/red background.
+- Batch issue: ROI2 heatmap missing after the first image — investigate and add regression guard.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,73 +1,75 @@
 # Front-end (WPF) reference
 
-The GUI is implemented in `gui/BrakeDiscInspector_GUI_ROI`. This guide describes the structure that actually exists in the codebase and the workflows exposed to operators.
+This document describes the WPF GUI under `gui/` as implemented in the repository.
 
-## Application structure
-- **Entry point:** `App.xaml` loads `MainWindow`. `AppConfigLoader` merges `config/appsettings.json`, `appsettings.json` and environment overrides (`BDI_BACKEND_BASEURL`, `BDI_ANALYZE_*`, `BDI_HEATMAP_OPACITY`).
-- **Main window:** `MainWindow.xaml.cs` instantiates `WorkflowViewModel`, sets up ROI overlays, handles image loading and delegates log output to `GuiLog`. It resolves the recipe root via `EnsureDataRoot`, which maps the current layout name to `<exe>/Recipes/<LayoutName or DefaultLayout>/`.
-- **View model:** `WorkflowViewModel` contains all commands bound in XAML:
-  - Dataset commands: `AddRoiToDatasetOkCommand`, `AddRoiToDatasetNgCommand`, `RemoveSelectedCommand`, `RefreshDatasetCommand`, `BrowseDatasetCommand`, `OpenDatasetFolderCommand`.
-  - Training/calibration: `TrainSelectedRoiCommand`, `CalibrateSelectedRoiCommand`, `InferFromCurrentRoiCommand`, `EvaluateSelectedRoiCommand`, `EvaluateAllRoisCommand`, `InferEnabledRoisCommand`.
-  - Batch: `BrowseBatchFolderCommand`, `StartBatchCommand`, `PauseBatchCommand`, `StopBatchCommand`.
-  - Health: `RefreshHealthCommand`.
-- **Backend client:** `Workflow/BackendClient` wraps `HttpClient` with strongly typed methods for `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` and provides helper APIs such as `EnsureFittedAsync`.
+## Responsibilities (GUI vs backend)
+**GUI (source of truth for geometry):**
+- ROI drawing and editing (rect/circle/annulus).
+- Canonical ROI export (crop + rotation) and `shape` JSON generation.
+- Master patterns, layout persistence, batch visualization.
 
-## Setup GUI (appearance + persistence)
-- **What is configurable:** the setup UI captures theme preference, font families (body/header), font sizes (window title, section title, group header, control label/text, button text, checkbox) and core brushes/colors (foreground, accent, button foreground/background/hover, group header foreground).
-- **Persistence location:** `%LOCALAPPDATA%\BrakeDiscInspector\gui_setup.json`.
-- **Resetting to defaults:** close the app and delete `gui_setup.json`; the next launch will recreate it with defaults.
-- **Startup behavior:** `App.xaml.cs` loads the settings via `GuiSetupSettingsService.LoadOrDefault`, applies them to the resource dictionary, and re-applies the selected theme preference automatically.
-- **Logs:** setup persistence writes to `%LOCALAPPDATA%\BrakeDiscInspector\logs\gui_setup.log` (look for `[LOAD]`/`[SAVE]` entries).
+**Backend (source of truth for data):**
+- Datasets, models, calibration, and inference. See `docs/BACKEND.md`.
 
-## ROI editing and persistence
-- **Shapes:** `RoiModel` supports `Rectangle`, `Circle` and `Annulus`. Each ROI tracks both geometric data (center, radii, angle) and frozen state.
-- **Overlay/adorner:** `RoiOverlay` renders active shapes; `RoiAdorner`/`ResizeAdorner`/`RoiRotateAdorner` manipulate them. The adorner code is shared between manual and batch canvases and must stay untouched per `agents.md`.
-- **Circle/annulus geometry:** resizing keeps the bounding box square (diameter-based) and `SyncModelFromShape` mirrors the true center into `X/Y` and `CX/CY` so layout persistence and heatmap alignment stay in sync.
-- **Master layouts:** `MasterLayoutManager` reads/writes `Layouts/*.layout.json`. `MasterLayout` includes Master 1/2 pattern/search ROIs, inspection baselines and UI/analyse options. When loading a layout, `MainWindow` calls `EnsureInspectionDatasetStructure`, which assigns `Inspection_<n>` directories under the recipe’s `Dataset` folder to each slot.
-- **Alignment:** `InspectionAlignmentHelper.MoveInspectionTo` applies translation/rotation/scale from the saved Master anchors (`Master1Pattern`/`Master2Pattern`) to the currently detected anchors before batch inspection. Every inspection slot stores its preferred anchor in `InspectionRoiConfig.AnchorMaster`, and the transform derives scale and rotation from the vector between the detected master centers. If anchors are missing the ROI keeps its saved position; inner/outer radii stay clamped when annulus shapes are scaled.
-- **Canvas reset:** The **Clear canvas** button now clears adorners/overlays, removes persisted inspection ROIs from the canvas, empties cached inspection baselines and disables every inspection slot inside the current `MasterLayout` before reinitialising the wizard in `MainWindow`. Use it to avoid mixing new masters with stale inspection geometry.
+## Layouts and local storage
+- Layouts and master assets are stored under `<exe>/Recipes/<LayoutName>/`.
+- Master patterns are saved under `<exe>/Recipes/<LayoutName>/Master/`.
+- Dataset previews are cached under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
+
+> The GUI still creates local dataset folders (`<exe>/Recipes/<LayoutName>/Dataset/...`) for legacy compatibility, but the **authoritative dataset** is the backend dataset under `BDI_MODELS_DIR`.
 
 ## Dataset workflow (backend source of truth)
-- The dataset is stored in the backend under `BDI_MODELS_DIR/recipes/<recipe_id>/datasets/...` with image + JSON sidecar metadata per sample.
-- The GUI **does not** write dataset images to the recipe folder. Instead:
-  - When the operator adds OK/NG samples, the GUI posts the ROI PNG + metadata JSON to `/datasets/{ok|ng}/upload`.
-  - The dataset tab refreshes counts via `/datasets/list`.
-  - Thumbnails are cached locally under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\<recipe>\<role>_<roi>\<ok|ng>\` (cache only, not source of truth).
-- CSV import/legacy dataset browsing is intentionally disabled; the backend dataset is authoritative.
+- **Upload:** the GUI exports the canonical ROI and uploads it to `/datasets/ok/upload` or `/datasets/ng/upload`.
+- **List/preview:** the GUI calls `/datasets/list` and downloads thumbnails via `/datasets/file` into its local cache.
+- **Delete:** the GUI deletes remote files via `/datasets/file` (DELETE) and removes cached copies.
 
-## Manual vs batch inspection
-### Manual
-1. Load an image through the toolbar. `WorkflowViewModel.BeginManualInspection` remembers the path.
-   Analyze search sliders for rotation/scale are populated from the layout’s persisted `AnalyzeOptions` via `SyncPresetUiFromLayoutAnalyzeOptions`, so reloading a layout reuses the tuned search window instead of resetting to defaults.
-2. Select an inspection ROI; the canvas shows adorners so it can be edited/frozen.
-3. Click **Evaluate** (or **Evaluate all enabled ROIs**). `EvaluateRoiAsync` exports the canonical ROI via `_exportRoiAsync`, builds `InferRequest` with `RoleId`, `RoiId`, `MmPerPx` and `ShapeJson`, calls `BackendClient.InferAsync` (multipart POST to `/infer`), then updates `Regions`, `InferenceScore` and the heatmap overlay.
-4. `BackendMemoryNotFittedException` triggers an automatic `/fit_ok` using the OK samples already present under that ROI’s dataset path, so the UI can recover without manual intervention.
+## Training and inference flows
+- **fit_ok:** GUI calls `/fit_ok` with `use_dataset=true` to train from backend datasets.
+- **calibrate:** GUI calls `/calibrate_dataset` or `/calibrate_ng` depending on the workflow.
+- **infer:** GUI calls `/infer` for a single ROI crop, always including the `shape` JSON.
 
-### Batch
-1. Use **Browse batch folder** to pick a directory. `LoadBatchListFromFolder` collects every supported image and displays it in the batch grid.
-2. Press **Start batch**. `RunBatchAsync` iterates through all `BatchRow`s, calls `RepositionInspectionRoisForImageAsync` to align the saved ROIs and exports each enabled ROI via `ExportRoiFromFileAsync`.
-3. Before the first inference per ROI the view-model calls `BackendClient.EnsureFittedAsync` to make sure `/fit_ok` was executed. Each result updates the per-row `BatchCellStatus` and the shared heatmap overlay; optional pauses between ROIs are controlled by `BatchPausePerRoiSeconds`.
-4. Batch commands support pause/stop; they use `_pauseGate` plus a cancellation token to stop the loop gracefully.
+Exact HTTP contracts live in `docs/API_CONTRACTS.md`.
 
-## Backend contract from the GUI
-The GUI calls `/datasets/*` for dataset management, `/fit_ok` (with `use_dataset=true`) for training, `/calibrate_dataset` for calibration, and `/infer` for single-image inference. Every request includes:
-- `role_id`: derived from the ROI role (`Master1`, `Master2`, `Inspection`) or the inspection slot (e.g. `inspection-1`).
-- `roi_id`: inspection slot key (default `inspection-<n>`).
-- `mm_per_px`: resolved from `Preset` or the override UI field.
-- `shape`: JSON string describing the ROI in canonical coordinates (rectangles use `{kind:"rect", x, y, w, h}`, circles `{kind:"circle", cx, cy, r}`, annulus `{kind:"annulus", cx, cy, r, r_inner}`).
-`BackendClient` serialises these fields into multipart (`/fit_ok`, `/infer`) or JSON (`/calibrate_dataset`) using `HttpClient`. Batch mode builds a separate payload per enabled inspection ROI, honouring each slot’s anchor-based transform, and always sends the mask so backend heatmaps/regions align with the GUI overlay.
+## Enabled vs backend fitted state
+Each inspection ROI has a local **Enabled** toggle that controls **UI participation** in batch/inference.
+- **Enabled** is a GUI-only flag; it does **not** change backend artifacts.
+- Backend readiness is tracked separately (e.g., memory/calibration presence returned by `/state`).
 
-## Error handling
-- All HTTP calls run on background threads (`AsyncCommand`, `await`). Failure paths call `ShowMessageAsync` and clear heatmap/region state via `ResetAfterFailureAsync`.
-- Dataset errors mark `InspectionRoiConfig.DatasetStatus` with human-readable messages such as `Dataset missing OK samples` or `Dataset error: ...`.
-- Heatmap rendering issues are logged to `%LocalAppData%/BrakeDiscInspector/logs/gui_heatmap.log`; the UI falls back to hiding the overlay when a PNG fails to decode.
+**Legacy note:** older layout files may include `HasFitOk`. This field is migrated out on load and should be treated as **stale**. The backend is the source of truth for fitted state.
 
-## Useful files
-- ROI geometry: `RoiCropUtils.cs`, `InspectionAlignmentHelper.cs`, `RoiOverlay.cs`.
-- Dataset management: `Workflow/DatasetManager.cs`, `Workflow/DatasetSample.cs`.
-- Batch orchestration: `Workflow/WorkflowViewModel.cs` (`RunBatchAsync`, `UpdateBatchHeatmapIndex`, etc.).
-- Backend communications: `Workflow/BackendClient.cs`.
+### Where Enabled is controlled
+- **InspectionDefaultPanel:** checkbox next to each inspection ROI row (main panel).
+- **InspectionDatasetTabView:** an `Enabled` checkbox in the dataset tab.
 
-## Backend online indicator behavior
-- The status dot/text is driven by the workflow DataContext (`IsBackendOnline`, `HealthSummary`) and refreshed via the `RefreshHealthCommand` (`GET /health`).
-- If the backend is started after the GUI, a single refresh at startup can leave the indicator offline. Add polling or expose a manual refresh action if operators need live status.
+Both bind to the same `InspectionRoiConfig.Enabled` property and stay synchronized.
+
+## Master patterns (GUI-only)
+- Master patterns are **independent of the backend**.
+- Saved as `master1_pattern.png` / `master2_pattern.png` under `<exe>/Recipes/<LayoutName>/Master/`.
+- Older versions are moved to `Master/obsolete/` (no timestamp in the base filename).
+
+**Cache risk:** master patterns are cached by **path + mtime + size**. If you overwrite a file without changing its mtime/size, the GUI may reuse a stale cache. Recommended invalidation: update mtime or version the file name (timestamp suffix).
+
+## Heatmap & badge UI spec (current expectation)
+> This section is a UI spec. If the current implementation deviates, treat it as TODO and align UI later.
+
+### Heatmap visibility rules
+- Only show **red zones** when the **final result is NG** and the heatmap is the cause of NG.
+- If the result is **OK**, no heatmap overlay should be shown.
+- Apply the same rule in **manual** and **batch** views.
+
+### OK/NG badge
+- Square badge (width == height).
+- **NG:** red square, white text `NG`, very bold typography.
+- **OK:** green square, white text `OK`, very bold typography.
+
+## Known batch issue (ROI2)
+There is a known issue where **ROI2 heatmap may not appear after the first batch image**. The plan is:
+1. Confirm ROI2 placement logs in `gui.log`/`gui_heatmap.log`.
+2. Ensure the batch placement guard does not reuse ROI1 geometry for ROI2.
+3. Add a regression test or manual checklist step once fixed.
+
+## Related docs
+- `docs/ROI_AND_HEATMAP_FLOW.md` — ROI export + heatmap pipeline details.
+- `docs/LOGGING.md` — log locations and correlation.
+- `docs/TROUBLESHOOTING.md` — operational checklist.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,26 @@
+# Documentation index
+
+Use this page as the **single entry point** for all documentation in the repo.
+
+## Core docs
+- [`README.md`](../README.md) — project overview and quickstart.
+- [`docs/AI_ONBOARDING.md`](AI_ONBOARDING.md) — 10-minute onboarding + glossary.
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — component boundaries and data flow.
+- [`docs/FRONTEND.md`](FRONTEND.md) — WPF UI behaviors and specs.
+- [`docs/BACKEND.md`](BACKEND.md) — FastAPI configuration, persistence, failure modes.
+- [`docs/API_CONTRACTS.md`](API_CONTRACTS.md) — exact HTTP contracts.
+- [`docs/ROI_AND_HEATMAP_FLOW.md`](ROI_AND_HEATMAP_FLOW.md) — ROI export + heatmap flow.
+- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — common issues and fixes.
+- [`LOGGING.md`](../LOGGING.md) — **source of truth for logs**.
+- [`docs/CHANGELOG.md`](CHANGELOG.md) — implemented vs planned.
+
+## Operations
+- [`DEPLOYMENT.md`](../DEPLOYMENT.md) — backend deployment guide.
+- [`docker/README.md`](../docker/README.md) — Docker build/run.
+
+## Contributor / agent guides
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contributor workflow.
+- [`agents.md`](../agents.md) — project playbook.
+- [`instructions_codex_gui_workflow.md`](../instructions_codex_gui_workflow.md) — AI workflow checklist.
+- [`backend/README_backend.md`](../backend/README_backend.md) — backend quick reference.
+- [`backend/agents_for_backend.md`](../backend/agents_for_backend.md) — backend playbook.

--- a/instructions_codex_gui_workflow.md
+++ b/instructions_codex_gui_workflow.md
@@ -1,41 +1,44 @@
-# Workflow para agentes (GUI + Backend) — Actualización Octubre 2025
+# Workflow para agentes (GUI + Backend) — Actualización
 
-Este documento está orientado a asistentes IA que colaboran en tareas GUI/back-end. Resume restricciones de `agents.md` e incluye el contrato frontend ↔ backend.
+Este documento orienta a asistentes IA que colaboran en tareas GUI/back-end. Resume restricciones de `agents.md` y el contrato frontend ↔ backend.
 
 ## 1. Restricciones críticas
 - **No modificar** `RoiAdorner`, `ResizeAdorner`, `RoiRotateAdorner`, `RoiOverlay` salvo instrucción explícita.
-- Respetar pipeline de ROI canónica (`TryBuildRoiCropInfo`, `TryGetRotatedCrop`).
-- Mantener endpoints estables (`/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, `/manifest`, `/datasets/*`).
+- Reutilizar la **ROI canónica** (crop + rotación) existente.
+- Mantener endpoints estables (`/health`, `/fit_ok`, `/calibrate_ng`, `/infer`, `/calibrate_dataset`, `/infer_dataset`, `/manifest`, `/datasets/*`).
 
 ## 2. Pasos sugeridos para tareas GUI
-1. Identificar ViewModel implicado (`WorkflowViewModel`, `BackendClientService`).
-2. Confirmar que las llamadas HTTP son `async` y utilizan `CancellationToken` cuando corresponda.
-3. Validar actualizaciones de UI: logs (`AppendLog`), contadores de datasets, overlays.
-4. Al añadir campos nuevos, actualizar `docs/API_CONTRACTS.md` y las referencias en `docs/BACKEND.md`.
+1. Identificar el ViewModel o control implicado.
+2. Confirmar llamadas HTTP `async` y no bloquear el UI thread.
+3. Validar UI: overlays, dataset previews, batch alignment.
+4. Actualizar documentación (`docs/FRONTEND.md`, `docs/API_CONTRACTS.md`, `LOGGING.md`).
 
 ## 3. Pasos sugeridos para tareas backend
 1. Revisar `backend/app.py` para rutas afectadas.
-2. Actualizar lógica en `infer.py`, `calib.py`, `storage.py` sin romper contrato.
-3. Añadir tests en `backend/tests/` y ejecutar `pytest`.
-4. Documentar cambios en `docs/BACKEND.md` y `docs/API_CONTRACTS.md`.
+2. Mantener compatibilidad de `recipe_id`, `role_id`, `roi_id`, `model_key`.
+3. Actualizar `docs/BACKEND.md` y `docs/API_CONTRACTS.md`.
+4. Ejecutar `pytest` cuando aplique.
 
 ## 4. Contrato HTTP (resumen)
-- `GET /health` → status + device + version + request_id + recipe_id.
-- `POST /fit_ok` → multipart con `role_id`, `roi_id`, `mm_per_px`, `images[]`.
-- `POST /calibrate_ng` → JSON con `ok_scores`, `ng_scores?`, `score_percentile`, `area_mm2_thr`.
-- `POST /infer` → multipart con `image`, `shape` (rect/circle/annulus) en pixeles canónicos.
-- Todas las respuestas devuelven `request_id` y `recipe_id` en el JSON (detalles en `docs/API_CONTRACTS.md`).
+- `GET /health` → `{ status, device, model, version, request_id, recipe_id, reason? }`.
+- `POST /fit_ok` (multipart) → `role_id`, `roi_id`, `mm_per_px`, `images[]`, `use_dataset`, `memory_fit`, `recipe_id`, `model_key`.
+- `POST /calibrate_ng` (JSON) → `role_id`, `roi_id`, `ok_scores[]`, `ng_scores?`, `score_percentile`, `area_mm2_thr`.
+- `POST /calibrate_dataset` (JSON) → calibración usando datasets backend.
+- `POST /infer` (multipart) → `image`, `shape` (rect/circle/annulus) en coordenadas canónicas.
+- `POST /infer_dataset` (JSON) → inferencia sobre datasets backend.
 
-## 5. Documentación obligatoria a revisar antes de intervenir
-- `README.md`, `docs/ARCHITECTURE.md`, `docs/API_CONTRACTS.md`.
-- `docs/FRONTEND.md`, `docs/BACKEND.md`, `docs/ROI_AND_HEATMAP_FLOW.md`.
+Todos los responses incluyen `request_id` y `recipe_id` en el JSON; el backend también devuelve `X-Request-Id` en headers.
 
-## 6. Checklist final antes de PR
-- [ ] Tests backend (`pytest`).
-- [ ] Validación manual GUI (fit/calibrate/infer en dataset demo).
-- [ ] Documentación actualizada (este archivo + relevantes).
-- [ ] Capturas/heatmaps si hay cambios visuales.
+## 5. Logs (fuente de verdad)
+- Ver `LOGGING.md` para rutas y formatos.
+- Backend escribe JSONL en `backend_diagnostics.jsonl` (directorio resuelto por `BDI_GUI_LOG_DIR` o `%LOCALAPPDATA%`).
 
-## Backend readiness + recipe notes
-- The GUI health indicator uses `GET /health`. If the backend is not ready at app start, the indicator may remain offline until a refresh is executed.
-- The GUI must never send `X-Recipe-Id: last` (reserved). Use the active layout name; when the active layout name is `last`, the GUI must send no recipe header (fallback to `default`).
+## 6. Recipe IDs
+- `last` está **reservado** y el backend debe responder 400 si se envía.
+- `recipe_id` se normaliza a minúsculas y debe cumplir `^[a-z0-9][a-z0-9_-]{0,63}$`.
+
+## 7. Checklist final antes de PR
+- [ ] Tests backend (`pytest`) si aplica.
+- [ ] Validación manual GUI (fit/calibrate/infer/batch).
+- [ ] Documentación actualizada (incluye `docs/INDEX.md`).
+- [ ] Logs revisados (GUI + backend).


### PR DESCRIPTION
### Motivation

- Align all Markdown docs with the actual code (WPF GUI + FastAPI backend) and remove contradictory/legacy statements.
- Make logs, storage layout and frontend↔backend responsibilities explicit and machine/AI-friendly.
- Provide a short AI-friendly onboarding and a single docs index to accelerate ramp-up.

### Description

- Updated top-level docs and README to state that the GUI is source-of-truth for ROI geometry and the backend is source-of-truth for datasets/models, and to reference the new docs (e.g. `docs/ARCHITECTURE.md`, `docs/BACKEND.md`, `LOGGING.md`).
- Rewrote and consolidated logging guidance into `LOGGING.md` (JSONL backend diagnostics, GUI log locations, correlation tips) and updated references across docs.
- Clarified backend persistence and recipe rules (`BDI_MODELS_DIR/recipes/<recipe_id>/<model_key>/...`, `base_name` encoding, `recipe_id` validation and reserved id `last`) in `docs/BACKEND.md`, `docs/API_CONTRACTS.md`, and `backend/README_backend.md`.
- Documented API contracts and behaviors implemented in `backend/app.py` (endpoints, `fit_ok`/`calibrate_ng`/`infer` semantics, dataset helpers, `mm_per_px` locking and fallback rules) in `docs/API_CONTRACTS.md`.
- Aligned frontend docs (`docs/FRONTEND.md`, `docs/ROI_AND_HEATMAP_FLOW.md`) to describe canonical ROI export, `shape` JSON, `Enabled` vs backend fitted state, master pattern persistence and cache considerations, and provided a UI spec for heatmap/badge behavior.
- Added `docs/AI_ONBOARDING.md` (10-minute quickstart, architecture summary, debugging cookbook and glossary) and `docs/INDEX.md` as the documentation index.
- Harmonized contributor/agent playbooks (`agents.md`, `backend/agents_for_backend.md`, `instructions_codex_gui_workflow.md`, `CONTRIBUTING.md`) and deployment/docker README to reference the updated storage/logging/contracts.
- Minor improvements to `docker/README.md` to recommend log and models volume mounts and diagnostics location.

### Testing

- Documentation-only change: no backend or GUI code was modified, so no functional tests were executed.
- Manual verification performed: opened and reviewed each modified/new Markdown to ensure consistency with code (checked `backend/app.py`, `backend/storage.py`, GUI files under `gui/` for referenced fields and behaviors).
- Automated tests: none run as part of this PR (docs-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b735a0c98832b82642bfa88221858)