### PR TITLE
Invalidar comandos de dataset al cambiar ROI/contadores (Train/Calibrate)

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -1326,14 +1326,24 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             {
                 if (!ReferenceEquals(_selectedInspectionRoi, value))
                 {
+                    if (_selectedInspectionRoi != null)
+                    {
+                        _selectedInspectionRoi.PropertyChanged -= InspectionRoiPropertyChanged;
+                    }
+
                     _selectedInspectionRoi = value;
+                    if (_selectedInspectionRoi != null)
+                    {
+                        _selectedInspectionRoi.PropertyChanged += InspectionRoiPropertyChanged;
+                    }
+
                     OnPropertyChanged();
                     OnPropertyChanged(nameof(SelectedInspectionShape));
                     OnPropertyChanged(nameof(ActiveInspectionRoiModel));
                     OnPropertyChanged(nameof(ActiveInspectionRoiImageRectPx));
                     UpdateSelectedRoiState();
                     OpenDatasetFolderCommand.RaiseCanExecuteChanged();
-                    RemoveSelectedPreviewCommand.RaiseCanExecuteChanged();
+                    RaiseDatasetCommandCanExecuteChanged();
 
                     if (value != null)
                     {
@@ -2543,10 +2553,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             if (e.PropertyName == nameof(InspectionRoiConfig.DatasetOkCount)
                 || e.PropertyName == nameof(InspectionRoiConfig.DatasetKoCount)
-                || e.PropertyName == nameof(InspectionRoiConfig.IsDatasetLoading))
+                || e.PropertyName == nameof(InspectionRoiConfig.IsDatasetLoading)
+                || e.PropertyName == nameof(InspectionRoiConfig.Enabled)
+                || e.PropertyName == nameof(InspectionRoiConfig.BackendMemoryFitted)
+                || e.PropertyName == nameof(InspectionRoiConfig.BackendCalibPresent))
             {
-                TrainSelectedRoiCommand.RaiseCanExecuteChanged();
-                CalibrateSelectedRoiCommand.RaiseCanExecuteChanged();
+                RaiseDatasetCommandCanExecuteChanged();
             }
 
             if (ReferenceEquals(sender, SelectedInspectionRoi))
@@ -2554,7 +2566,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 if (e.PropertyName == nameof(InspectionRoiConfig.SelectedOkPreviewItem)
                     || e.PropertyName == nameof(InspectionRoiConfig.SelectedNgPreviewItem))
                 {
-                    RemoveSelectedPreviewCommand.RaiseCanExecuteChanged();
+                    RaiseDatasetCommandCanExecuteChanged();
                 }
 
                 OnPropertyChanged(nameof(SelectedInspectionRoi));
@@ -2640,6 +2652,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     _isBusy = value;
                     OnPropertyChanged();
                     RaiseBusyChanged();
+                    RaiseDatasetCommandCanExecuteChanged();
                 }
             }
         }
@@ -2898,6 +2911,31 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             }
             BrowseBatchFolderCommand?.RaiseCanExecuteChanged();
             UpdateBatchCommandStates();
+        }
+
+        private static void RaiseCanExecuteChanged(ICommand? command)
+        {
+            if (command is AsyncCommand asyncCommand)
+            {
+                asyncCommand.RaiseCanExecuteChanged();
+            }
+        }
+
+        private void RaiseDatasetCommandCanExecuteChanged()
+        {
+            RaiseCanExecuteChanged(TrainSelectedRoiCommand);
+            RaiseCanExecuteChanged(CalibrateSelectedRoiCommand);
+            RaiseCanExecuteChanged(EvaluateSelectedRoiCommand);
+            RaiseCanExecuteChanged(RemoveSelectedPreviewCommand);
+            RaiseCanExecuteChanged(InferEnabledRoisCommand);
+            if (!ReferenceEquals(EvaluateAllRoisCommand, InferEnabledRoisCommand))
+            {
+                RaiseCanExecuteChanged(EvaluateAllRoisCommand);
+            }
+            else
+            {
+                RaiseCanExecuteChanged(EvaluateAllRoisCommand);
+            }
         }
 
         public void SetMasterEditState(bool isMaster1Editing, bool isMaster2Editing)
@@ -3228,6 +3266,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                 await RefreshRoiDatasetStateAsync(roi).ConfigureAwait(false);
                 await RefreshDatasetPreviewsForRoiAsync(roi).ConfigureAwait(false);
