### PR TITLE
Add detailed pattern matching diagnostics

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
@@ -13,6 +13,20 @@ namespace BrakeDiscInspector_GUI_ROI
             public int Score { get; init; }
             public double AngleDeg { get; init; }
             public bool UsedFeatures { get; init; }
+            public string ModeRequested { get; init; } = string.Empty;
+            public string ModeUsed { get; init; } = string.Empty;
+            public bool UsedFallback { get; init; }
+            public string? Failure { get; init; }
+            public double BestCorr { get; init; }
+            public double SecondBestCorr { get; init; }
+            public double CorrMargin { get; init; }
+            public double BestScale { get; init; }
+            public double BestAngleDeg { get; init; }
+            public int ImgKeypoints { get; init; }
+            public int PatternKeypoints { get; init; }
+            public int GoodMatches { get; init; }
+            public int Inliers { get; init; }
+            public double AvgDistance { get; init; }
         }
 
         private static void Log(Action<string>? log, string message) => log?.Invoke(message);
@@ -61,8 +75,8 @@ namespace BrakeDiscInspector_GUI_ROI
             return dst;
         }
 
-        private static (Point2d? center, int score, string? failure, double bestCorr, double bestAngleDeg) MatchTemplateRot(
-            Mat imageGray, Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax, Action<string>? log)
+        private static (Point2d? center, int score, string? failure, double bestCorr, double secondBestCorr, double corrMargin, double bestScale, double bestAngleDeg) MatchTemplateRot(
+            Mat imageGray, Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax, Action<string>? log, string roleTag)
         {
             if (imageGray.Empty() || patternGray.Empty())
                 return (null, 0, "imgs vacías", 0, 0);
@@ -70,6 +84,8 @@ namespace BrakeDiscInspector_GUI_ROI
             double best = -1.0;
             Point2d? bestPoint = null;
             double bestAngle = 0.0;
+            double secondBest = -1.0;
+            double bestScale = 1.0;
 
             var minScale = Math.Min(scaleMin, scaleMax);
             var maxScale = Math.Max(scaleMin, scaleMax);
@@ -96,19 +112,29 @@ namespace BrakeDiscInspector_GUI_ROI
 
                     if (maxVal > best)
                     {
+                        secondBest = best;
                         best = maxVal;
                         bestPoint = new Point2d(maxLoc.X + rotated.Width / 2.0, maxLoc.Y + rotated.Height / 2.0);
                         bestAngle = angle;
+                        bestScale = scale;
+                    }
+                    else if (maxVal > secondBest)
+                    {
+                        secondBest = maxVal;
                     }
                 }
             }
 
             string? failure = bestPoint == null ? "sin correlación" : $"maxCorr={Math.Max(best, 0):F4}";
-            return (bestPoint, ToScore(best), failure, best, bestAngle);
+            double safeBest = Math.Max(best, 0);
+            double safeSecond = Math.Max(secondBest, 0);
+            double margin = safeBest - safeSecond;
+            Log(log, $"[PATTERN][TM] role={roleTag} angle={bestAngle:F2} scale={bestScale:F4} best={safeBest:F4} second={safeSecond:F4} margin={margin:F4} score={ToScore(best)}");
+            return (bestPoint, ToScore(best), failure, safeBest, safeSecond, margin, bestScale, bestAngle);
         }
 
         private static (Point2d? center, int score, string? failure, int imgKps, int patKps, int goodCount, int inliers, double avgDist, double rotDegApprox) MatchFeatures(
-            Mat imageGrayIn, Mat patternGrayIn, Action<string>? log)
+            Mat imageGrayIn, Mat patternGrayIn, Action<string>? log, string roleTag)
         {
             // Trabajar sobre clones: NUNCA liberar ni reasignar Mats del caller
             using var imageGray = imageGrayIn.Clone();
@@ -243,6 +269,7 @@ namespace BrakeDiscInspector_GUI_ROI
             Log(log,
                 $"[FEATURE] inliers={inliers}/{good.Length} " +
                 $"avgDist={avgDist:F1} score={score} rot≈{rotDegApprox:F1}deg");
+            Log(log, $"[PATTERN][FEATURE] role={roleTag} kpsImg={imgKp.Length} kpsPat={patKp.Length} good={good.Length} inliers={inliers} avgDist={avgDist:F1} score={score}");
             return (new Point2d(cx, cy), score, null, imgKp.Length, patKp.Length, good.Length, inliers, avgDist, rotDegApprox);
         }
 
