### PR TITLE
Fix typing for PatchCore memory cache handling

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -13,7 +13,7 @@ import datetime
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
 
 import numpy as np
 import cv2
@@ -694,6 +694,7 @@ def _get_patchcore_memory_cached(role_id: str, roi_id: str, *, recipe_id: str, m
             _MEM_CACHE.pop(key, None)
         return None
     emb_mem, token_hw_mem, metadata = loaded
+    token_hw_mem = cast(Tuple[int, int], token_hw_mem)
 
     faiss_cfg = SETTINGS.get("faiss", {}) or {}
     prefer_gpu = _is_truthy(faiss_cfg.get("prefer_gpu", 1))

--- a/backend/patchcore.py
+++ b/backend/patchcore.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+from typing import Any
+
 import numpy as np
 
 try:
@@ -55,6 +57,7 @@ class PatchCoreMemory:
         self.index = index
         self.nn = None
         self.coreset_rate = coreset_rate
+        self._faiss_gpu_res: Any | None = None
         if index is None:
             if _HAS_FAISS:
                 import faiss  # type: ignore


### PR DESCRIPTION
### Motivation
- Silence Pylance type errors when storing/loading PatchCore memory by making the FAISS GPU resource attribute explicit and casting the loaded token grid to a concrete tuple type.

### Description
- Add a typed `_faiss_gpu_res` attribute to `PatchCoreMemory` in `backend/patchcore.py` to hold optional FAISS GPU resources (`self._faiss_gpu_res: Any | None = None`).
- Import `cast` and cast the loaded `token_hw` value to `Tuple[int, int]` in `backend/app.py` (`token_hw_mem = cast(Tuple[int, int], token_hw_mem)`) before using it.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6970c238664c832bbd6b72abca013950)