+                RaiseDatasetCommandCanExecuteChanged();
 
                 await ShowDatasetSavedAsync(roi.DisplayName, fileName, isOk).ConfigureAwait(false);
             }
@@ -3290,6 +3329,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 await _client.UploadDatasetSampleAsync(role, roiId, !positive, export.PngBytes, fileName, meta).ConfigureAwait(false);
 
                 await RefreshRoiDatasetStateAsync(roi).ConfigureAwait(false);
+                RaiseDatasetCommandCanExecuteChanged();
                 GuiLog.Info($"AddToDataset (direct) uploaded {(positive ? "OK" : "NG")} -> '{fileName}'");
                 await ShowDatasetSavedAsync(roi.Label ?? roi.Role.ToString(), fileName, positive).ConfigureAwait(false);
             }
@@ -3514,6 +3554,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             await RefreshDatasetPreviewsForRoiAsync(roi).ConfigureAwait(false);
             await RefreshRoiDatasetStateAsync(roi).ConfigureAwait(false);
+            RaiseDatasetCommandCanExecuteChanged();
         }
 
         private async Task OpenDatasetFolderAsync()
@@ -3602,6 +3643,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             TrainFitCommand.RaiseCanExecuteChanged();
             CalibrateCommand.RaiseCanExecuteChanged();
+            RaiseDatasetCommandCanExecuteChanged();
         }
 
         private async Task TrainAsync()
@@ -4055,6 +4097,10 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             await RefreshDatasetPreviewsForRoiAsync(roi).ConfigureAwait(false);
             _roiDatasetCache[roi] = analysis;
+            var trainEnabled = !IsBusy && roi.DatasetOkCount >= 10;
+            var calibrateEnabled = !IsBusy && ReferenceEquals(roi, SelectedInspectionRoi) && CanCalibrateSelectedRoi();
+            _log($"[dataset] roi={roi.ModelKey} ok={roi.DatasetOkCount} ng={roi.DatasetKoCount} trainEnabled={trainEnabled} calibrateEnabled={calibrateEnabled}");
+            RaiseDatasetCommandCanExecuteChanged();
 
             return analysis;
         }


### PR DESCRIPTION
### Motivation
- Los botones `Train` y `Calibrate` no se habilitaban inmediatamente al cambiar `DatasetOkCount`/`DatasetKoCount` o al cambiar de ROI porque los comandos no recibían una invalidación de `CanExecute` consistente.

### Description
- Se actualizó `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs` para centralizar la invalidación con `RaiseDatasetCommandCanExecuteChanged()` y un helper seguro `RaiseCanExecuteChanged(ICommand? command)` que hace cast a `AsyncCommand` antes de llamar `RaiseCanExecuteChanged()`.
- En el setter de `SelectedInspectionRoi` se desuscribe el ROI anterior y se suscribe el nuevo a `PropertyChanged` (`SelectedInspectionRoi.PropertyChanged += InspectionRoiPropertyChanged`) y se fuerza la reevaluación de comandos al cambiar la selección.
- El handler `InspectionRoiPropertyChanged` ahora invoca la invalidación central cuando cambian `DatasetOkCount`, `DatasetKoCount`, `IsDatasetLoading`, `Enabled`, `BackendMemoryFitted`, `BackendCalibPresent`, `SelectedOkPreviewItem` o `SelectedNgPreviewItem`.
- Se añadió la llamada a `RaiseDatasetCommandCanExecuteChanged()` en el setter de `IsBusy` y como cinturón de seguridad al final de flujos que añaden/elimnan/refrescan muestras (`AddRoiToDatasetAsync`, `RemoveSelectedPreviewAsync`, `RefreshDatasetAsync`, `RefreshRoiDatasetStateAsync`).
- Se añadió logging diagnóstico en `RefreshRoiDatasetStateAsync` con el formato pedido: `[dataset] roi=<id> ok=<n> ng=<n> trainEnabled=<bool> calibrateEnabled=<bool>`.

### Testing
- Ejecuté el comando solicitado `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj` en este entorno, pero falló por ausencia de la herramienta: `/bin/bash: line 1: dotnet: command not found`.
- No se ejecutaron tests unitarios por la limitación anterior; el cambio fue verificado localmente mediante inspección del flujo de llamadas y puntos de invalidación en el `ViewModel` para asegurar que las rutas que mutan el dataset llaman a la invalidación de comandos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a032fac7db0832b9a4b3e00379e17fa)