### PR TITLE
Fix CS7036 in WorkflowViewModel dataset status generation

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -2877,8 +2877,13 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
         private static string BuildDatasetStatusText(InspectionRoiConfig roi)
         {
-            var missingOk = MissingOkForCalibration(roi);
-            var missingNg = MissingNgForCalibration(roi);
+            return BuildDatasetStatusText(roi.DatasetOkCount, roi.DatasetKoCount);
+        }
+
+        private static string BuildDatasetStatusText(int okCount, int ngCount)
+        {
+            var missingOk = Math.Max(0, MinOkSamplesForCalibration - okCount);
+            var missingNg = Math.Max(0, MinNgSamplesForCalibration - ngCount);
 
             if (missingOk == 0 && missingNg == 0)
             {
@@ -4159,7 +4164,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 var ready = okCount >= MinOkSamplesForCalibration && ngCount >= MinNgSamplesForCalibration;
                 var status = ready
                     ? "Dataset ready"
-                    : BuildDatasetStatusText(new InspectionRoiConfig { DatasetOkCount = okCount, DatasetKoCount = ngCount });
+                    : BuildDatasetStatusText(okCount, ngCount);
                 analysis = new RoiDatasetAnalysis(string.Empty, new List<DatasetEntry>(), okCount, ngCount, ready, status, new List<(string, bool)>());
 
                 await Application.Current.Dispatcher.InvokeAsync(() =>


### PR DESCRIPTION
### Motivation
- The code attempted to construct `InspectionRoiConfig` without providing the required `index` parameter, causing a `CS7036` compile error when building dataset status from counts.

### Description
- Added a new overload `BuildDatasetStatusText(int okCount, int ngCount)` that computes missing samples and returns the same status strings as before.
- Changed `BuildDatasetStatusText(InspectionRoiConfig roi)` to delegate to the new overload by passing `roi.DatasetOkCount` and `roi.DatasetKoCount`.
- Replaced the temporary object construction `new InspectionRoiConfig { DatasetOkCount = okCount, DatasetKoCount = ngCount }` with a direct call to `BuildDatasetStatusText(okCount, ngCount)` in `RefreshRoiDatasetStateAsync`.

### Testing
- Attempted to run `dotnet build BrakeDiscInspector.sln`, but `dotnet` is not installed in this environment so the build could not be executed.
- No other automated tests were run here, but the change is expected to resolve the `CS7036` compile error when built in a proper .NET environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0337020ba8832b882d4b1e842fd040)