@@ -412,6 +439,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     }
 
                     Log(log, $"[INPUT] feature={feature} thr={threshold} search={searchRect.Width}x{searchRect.Height} pattern={patternGray.Width}x{patternGray.Height}");
+                    string roleTag = patternRoi?.Role == RoiRole.Master2Pattern ? "M2" : "M1";
 
                     var mode = (feature ?? "").Trim().ToLowerInvariant();
 
@@ -434,12 +462,12 @@ namespace BrakeDiscInspector_GUI_ROI
                         Log(log, $"[EDGES] nz(search,pattern)=({nzSearch},{nzPattern}) thr={threshold}");
                         Log(log, "[EDGES] using Canny + MatchTemplateRot");
 
-                        var tm = MatchTemplateRot(searchEdges, patternEdges, rotRange, scaleMin, scaleMax, log);
+                        var tm = MatchTemplateRot(searchEdges, patternEdges, rotRange, scaleMin, scaleMax, log, roleTag);
 
                         if (tm.center is null || tm.score < threshold)
                         {
                             Log(log, $"[EDGES] no-hit score={tm.score} (<{threshold}) corr={tm.bestCorr:F3} cause={tm.failure}");
-                            return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false };
+                            return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "edges", Failure = tm.failure, BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg };
                         }
 
                         var globalEdges = new Point2d(
@@ -450,62 +478,62 @@ namespace BrakeDiscInspector_GUI_ROI
                             FormattableString.Invariant(
                                 $"[EDGES] HIT center=({globalEdges.X:F1},{globalEdges.Y:F1}) score={tm.score} corr={tm.bestCorr:F3}"));
 
-                        return new LocalMatchResult { Center = globalEdges, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false };
+                        return new LocalMatchResult { Center = globalEdges, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "edges", BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg };
                     }
 
                     if (mode == "tm_rot")
                     {
-                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log);
+                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
 
                         if (tm.center is null || tm.score < threshold)
                         {
                             Log(log, $"[TM] no-hit score={tm.score} (<{threshold}) corr={tm.bestCorr:F3} cause={tm.failure}");
-                            return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false };
+                            return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "tm_rot", Failure = tm.failure, BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg };
                         }
 
                         var globalTM = new Point2d(searchRect.X + tm.center.Value.X, searchRect.Y + tm.center.Value.Y);
                         Log(log,
                             FormattableString.Invariant(
                                 $"[RESULT] HIT (TM) center=({globalTM.X:F1},{globalTM.Y:F1}) score={tm.score} corr={tm.bestCorr:F3}"));
-                        return new LocalMatchResult { Center = globalTM, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false };
+                        return new LocalMatchResult { Center = globalTM, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "tm_rot", BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg };
                     }
 
                     // 1) FEATURES
-                    var feat = MatchFeatures(searchGray, patternGray, log);
+                    var feat = MatchFeatures(searchGray, patternGray, log, roleTag);
 
                     // 2) AUTO: fallback a TM si fallan features
                     if (mode == "auto" && (feat.center is null || feat.score < threshold))
                     {
-                        Log(log, $"[AUTO] fallback TM: causeFeat={feat.failure} kpsImg={feat.imgKps} kpsPat={feat.patKps} good={feat.goodCount} inliers={feat.inliers} avgDist={feat.avgDist:F1}");
-                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log);
+                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
+                        Log(log, $"[PATTERN][AUTO] role={roleTag} fallback=True causeFeat={feat.failure} featScore={feat.score} tmScore={tm.score}");
 
                         if (tm.center is null || tm.score < threshold)
                         {
                             Log(log, $"[RESULT] no-hit scoreFeat={feat.score} scoreTM={tm.score} (<{threshold}) causeFeat={feat.failure} causeTM={tm.failure}");
                             var maxScore = Math.Max(feat.score, tm.score);
                             var angleDeg = tm.score >= feat.score ? tm.bestAngleDeg : feat.rotDegApprox;
-                            return new LocalMatchResult { Center = null, Score = maxScore, AngleDeg = angleDeg, UsedFeatures = tm.score < feat.score };
+                            return new LocalMatchResult { Center = null, Score = maxScore, AngleDeg = angleDeg, UsedFeatures = tm.score < feat.score, ModeRequested = mode, ModeUsed = "auto_fail", UsedFallback = true, Failure = $"feat={feat.failure};tm={tm.failure}", BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg, ImgKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist };
                         }
 
                         var globalTM = new Point2d(searchRect.X + tm.center.Value.X, searchRect.Y + tm.center.Value.Y);
                         Log(log,
                             FormattableString.Invariant(
                                 $"[RESULT] HIT (TM) center=({globalTM.X:F1},{globalTM.Y:F1}) score={tm.score} corr={tm.bestCorr:F3}"));
