### PR TITLE
Fix tuple arity in LocalMatcher.MatchTemplateRot empty-input return

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
@@ -79,7 +79,7 @@ namespace BrakeDiscInspector_GUI_ROI
             Mat imageGray, Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax, Action<string>? log, string roleTag)
         {
             if (imageGray.Empty() || patternGray.Empty())
-                return (null, 0, "imgs vacías", 0, 0);
+                return (null, 0, "imgs vacías", 0, 0, 0, 1.0, 0.0);
 
             double best = -1.0;
             Point2d? bestPoint = null;


### PR DESCRIPTION
### Motivation
- Fix compiler error `CS8135` caused by an early return in `MatchTemplateRot` that returned a 5-tuple while the method signature requires 8 elements.

### Description
- Updated the early-return in `gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs` inside `MatchTemplateRot` to return `(null, 0, "imgs vacías", 0, 0, 0, 1.0, 0.0)` so the returned tuple matches the signature `(Point2d? center, int score, string? failure, double bestCorr, double secondBestCorr, double corrMargin, double bestScale, double bestAngleDeg)`.

### Testing
- Attempted to run `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln`, but the build could not be executed because the `dotnet` CLI is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0460f50370832bbb8d1c5d6a2be6b4)