### PR TITLE
Add typing for stored PatchCore memory

### DIFF
--- a/backend/storage.py
+++ b/backend/storage.py
@@ -14,6 +14,8 @@ from .diagnostics import diag_event
 
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".bmp", ".webp"}
 
+MemoryPayload = Tuple[np.ndarray, Tuple[int, int], Dict[str, Any]]
+
 
 def _is_image_file(p: Path) -> bool:
     return p.is_file() and p.suffix.lower() in IMAGE_EXTS
@@ -392,7 +394,7 @@ class ModelStore:
 
 
 
-    def _load_memory_from_path(self, path: Path):
+    def _load_memory_from_path(self, path: Path) -> MemoryPayload:
         with np.load(path, allow_pickle=False) as z:
             emb = z["emb"].astype(np.float32)
             H = int(z["token_h"])
@@ -436,7 +438,14 @@ class ModelStore:
         np.savez_compressed(path, **payload)
         return path
 
-    def load_memory(self, role_id: str, roi_id: str, *, recipe_id: Optional[str] = None, model_key: Optional[str] = None):
+    def load_memory(
+        self,
+        role_id: str,
+        roi_id: str,
+        *,
+        recipe_id: Optional[str] = None,
+        model_key: Optional[str] = None,
+    ) -> Optional[MemoryPayload]:
         """
         Carga (embeddings, (Ht, Wt), metadata) o None si no existe.
 


### PR DESCRIPTION
### Motivation
- Pyright/type-checker warnings indicated `token_hw` and memory payloads were being treated as `object`, causing assignment errors when used as integer dimensions, so explicit typing is needed to clarify the stored memory shape and metadata.

### Description
- Introduced a `MemoryPayload = Tuple[np.ndarray, Tuple[int, int], Dict[str, Any]]` alias to document the stored memory layout.
- Annotated `_load_memory_from_path` with `-> MemoryPayload` to signal the exact return types from NPZ files.
- Annotated `load_memory` with `-> Optional[MemoryPayload]` to make the external API return type explicit.

### Testing
- No automated tests or type-checker runs were executed after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6970c067d5ac832bad4502292ba7edc7)