-                        return new LocalMatchResult { Center = globalTM, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false };
+                        return new LocalMatchResult { Center = globalTM, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "tm_fallback", UsedFallback = true, BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg, ImgKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist };
                     }
 
                     if (feat.center is null || feat.score < threshold)
                     {
                         var reason = feat.failure ?? (feat.center is null ? "sin coincidencias" : $"score={feat.score}");
                         Log(log, $"[RESULT] no-hit score={feat.score} (<{threshold}) cause={reason}");
-                        return new LocalMatchResult { Center = null, Score = feat.score, AngleDeg = feat.rotDegApprox, UsedFeatures = true };
+                        return new LocalMatchResult { Center = null, Score = feat.score, AngleDeg = feat.rotDegApprox, UsedFeatures = true, ModeRequested = mode, ModeUsed = mode == "auto" ? "features" : "features", Failure = reason, ImgKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist };
                     }
 
                     var global = new Point2d(searchRect.X + feat.center.Value.X, searchRect.Y + feat.center.Value.Y);
                     Log(log,
                         FormattableString.Invariant(
                             $"[RESULT] HIT (FEATURES) center=({global.X:F1},{global.Y:F1}) score={feat.score} inliers={feat.inliers}/{Math.Max(feat.goodCount, 1)}"));
-                    return new LocalMatchResult { Center = global, Score = feat.score, AngleDeg = feat.rotDegApprox, UsedFeatures = true };
+                    return new LocalMatchResult { Center = global, Score = feat.score, AngleDeg = feat.rotDegApprox, UsedFeatures = true, ModeRequested = mode, ModeUsed = "features", ImgKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist };
                 }
                 finally
                 {

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2087,6 +2087,25 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
             }
 
+            var baselineDist = (!double.IsNaN(baselineM1Point.X) && !double.IsNaN(baselineM2Point.X))
+                ? Dist(baselineM1Point.X, baselineM1Point.Y, baselineM2Point.X, baselineM2Point.Y)
+                : double.NaN;
+            var detectedDist = Dist(newM1.X, newM1.Y, newM2.X, newM2.Y);
+            var rawScale = !double.IsNaN(baselineDist) && baselineDist > 0 ? detectedDist / baselineDist : double.NaN;
+            var scaleRange = (effectiveAnalyze.ScaleMin, effectiveAnalyze.ScaleMax);
+            InspLog($"[PATTERN][GEOM] distBase={baselineDist:F3} distDet={detectedDist:F3} scale={rawScale:F4} scaleRange=({scaleRange.Item1:F2},{scaleRange.Item2:F2}) angleDelta={dAng:F3} angTol={angTol:F3} dM1={dM1:F3} dM2={dM2:F3} posTol={posTol:F3} hasLast={hasLast} accepted={accept} reason={reason}");
+            if (accept)
+            {
+                bool outsideTol = (!double.IsNaN(dM1) && posTol > 0 && dM1 > posTol)
+                    || (!double.IsNaN(dM2) && posTol > 0 && dM2 > posTol)
+                    || (!double.IsNaN(dAng) && angTol > 0 && dAng > angTol)
+                    || (!double.IsNaN(rawScale) && (rawScale < scaleRange.Item1 || rawScale > scaleRange.Item2));
+                if (outsideTol)
+                {
+                    InspLog($"[PATTERN][WARN] accepted outside tolerance: dM1={dM1:F3} dM2={dM2:F3} angleDelta={dAng:F3} scale={rawScale:F4} reason={reason}");
+                }
+            }
+
             decisionInfo.Accepted = accept;
             decisionInfo.Reason = reason;
 
@@ -11700,6 +11719,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void LogToFileAndUI(string message)
         {
+            VisConfLog.AnalyzeMaster(message);
 #if DEBUG
             var stamped = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}";
             Debug.WriteLine(stamped);
@@ -15998,3 +16018,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
     }
 }
