### PR TITLE
Adjust result text styling in Inspection Dataset tab

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml
@@ -170,6 +170,8 @@
             <TextBlock Margin="4,0,0,0">
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
+                        <Setter Property="FontSize" Value="16"/>
+                        <Setter Property="FontWeight" Value="SemiBold"/>
                         <Setter Property="Text" Value="—"/>
                         <Setter Property="Foreground" Value="Gray"/>
                         <Style.Triggers>


### PR DESCRIPTION
### Motivation
- Make the Result indicator in the inspection dataset panel visually consistent with the other dataset status text by increasing its size and weight.

### Description
- In `gui/BrakeDiscInspector_GUI_ROI/Workflow/InspectionDatasetTabView.xaml` add `FontSize="16"` and `FontWeight="SemiBold"` to the `TextBlock` style that displays the `LastResultOk`-bound Result text so the OK/NOK text matches the surrounding status styling.

### Testing
- No automated tests were run since this is a UI-only XAML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e467ed010832b8c55b79aea520669)