### PR TITLE
Fix batch heatmap flicker and align /infer calibration & heatmap contract

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/BackendAPI.cs
@@ -40,6 +40,7 @@ namespace BrakeDiscInspector_GUI_ROI
         public InferRegion[]? regions { get; set; }
         public int[]? token_shape { get; set; }
         public InferParams? @params { get; set; }
+        public string? decision { get; set; }
         public string? role_id { get; set; }
         public string? roi_id { get; set; }
         public string? error { get; set; }

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs
@@ -58,7 +58,7 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             var result = resp.result;
-            bool pass = !result.threshold.HasValue || result.score <= result.threshold.Value;
+            bool pass = !result.threshold.HasValue || result.score < result.threshold.Value;
             string thrText = result.threshold.HasValue ? result.threshold.Value.ToString("0.###") : "n/a";
             AppendLog($"[infer] Inspection score={result.score:0.###} thr={thrText} regions={(result.regions?.Length ?? 0)} status={(pass ? "OK" : "NG")}");
             string msg = pass

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendExceptions.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendExceptions.cs
@@ -20,5 +20,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         {
         }
     }
-}
 
+    public sealed class BackendCalibrationMissingException : BackendBadRequestException
+    {
+        public BackendCalibrationMissingException(string? detail = null)
+            : base("Backend calibration missing", detail)
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix a bug in BATCH mode where ROI heatmaps (especially ROI2) were painted and removed too quickly due to overlay selection/clearing races and stale placement actions. 
- Make backend/GUI contract for inference and calibration consistent so the GUI can rely on `decision` and explicit calibration errors, and avoid backend/GUI fallback thresholds that hid missing calibration.

### Description
- Preserve per-ROI heatmaps and avoid global clears by changing `SetBatchHeatmapForRoi` to only update selection when new bytes arrive or when the currently-displayed ROI is being removed, and replace global `ClearBatchHeatmap()` calls with `SetBatchHeatmapForRoi(null, roiIndex)` when a single ROI is disabled (`gui/.../Workflow/WorkflowViewModel.cs`).
- Prevent pre-selecting the next ROI before a real heatmap arrives by removing the premature `UpdateBatchHeatmapIndex` call in the batch loop and only selecting/updating when a heatmap payload is received (`WorkflowViewModel.cs`).
- Make placement resilient to stale captures and prioritize render: schedule placements with `DispatcherPriority.Render` when a new heatmap source/roi-index arrives, and if a scheduled action runs late reconcile the captured `roiIndex` with the current `BatchHeatmapRoiIndex` or abort the stale placement (`gui/.../MainWindow.xaml.cs`).
- Change the sentinel that marked a row as "placed" on `BatchRowOk` updates so it no longer prevents the first real placement; placement marking is kept when the final overlay is actually placed (`WorkflowViewModel.cs` & placement code paths).
- Align NG/OK decision and carry decision metadata: use `score >= threshold` for NG in GUI and backend, add a `decision` field to the `/infer` response and GUI DTOs, and let GUI prefer `decision` if present (`backend/app.py`, `gui/.../BackendClient.cs`, `BackendAPI.cs`, `WorkflowViewModel.cs`, `MainWindow.xaml.cs`).
- Backend `/infer` improvements: add optional `include_heatmap` form parameter, default to returning heatmap only for NG results (AUTO), and return a clear 400 error `{"error":"calibration_missing"}` when calibration threshold is absent or <= 0 (`backend/app.py`).
- GUI error alignment: detect backend calibration-missing errors and throw/display `BackendCalibrationMissingException` instead of silently falling back to a default threshold, and handle that error in manual and batch flows (`Workflow/BackendClient.cs`, `Workflow/BackendExceptions.cs`, `Workflow/WorkflowViewModel.cs`).

Files touched (high-level):
- backend/app.py — add `include_heatmap`, return `decision`, require calibration and explicit 400 for missing calibration.
- gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs — per-ROI heatmap storage/selection fixes, avoid clearing overlays globally, NG/threshold logic (>=), error handling for missing calibration.
- gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs — stale roiIndex guard, schedule placement with higher `DispatcherPriority` for heatmap updates and reconcile stale placements.
- gui/BrakeDiscInspector_GUI_ROI/Workflow/BackendClient.cs, BackendAPI.cs, BackendExceptions.cs — DTO updates (`decision`), surface calibration-missing as a specific exception and remove fallback threshold overrides.
- gui/BrakeDiscInspector_GUI_ROI/MainWindow.cs — minor threshold comparison adjustments in manual flows.

### Testing
- Ran unit/integration tests with `pytest` and all tests passed: `python -m pytest -q` → `7 passed`.
- Attempted to build the GUI with `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln -c Release` but `dotnet` is not available in the environment so the GUI build was not executed here.
- No GUI manual acceptance tests were executed in this environment; the code changes are targeted to preserve MANUAL behavior while fixing BATCH flicker and aligning contracts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f8779be7c832b9f642563abf7a2f0)