+                        logs.Add(FormattableString.Invariant(
+                            $"[PATTERN][SUMMARY] role=M1 requested={res1.ModeRequested} used={res1.ModeUsed} score={res1.Score} thr={localAnalyze.ThrM1} center=({res1.Center?.X:F0},{res1.Center?.Y:F0}) angle={res1.AngleDeg:F2} scale={res1.BestScale:F4} best={res1.BestCorr:F4} second={res1.SecondBestCorr:F4} margin={res1.CorrMargin:F4} kps={res1.ImgKeypoints}/{res1.PatternKeypoints} good={res1.GoodMatches} inliers={res1.Inliers} accepted={res1.Center.HasValue && res1.Score >= localAnalyze.ThrM1}"));
+                        logs.Add(FormattableString.Invariant(
+                            $"[PATTERN][SUMMARY] role=M2 requested={res2.ModeRequested} used={res2.ModeUsed} score={res2.Score} thr={localAnalyze.ThrM2} center=({res2.Center?.X:F0},{res2.Center?.Y:F0}) angle={res2.AngleDeg:F2} scale={res2.BestScale:F4} best={res2.BestCorr:F4} second={res2.SecondBestCorr:F4} margin={res2.CorrMargin:F4} kps={res2.ImgKeypoints}/{res2.PatternKeypoints} good={res2.GoodMatches} inliers={res2.Inliers} accepted={res2.Center.HasValue && res2.Score >= localAnalyze.ThrM2}"));


### PR DESCRIPTION
### Motivation

- Los logs actuales no muestran qué método interno se usó, ni métricas suficientes para depurar fallos en detección de patrones Master1/Master2.  
- Se necesita trazar correlaciones internas, segunda mejor coincidencia, métricas de features y razones de fallback sin cambiar la lógica de aceptación.  

### Description

- Amplié `LocalMatchResult` en `LocalMatcher.cs` con campos diagnósticos: `ModeRequested`, `ModeUsed`, `UsedFallback`, `Failure`, `BestCorr`, `SecondBestCorr`, `CorrMargin`, `BestScale`, `BestAngleDeg`, `ImgKeypoints`, `PatternKeypoints`, `GoodMatches`, `Inliers`, `AvgDistance` para exportar toda la información de búsqueda.  
- `MatchTemplateRot` ahora calcula `bestCorr`, `secondBestCorr`, `corrMargin`, `bestScale` y `bestAngleDeg` y emite logs estructurados ` [PATTERN][TM] role=... angle=... scale=... best=... second=... margin=... score=...`.  
- `MatchFeatures` devuelve y loguea métricas de keypoints/matches/inliers/avgDist y emite ` [PATTERN][FEATURE] role=... kpsImg=... kpsPat=... good=... inliers=... avgDist=... score=...`.  
- Modo `auto` registra decisión de fallback con ` [PATTERN][AUTO] role=... fallback=True causeFeat=... featScore=... tmScore=...` y los resultados devuelven `ModeUsed`/`UsedFallback`/`Failure` según corresponda.  
- En el caller (`MainWindow.xaml.cs`) se enchufó `LogToFileAndUI` para escribir en `roi_analyze_master.log` vía `VisConfLog.AnalyzeMaster(...)`, y se añadieron resúmenes por master ` [PATTERN][SUMMARY] ...` así como diagnóstico geométrico ` [PATTERN][GEOM] ...` y advertencia ` [PATTERN][WARN]` cuando se acepta fuera de tolerancias.  
- Archivos modificados: `gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs` y `gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs`.  
- Ejemplos de líneas nuevas esperadas: ` [PATTERN][TM] role=M1 angle=... scale=... best=... second=... margin=... score=...`, ` [PATTERN][FEATURE] role=M2 kpsImg=... kpsPat=... good=... inliers=... avgDist=... score=...`, ` [PATTERN][AUTO] role=M2 fallback=True causeFeat=... featScore=... tmScore=...`, ` [PATTERN][SUMMARY] role=M2 requested=auto used=features|tm_fallback ...`, ` [PATTERN][GEOM] distBase=... distDet=... scale=... ... accepted=... reason=...`, ` [PATTERN][WARN] accepted outside tolerance: ...`. 

### Testing

- Intenté ejecutar los tests automatizados con `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj` pero falló por limitación del entorno con el error `dotnet: command not found`.  
- No se ejecutaron otros tests automatizados en este entorno; los cambios son principalmente de trazabilidad y no alteran la lógica de aceptación.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a042c013d60832b85828522aac9cf97)