### PR TITLE
Use current Analyze options for batch placement

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -5594,7 +5594,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             var m1BaselineCenter = new ImgPoint(m1bx, m1by);
             var m2BaselineCenter = new ImgPoint(m2bx, m2by);
 
-            var analyzeOpts = _layoutOriginal.Analyze ?? new AnalyzeOptions();
+            var analyzeOpts = _layout?.Analyze ?? _layoutOriginal?.Analyze ?? new AnalyzeOptions();
             input = new RoiPlacementInput(
                 m1BaselineCenter,
                 m2BaselineCenter,


### PR DESCRIPTION
### Motivation
- Batch placement used the deep-cloned `_layoutOriginal.Analyze` snapshot so toggling `DisableRot`/`ScaleLock` did not affect batch ROI placement or heatmap orientation, causing batch and Evaluate ROI to disagree.

### Description
- Prefer the live `_layout?.Analyze` when building the `RoiPlacementInput` in `TryBuildPlacementInputFromDetections`, falling back to `_layoutOriginal?.Analyze` and `new AnalyzeOptions()` in `WorkflowViewModel.cs` so UI toggles apply immediately to batch placement.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6970de581eec832bb0c39f3b4cfcbb17)