### PR TITLE
Fix heatmap placement/rotation for Batch Inspection and respect `DisableRot`

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Helpers/HeatmapOverlayHelper.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Helpers/HeatmapOverlayHelper.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace BrakeDiscInspector_GUI_ROI.Helpers
+{
+    public static class HeatmapOverlayHelper
+    {
+        public static bool TryGetDisplayRect(Image imageControl, out Rect displayRect, out int pixelWidth, out int pixelHeight)
+        {
+            displayRect = Rect.Empty;
+            pixelWidth = 0;
+            pixelHeight = 0;
+
+            if (imageControl?.Source is not BitmapSource bmp)
+            {
+                return false;
+            }
+
+            double cw = imageControl.ActualWidth;
+            double ch = imageControl.ActualHeight;
+            if (bmp.PixelWidth <= 0 || bmp.PixelHeight <= 0 || cw <= 0 || ch <= 0)
+            {
+                return false;
+            }
+
+            double scale = Math.Min(cw / bmp.PixelWidth, ch / bmp.PixelHeight);
+            double w = bmp.PixelWidth * scale;
+            double h = bmp.PixelHeight * scale;
+            double x = (cw - w) * 0.5;
+            double y = (ch - h) * 0.5;
+            displayRect = new Rect(x, y, w, h);
+            pixelWidth = bmp.PixelWidth;
+            pixelHeight = bmp.PixelHeight;
+            return true;
+        }
+
+        public static Rect? UpdateHeatmapOverlay(
+            Image overlay,
+            FrameworkElement canvasHost,
+            Rect displayRect,
+            int imagePixelWidth,
+            int imagePixelHeight,
+            RoiModel roiImageSpace,
+            double overlayOpacity,
+            bool disableRotation,
+            bool skipClip,
+            string modeTag,
+            Action<string>? log)
+        {
+            if (overlay == null || canvasHost == null || roiImageSpace == null)
+            {
+                return null;
+            }
+
+            if (displayRect.Width <= 0 || displayRect.Height <= 0 || imagePixelWidth <= 0 || imagePixelHeight <= 0)
+            {
+                log?.Invoke($"[heatmap:{modeTag}] skip placement (displayRect={displayRect}, imgPx={imagePixelWidth}x{imagePixelHeight}).");
+                return null;
+            }
+
+            var roiCanvasRect = ConvertRoiImageToCanvasRect(roiImageSpace, displayRect, imagePixelWidth, imagePixelHeight);
+
+            overlay.Width = Math.Max(1.0, roiCanvasRect.Width);
+            overlay.Height = Math.Max(1.0, roiCanvasRect.Height);
+            overlay.Opacity = overlayOpacity;
+
+            var parent = VisualTreeHelper.GetParent(overlay) as FrameworkElement;
+            bool parentIsCanvas = parent is Canvas;
+            string parentType = parent?.GetType().Name ?? "<null>";
+            Point hostOffset = new Point(0, 0);
+
+            if (!parentIsCanvas && parent != null)
+            {
+                try
+                {
+                    hostOffset = canvasHost.TransformToVisual(parent).Transform(new Point(0, 0));
+                }
+                catch (Exception ex)
+                {
+                    log?.Invoke($"[heatmap:{modeTag}] offset transform failed: {ex.Message}");
+                }
+            }
+
+            if (parentIsCanvas)
+            {
+                overlay.Margin = new Thickness(0);
+                Canvas.SetLeft(overlay, roiCanvasRect.Left);
+                Canvas.SetTop(overlay, roiCanvasRect.Top);
+            }
+            else
+            {
+                double leftRounded = Math.Round(hostOffset.X + roiCanvasRect.Left, MidpointRounding.AwayFromZero);
+                double topRounded = Math.Round(hostOffset.Y + roiCanvasRect.Top, MidpointRounding.AwayFromZero);
+                overlay.Margin = new Thickness(leftRounded, topRounded, 0, 0);
+            }
+
+            double angle = double.IsNaN(roiImageSpace.AngleDeg) ? 0.0 : roiImageSpace.AngleDeg;
+            if (disableRotation)
+            {
+                angle = 0.0;
+            }
+
+            var pivotLocal = RoiAdorner.GetRotationPivotLocalPoint(roiImageSpace, overlay.Width, overlay.Height);
+            if (overlay.RenderTransform is RotateTransform rotate)
+            {
+                rotate.Angle = angle;
+                rotate.CenterX = pivotLocal.X;
+                rotate.CenterY = pivotLocal.Y;
+            }
+            else
+            {
+                overlay.RenderTransform = new RotateTransform(angle, pivotLocal.X, pivotLocal.Y);
+            }
+
+            overlay.Clip = BuildClipGeometry(roiImageSpace, overlay.Width, overlay.Height, skipClip);
+
+            log?.Invoke(
+                $"[heatmap:{modeTag}] roiId={roiImageSpace.Id ?? "<null>"} shape={roiImageSpace.Shape} angle={roiImageSpace.AngleDeg:0.##} " +
+                $"disableRot={disableRotation} canvasRect=({roiCanvasRect.Left:0.##},{roiCanvasRect.Top:0.##},{roiCanvasRect.Width:0.##},{roiCanvasRect.Height:0.##}) " +
+                $"parent={parentType} parentIsCanvas={parentIsCanvas} hostOffset=({hostOffset.X:0.##},{hostOffset.Y:0.##})");
+
+            return roiCanvasRect;
+        }
+
+        public static Rect? GetRoiCanvasRect(Rect displayRect, int imagePixelWidth, int imagePixelHeight, RoiModel roiImageSpace)
+        {
+            if (roiImageSpace == null)
+            {
+                return null;
+            }
+
+            if (displayRect.Width <= 0 || displayRect.Height <= 0 || imagePixelWidth <= 0 || imagePixelHeight <= 0)
+            {
+                return null;
+            }
+
+            return ConvertRoiImageToCanvasRect(roiImageSpace, displayRect, imagePixelWidth, imagePixelHeight);
+        }
+
+        private static Rect ConvertRoiImageToCanvasRect(RoiModel roi, Rect displayRect, int imagePixelWidth, int imagePixelHeight)
+        {
+            double scaleX = displayRect.Width / imagePixelWidth;
+            double scaleY = displayRect.Height / imagePixelHeight;
+            double k = Math.Min(scaleX, scaleY);
+
+            if (roi.Shape == RoiShape.Circle || roi.Shape == RoiShape.Annulus)
+            {
+                double cx = displayRect.X + roi.CX * scaleX;
+                double cy = displayRect.Y + roi.CY * scaleY;
+                double r = roi.R * k;
+                return new Rect(cx - r, cy - r, r * 2.0, r * 2.0);
+            }
+
+            double w = roi.Width * scaleX;
+            double h = roi.Height * scaleY;
+            double centerX = displayRect.X + roi.X * scaleX;
+            double centerY = displayRect.Y + roi.Y * scaleY;
+            return new Rect(centerX - w / 2.0, centerY - h / 2.0, w, h);
+        }
+
+        private static Geometry? BuildClipGeometry(RoiModel roi, double overlayWidth, double overlayHeight, bool skipClip)
+        {
+            if (skipClip)
+            {
+                return null;
+            }
+
+            if (overlayWidth <= 0 || overlayHeight <= 0)
+            {
+                return null;
+            }
+
+            double outerR = Math.Max(overlayWidth, overlayHeight) * 0.5;
+            var center = new Point(overlayWidth * 0.5, overlayHeight * 0.5);
+
+            if (roi.R > 0 && roi.RInner > 0)
+            {
+                double innerR = outerR * (roi.RInner / roi.R);
+                var outer = new EllipseGeometry(center, outerR, outerR);
+                var inner = new EllipseGeometry(center, innerR, innerR);
+                return new CombinedGeometry(GeometryCombineMode.Exclude, outer, inner);
+            }
+
+            if (roi.R > 0)
+            {
+                return new EllipseGeometry(center, outerR, outerR);
+            }
+
+            return null;
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -1769,6 +1769,22 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             return GetInspectionRoiModelByIndex(idx);
         }
 
+        public RoiModel? GetInspectionRoiImageModel(int idx)
+        {
+            var roi = GetInspectionRoiModelByIndex(idx);
+            if (roi == null)
+            {
+                return null;
+            }
+
+            if (_isBatchRunning)
+            {
+                return GetBatchTransformedRoi(roi);
+            }
+
+            return roi.Clone();
+        }
+
         public Int32Rect? GetInspectionRoiImageRectPx(int idx)
         {
             var roi = GetInspectionRoiModelByIndex(idx);


### PR DESCRIPTION
### Motivation
- Batch heatmaps were misaligned/rotated (~±30°) compared to Evaluate ROI because the two flows used different placement pipelines and the `DisableRot` option was not consistently respected.
- The goal is to make Batch and Evaluate use the exact same image→canvas mapping, ROI source, rotation pivot and to honor the layout `DisableRot` flag.

### Description
- Added a shared helper `HeatmapOverlayHelper` (`Helpers/HeatmapOverlayHelper.cs`) that consolidates display-rect computation, ROI image→canvas rect conversion, overlay placement (Canvas vs Margin), rotation application with pivot, clipping geometry, and debug logging via `TryGetDisplayRect`, `UpdateHeatmapOverlay` and `GetRoiCanvasRect`.
- Updated Evaluate heatmap flow (`UpdateHeatmapOverlayLayoutAndClip` in `MainWindow.xaml.cs`) to use the new helper for sizing/positioning/rotation/clipping and to obtain `disableRotation` from `GetEffectiveAnalyzeOptions()` so `DisableRot` is respected.
- Updated Batch placement (`TryPlaceBatchHeatmap` / `TryPlaceBatchHeatmap` path in `MainWindow.xaml.cs`) to use the helper and to use `WorkflowViewModel.GetInspectionRoiImageModel` (added) which returns the batch-transformed/placed ROI when `_isBatchRunning`, ensuring Batch uses the same ROI source as Evaluate.
- Wiring ensures both flows pass the same `disableRotation` derived from layout analyze options, and logs include a `modeTag` so Batch vs Evaluate placements can be compared in `gui_heatmap.log`.

### Testing
- No automated tests were executed for this GUI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971d1c37974832ba00b29972df34645)