### PR TITLE
Fix Train/Calibrate command enablement after ROI dataset updates

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -181,6 +181,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         private MasterLayout? _layout;
         private MasterLayout? _layoutOriginal;
         private InspectionRoiConfig? _selectedInspectionRoi;
+        private InspectionRoiConfig? _selectedRoiCommandSubscription;
         private bool? _hasFitEndpoint;
         private bool? _hasCalibrateEndpoint;
         private long _batchStepId;
@@ -642,6 +643,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     Application.Current?.Dispatcher.Invoke(RedrawOverlays);
                 }
             };
+
+            AttachSelectedRoiCommandNotifications(SelectedInspectionRoi);
         }
 
         public void SetLayoutName(string layoutName)
@@ -1341,6 +1344,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     OnPropertyChanged(nameof(SelectedInspectionShape));
                     OnPropertyChanged(nameof(ActiveInspectionRoiModel));
                     OnPropertyChanged(nameof(ActiveInspectionRoiImageRectPx));
+                    AttachSelectedRoiCommandNotifications(_selectedInspectionRoi);
                     UpdateSelectedRoiState();
                     OpenDatasetFolderCommand.RaiseCanExecuteChanged();
                     RaiseDatasetCommandCanExecuteChanged();
@@ -2932,9 +2936,42 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             {
                 RaiseCanExecuteChanged(EvaluateAllRoisCommand);
             }
-            else
+        }
+
+        private void AttachSelectedRoiCommandNotifications(InspectionRoiConfig? roi)
+        {
+            if (_selectedRoiCommandSubscription != null)
             {
-                RaiseCanExecuteChanged(EvaluateAllRoisCommand);
+                _selectedRoiCommandSubscription.PropertyChanged -= SelectedRoi_PropertyChangedForCommands;
+            }
+
+            _selectedRoiCommandSubscription = roi;
+
+            if (_selectedRoiCommandSubscription != null)
+            {
+                _selectedRoiCommandSubscription.PropertyChanged += SelectedRoi_PropertyChangedForCommands;
+            }
+
+            RaiseDatasetCommandCanExecuteChanged();
+        }
+
+        private void SelectedRoi_PropertyChangedForCommands(object? sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(InspectionRoiConfig.DatasetOkCount):
+                case nameof(InspectionRoiConfig.DatasetKoCount):
+                case nameof(InspectionRoiConfig.OkCount):
+                case nameof(InspectionRoiConfig.NgCount):
+                case nameof(InspectionRoiConfig.Enabled):
+                case nameof(InspectionRoiConfig.IsDatasetLoading):
+                case nameof(InspectionRoiConfig.DatasetReady):
+                case nameof(InspectionRoiConfig.SelectedOkPreviewItem):
+                case nameof(InspectionRoiConfig.SelectedNgPreviewItem):
+                case nameof(InspectionRoiConfig.BackendMemoryFitted):
+                case nameof(InspectionRoiConfig.BackendCalibPresent):
+                    InvokeOnUi(RaiseDatasetCommandCanExecuteChanged);
+                    break;
             }
         }
 
@@ -4097,10 +4134,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             await RefreshDatasetPreviewsForRoiAsync(roi).ConfigureAwait(false);
             _roiDatasetCache[roi] = analysis;
-            var trainEnabled = !IsBusy && roi.DatasetOkCount >= 10;
-            var calibrateEnabled = !IsBusy && ReferenceEquals(roi, SelectedInspectionRoi) && CanCalibrateSelectedRoi();
-            _log($"[dataset] roi={roi.ModelKey} ok={roi.DatasetOkCount} ng={roi.DatasetKoCount} trainEnabled={trainEnabled} calibrateEnabled={calibrateEnabled}");
             RaiseDatasetCommandCanExecuteChanged();
+            GuiLog.Info($"[dataset-ui] roi='{roi.Name}' id='{roi.Id}' ok={roi.DatasetOkCount} ng={roi.DatasetKoCount} trainCan={TrainSelectedRoiCommand.CanExecute(null)} calibrateCan={CalibrateSelectedRoiCommand.CanExecute(null)} selected={ReferenceEquals(roi, SelectedInspectionRoi)}");
 
             return analysis;
         }


### PR DESCRIPTION
### Motivation
- Los botones `Train` y `Calibrate` no se actualizaban inmediatamente tras subir/borrar/refresh de muestras porque los cambios en `InspectionRoiConfig.DatasetOkCount/DatasetKoCount` no provocaban una reevaluación de `CanExecute` ligada al ROI seleccionado.
- Se necesitaba una suscripción estable al `PropertyChanged` del ROI seleccionado para invalidar los `CanExecute` de los comandos de dataset sin tocar backend ni geometría ROI.

### Description
- Añadí el campo privado `InspectionRoiConfig? _selectedRoiCommandSubscription` y el método `AttachSelectedRoiCommandNotifications(InspectionRoiConfig? roi)` para gestionar la suscripción/desuscripción del `PropertyChanged` del ROI seleccionado.
- Implementé `SelectedRoi_PropertyChangedForCommands(object? sender, PropertyChangedEventArgs e)` que reacciona a propiedades relevantes (`DatasetOkCount`, `DatasetKoCount`, `IsDatasetLoading`, `DatasetReady`, `SelectedOkPreviewItem`, `SelectedNgPreviewItem`, `Enabled`, `BackendMemoryFitted`, `BackendCalibPresent`, etc.) y llama a `RaiseDatasetCommandCanExecuteChanged()` en el hilo UI mediante `InvokeOnUi`.
- Llamo a `AttachSelectedRoiCommandNotifications(SelectedInspectionRoi)` desde el constructor (inicial) y en el setter de `SelectedInspectionRoi` para rebind automático al cambiar selección; además se preserva la lógica previa de `IsBusy` que también fuerza reevaluación.
- Al refrescar contadores de ROI (`RefreshRoiDatasetStateAsync`) añadí un `GuiLog.Info` diagnóstico que imprime `ok`, `ng` y el estado actual de `TrainSelectedRoiCommand.CanExecute(null)` y `CalibrateSelectedRoiCommand.CanExecute(null)` para facilitar depuración de la UI.
- Solo se modificó `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs` y no se alteró ningún contrato backend, geometría ROI ni el umbral funcional (Train sigue requiriendo `DatasetOkCount >= 10` y Calibrate usa `CanCalibrateSelectedRoi()`).

### Testing
- Ejecuté el comando de prueba automatizada `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj`, pero falló por la limitación del entorno con el error: `/bin/bash: line 1: dotnet: command not found`.
- No se añadieron tests unitarios en este cambio (se propuso una prueba en el plan pero no se pudo ejecutar en este entorno); la validación queda indicada en los logs diagnósticos añadidos y en los pasos de verificación manual descritos en la especificación original.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a033229d560832b8ae2467f0053a6ca)