### PR TITLE
Avoid blocking master create drawing by clearing edit flags in StartDrawingFor

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -15137,28 +15137,22 @@ namespace BrakeDiscInspector_GUI_ROI
             bool wasEditingM1 = _editingM1;
             bool wasEditingM2 = _editingM2;
 
+            if (_editingM1 || _editingM2)
+            {
+                CancelMasterEditing(redraw: false);
+            }
+
+            _editingM1 = false;
+            _editingM2 = false;
+
             if (role == RoiRole.Master1Pattern || role == RoiRole.Master1Search)
             {
-                if (_editingM2)
-                {
-                    CancelMasterEditing(redraw: false);
-                }
-
-                _editingM1 = true;
                 _activeMaster1Role = role;
-                _editingM2 = false;
                 _activeMaster2Role = null;
             }
             else if (role == RoiRole.Master2Pattern || role == RoiRole.Master2Search)
             {
-                if (_editingM1)
-                {
-                    CancelMasterEditing(redraw: false);
-                }
-
-                _editingM2 = true;
                 _activeMaster2Role = role;
-                _editingM1 = false;
                 _activeMaster1Role = null;
             }
 


### PR DESCRIPTION
### Motivation
- `StartDrawingFor` previously set `_editingM1`/`_editingM2` to true when starting a master create, which caused canvas mouse handlers to ignore create-draw events and blocked the create flow.
- The change aims to allow starting a master ROI draw while still tracking which master role is active without entering "edit existing ROI" mode.

### Description
- In `StartDrawingFor` call `CancelMasterEditing(redraw: false)` if either `_editingM1` or `_editingM2` is set and then clear both `_editingM1` and `_editingM2` so create-mode drawing is not suppressed.
- Do not set `_editingM1`/`_editingM2` to true for create; instead set `_activeMaster1Role`/`_activeMaster2Role` to remember the target master role for the create flow.
- Preserve `_editModeActive`, `_state`, logging, `UpdateMasterEditButtonVisuals()`, `UpdateWorkflowMasterEditState()`, and `SetDrawToolFromShape()` so UI and wizard state remain consistent.

### Testing
- No automated tests were executed for this change (no `pytest`/GUI test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696de7ffbae0832bbcdeaa4b069ca3aa)