### PR TITLE
Ensure master pattern logs show real algorithm used by M1 and M2

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
@@ -89,5 +89,53 @@ namespace BrakeDiscInspector_GUI_ROI.Tests
             Assert.InRange(center.Value.Y, patternRoi.Y - 0.5, patternRoi.Y + 0.5);
             Assert.InRange(score, 70, 100);
         }
+
+        [Fact]
+        public void MatchInSearchROIWithDetails_TmRot_FillsModeAndTemplateMetrics()
+        {
+            using var fullImage = new Mat(new Size(120, 120), MatType.CV_8UC3, Scalar.Black);
+            var patternRect = new Rect(35, 50, 30, 20);
+            Cv2.Rectangle(fullImage, patternRect, new Scalar(190, 30, 200), -1);
+            Cv2.Line(fullImage, new Point(patternRect.X, patternRect.Y), new Point(patternRect.Right - 1, patternRect.Bottom - 1), new Scalar(20, 240, 20), 2);
+
+            var roi = new RoiModel { Shape = RoiShape.Rectangle, X = 50, Y = 60, Width = 30, Height = 20 };
+            var search = new RoiModel { Shape = RoiShape.Rectangle, X = 50, Y = 60, Width = 80, Height = 80 };
+
+            var result = LocalMatcher.MatchInSearchROIWithDetails(fullImage, roi, search, "tm_rot", 40, 0, 1.0, 1.0);
+            Assert.Equal("tm_rot", result.ModeRequested);
+            Assert.Equal("tm_rot", result.ModeUsed);
+            Assert.False(result.UsedFallback);
+            Assert.False(result.UsedFeatures);
+            Assert.True(result.AcceptedByThreshold);
+            Assert.Equal(result.Score, (int)result.TemplateScore);
+            Assert.True(result.BestCorr > 0);
+        }
+
+        [Fact]
+        public void MatchInSearchROIWithDetails_Auto_AlwaysSetsModeUsed()
+        {
+            using var fullImage = new Mat(new Size(150, 150), MatType.CV_8UC3, Scalar.Black);
+            var patternRect = new Rect(60, 70, 28, 28);
+            Cv2.Rectangle(fullImage, patternRect, new Scalar(220, 220, 220), -1);
+            Cv2.Circle(fullImage, new Point(74, 84), 8, new Scalar(10, 10, 10), -1);
+
+            var pattern = new RoiModel { Shape = RoiShape.Rectangle, X = 74, Y = 84, Width = 28, Height = 28 };
+            var search = new RoiModel { Shape = RoiShape.Rectangle, X = 74, Y = 84, Width = 70, Height = 70 };
+
+            var result = LocalMatcher.MatchInSearchROIWithDetails(fullImage, pattern, search, "auto", 70, 4, 0.95, 1.05);
+            Assert.Equal("auto", result.ModeRequested);
+            Assert.False(string.IsNullOrWhiteSpace(result.ModeUsed));
+            Assert.Contains(result.ModeUsed, new[] { "features", "tm_fallback", "auto_fail" });
+            if (result.ModeUsed == "tm_fallback")
+            {
+                Assert.True(result.UsedFallback);
+                Assert.True(result.TemplateScore > 0);
+            }
+            if (result.ModeUsed == "features")
+            {
+                Assert.True(result.UsedFeatures);
+                Assert.True(result.FeatureScore > 0);
+            }
+        }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
@@ -151,7 +151,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
             }
             double margin = safeBest - safeSecond;
-            Log(log, $"[PATTERN][TM] role={roleTag} mode=tm_rot search={imageGray.Width}x{imageGray.Height} pattern={patternGray.Width}x{patternGray.Height} candidates={candidates.Count} best={safeBest:F4} second={safeSecond:F4} margin={margin:F4} score={ToScore(best)} angle={bestAngle:F3} scale={bestScale:F3} loc=({bestLoc.X},{bestLoc.Y}) center=({bestPoint?.X:F3},{bestPoint?.Y:F3})");
             return (bestPoint, ToScore(best), failure, safeBest, safeSecond, margin, bestScale, bestAngle, bestLoc, candidates.Count);
         }
 
@@ -291,7 +290,6 @@ namespace BrakeDiscInspector_GUI_ROI
             Log(log,
                 $"[FEATURE] inliers={inliers}/{good.Length} " +
                 $"avgDist={avgDist:F1} score={score} rot≈{rotDegApprox:F1}deg");
-            Log(log, $"[PATTERN][FEATURE] role={roleTag} kpsImg={imgKp.Length} kpsPat={patKp.Length} good={good.Length} inliers={inliers} avgDist={avgDist:F1} score={score}");
             return (new Point2d(cx, cy), score, null, imgKp.Length, patKp.Length, good.Length, inliers, avgDist, rotDegApprox);
         }
 
@@ -490,7 +488,9 @@ namespace BrakeDiscInspector_GUI_ROI
 
                         var tm = MatchTemplateRot(searchEdges, patternEdges, rotRange, scaleMin, scaleMax, log, roleTag);
 
-                        if (tm.center is null || tm.score < threshold)
+                        bool acceptedByThreshold = tm.center is not null && tm.score >= threshold;
+                        Log(log, $"[PATTERN][EDGES] role={roleTag} requested=edges used=edges nzSearch={nzSearch} nzPattern={nzPattern} best={tm.bestCorr:F4} second={tm.secondBestCorr:F4} margin={tm.corrMargin:F4} score={tm.score} threshold={threshold} acceptedByThreshold={acceptedByThreshold}");
+                        if (!acceptedByThreshold)
                         {
                             Log(log, $"[EDGES] no-hit score={tm.score} (<{threshold}) corr={tm.bestCorr:F3} cause={tm.failure}");
                             return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "edges", Failure = tm.failure, BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg, AcceptedByThreshold = false, SearchWidth = searchRect.Width, SearchHeight = searchRect.Height, PatternWidth = patternGray.Width, PatternHeight = patternGray.Height, TemplateScore = tm.score };
@@ -511,7 +511,9 @@ namespace BrakeDiscInspector_GUI_ROI
                     {
                         var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
 
-                        if (tm.center is null || tm.score < threshold)
+                        bool acceptedByThreshold = tm.center is not null && tm.score >= threshold;
+                        Log(log, $"[PATTERN][TM] role={roleTag} requested=tm_rot used=tm_rot search={searchRect.Width}x{searchRect.Height} pattern={patternGray.Width}x{patternGray.Height} candidates={tm.candidatesEvaluated} best={tm.bestCorr:F4} second={tm.secondBestCorr:F4} margin={tm.corrMargin:F4} score={tm.score} threshold={threshold} angle={tm.bestAngleDeg:F3} scale={tm.bestScale:F3} center=({(tm.center?.X):F3},{(tm.center?.Y):F3}) acceptedByThreshold={acceptedByThreshold}");
+                        if (!acceptedByThreshold)
                         {
                             Log(log, $"[TM] no-hit score={tm.score} (<{threshold}) corr={tm.bestCorr:F3} cause={tm.failure}");
                             return new LocalMatchResult { Center = null, Score = tm.score, AngleDeg = tm.bestAngleDeg, UsedFeatures = false, ModeRequested = mode, ModeUsed = "tm_rot", Failure = tm.failure, BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg, AcceptedByThreshold = false, SearchWidth = searchRect.Width, SearchHeight = searchRect.Height, PatternWidth = patternGray.Width, PatternHeight = patternGray.Height, TemplateScore = tm.score };
@@ -526,18 +528,22 @@ namespace BrakeDiscInspector_GUI_ROI
 
                     // 1) FEATURES
                     var feat = MatchFeatures(searchGray, patternGray, log, roleTag);
+                    bool featureAcceptedByThreshold = feat.center is not null && feat.score >= threshold;
+                    Log(log, $"[PATTERN][FEATURE] role={roleTag} requested={mode} used=features kpsImg={feat.imgKps} kpsPat={feat.patKps} good={feat.goodCount} inliers={feat.inliers} avgDist={feat.avgDist:F1} score={feat.score} threshold={threshold} acceptedByThreshold={featureAcceptedByThreshold} failure={feat.failure ?? "<none>"}");
 
                     // 2) AUTO: fallback a TM si fallan features
                     if (mode == "auto" && (feat.center is null || feat.score < threshold))
                     {
                         var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
-                        Log(log, $"[PATTERN][AUTO] role={roleTag} requested=auto used=tm_fallback fallback=True causeFeat={feat.failure ?? "<none>"} featScore={feat.score} tmScore={tm.score} threshold={threshold}");
+                        bool tmAcceptedByThreshold = tm.center is not null && tm.score >= threshold;
+                        Log(log, $"[PATTERN][AUTO] role={roleTag} requested=auto used=tm_fallback fallback=True causeFeat={feat.failure ?? "<none>"} featScore={feat.score} tmScore={tm.score} threshold={threshold} acceptedByThreshold={tmAcceptedByThreshold}");
 
                         if (tm.center is null || tm.score < threshold)
                         {
                             Log(log, $"[RESULT] no-hit scoreFeat={feat.score} scoreTM={tm.score} (<{threshold}) causeFeat={feat.failure} causeTM={tm.failure}");
                             var maxScore = Math.Max(feat.score, tm.score);
                             var angleDeg = tm.score >= feat.score ? tm.bestAngleDeg : feat.rotDegApprox;
+                            Log(log, $"[PATTERN][NOHIT] role={roleTag} requested=auto used=auto_fail score={maxScore} threshold={threshold} failure='feat={feat.failure};tm={tm.failure}'");
                             return new LocalMatchResult { Center = null, Score = maxScore, AngleDeg = angleDeg, UsedFeatures = tm.score < feat.score, ModeRequested = mode, ModeUsed = "auto_fail", UsedFallback = true, Failure = $"feat={feat.failure};tm={tm.failure}", BestCorr = tm.bestCorr, SecondBestCorr = tm.secondBestCorr, CorrMargin = tm.corrMargin, BestScale = tm.bestScale, BestAngleDeg = tm.bestAngleDeg, ImageKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist, FeatureScore = feat.score, TemplateScore = tm.score, AcceptedByThreshold = false, SearchWidth = searchRect.Width, SearchHeight = searchRect.Height, PatternWidth = patternGray.Width, PatternHeight = patternGray.Height };
                         }
 
@@ -559,7 +565,8 @@ namespace BrakeDiscInspector_GUI_ROI
                     Log(log,
                         FormattableString.Invariant(
                             $"[RESULT] HIT (FEATURES) center=({global.X:F1},{global.Y:F1}) score={feat.score} inliers={feat.inliers}/{Math.Max(feat.goodCount, 1)}"));
-                    Log(log, $"[PATTERN][AUTO] role={roleTag} requested={mode} used=features fallback=False featScore={feat.score} threshold={threshold} good={feat.goodCount} inliers={feat.inliers}");
+                    if (mode == "auto")
+                        Log(log, $"[PATTERN][AUTO] role={roleTag} requested=auto used=features fallback=False featScore={feat.score} threshold={threshold} good={feat.goodCount} inliers={feat.inliers} acceptedByThreshold=True");
                     return new LocalMatchResult { Center = global, Score = feat.score, AngleDeg = feat.rotDegApprox, UsedFeatures = true, ModeRequested = mode, ModeUsed = "features", ImageKeypoints = feat.imgKps, PatternKeypoints = feat.patKps, GoodMatches = feat.goodCount, Inliers = feat.inliers, AvgDistance = feat.avgDist, FeatureScore = feat.score, AcceptedByThreshold = true, SearchWidth = searchRect.Width, SearchHeight = searchRect.Height, PatternWidth = patternGray.Width, PatternHeight = patternGray.Height };
                 }
                 finally

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -2096,7 +2096,7 @@ namespace BrakeDiscInspector_GUI_ROI
             bool scaleInRange = !double.IsNaN(rawScale) && rawScale >= scaleRange.Item1 && rawScale <= scaleRange.Item2;
             bool angleInTol = !double.IsNaN(dAng) && angTol > 0 && dAng <= angTol;
             bool posInTol = !double.IsNaN(dM1) && !double.IsNaN(dM2) && posTol > 0 && dM1 <= posTol && dM2 <= posTol;
-            InspLog($"[PATTERN][GEOM] image='{Path.GetFileName(_currentImagePathWin ?? string.Empty)}' distBase={baselineDist:F3} distDet={detectedDist:F3} rawScale={rawScale:F4} scaleMin={scaleRange.Item1:F2} scaleMax={scaleRange.Item2:F2} scaleInRange={scaleInRange} angleDelta={dAng:F3} angTol={angTol:F3} angleInTol={angleInTol} dM1={dM1:F3} dM2={dM2:F3} posTol={posTol:F3} posInTol={posInTol} hasLast={hasLast} accepted={accept} reason='{reason}'");
+            InspLog($"[PATTERN][GEOM] image='{Path.GetFileName(_currentImagePathWin ?? string.Empty)}' distBase={baselineDist:F3} distDet={detectedDist:F3} rawScale={rawScale:F4} scaleMin={scaleRange.Item1:F2} scaleMax={scaleRange.Item2:F2} scaleInRange={scaleInRange} angleDelta={dAng:F3} angTolDeg={angTol:F3} angleInTol={angleInTol} dM1={dM1:F3} dM2={dM2:F3} posTolPx={posTol:F3} posInTol={posInTol} hasLast={hasLast} acceptedFinal={accept} reason='{reason}'");
             if (accept)
             {
                 bool outsideTol = (!double.IsNaN(dM1) && posTol > 0 && dM1 > posTol)
@@ -11194,6 +11194,7 @@ namespace BrakeDiscInspector_GUI_ROI
             AppendLog(
                 $"[ANALYZE_MASTER][START] key='{analyzeImageKey}' keyDetail='{_lastImageKeyDetail}' posTol={posTolForLog:0.###} angTol={angTolForLog:0.###} " +
                 $"minScore=({effectiveAnalyze.ThrM1},{effectiveAnalyze.ThrM2}) scaleLock={effectiveAnalyze.ScaleLock} lockRotation={effectiveAnalyze.DisableRot} useLocalMatcher={useLocalMatcher}");
+            LogToFileAndUI($"[PATTERN][CONFIG] image='{analyzeFileName}' layout='{GetCurrentLayoutName()}' featureM1='{effectiveAnalyze.FeatureM1}' thrM1={effectiveAnalyze.ThrM1} featureM2='{effectiveAnalyze.FeatureM2}' thrM2={effectiveAnalyze.ThrM2} rotRange={effectiveAnalyze.RotRange} scaleMin={effectiveAnalyze.ScaleMin:F2} scaleMax={effectiveAnalyze.ScaleMax:F2} posTolPx={effectiveAnalyze.PosTolPx:F3} angTolDeg={effectiveAnalyze.AngTolDeg:F3} scaleLock={effectiveAnalyze.ScaleLock} disableRot={effectiveAnalyze.DisableRot}");
 
             ViewModel?.TraceManual($"[manual-master] analyze file='{Path.GetFileName(ViewModel?.CurrentManualImagePath ?? string.Empty)}'");
 
@@ -11256,6 +11257,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 double score2 = 0;
                 double angle1 = double.NaN;
                 double angle2 = double.NaN;
+                LocalMatcher.LocalMatchResult? m1Detail = null;
+                LocalMatcher.LocalMatchResult? m2Detail = null;
                 long loadMsLocal = 0;
                 long matchMsLocal = 0;
                 bool disableLocal = false;
@@ -11277,11 +11280,17 @@ namespace BrakeDiscInspector_GUI_ROI
                             m2Override = _masterTemplateM2.Clone();
 
                         var matchSw = Stopwatch.StartNew();
+                        Action<string> patternLog = msg =>
+                        {
+                            try { VisConfLog.AnalyzeMaster(FormattableStringFactory.Create("{0}", msg)); } catch { }
+                            try { GuiLog.Info(msg); } catch { }
+                        };
+
                         var res1 = LocalMatcher.MatchInSearchROIWithDetails(img, localM1Pattern, localM1Search,
                             localAnalyze.FeatureM1, localAnalyze.ThrM1, localAnalyze.RotRange, localAnalyze.ScaleMin, localAnalyze.ScaleMax, m1Override,
-                            LogToFileAndUI, "M1");
-                        LogToFileAndUI($"[PATTERN][SUMMARY] role=M1 requested={res1.ModeRequested} used={res1.ModeUsed} fallback={res1.UsedFallback} score={res1.Score} thr={localAnalyze.ThrM1} acceptedByThreshold={res1.AcceptedByThreshold} center=({res1.Center?.X:F3},{res1.Center?.Y:F3}) angle={res1.AngleDeg:F3} scale={res1.BestScale:F3} bestCorr={res1.BestCorr:F3} secondCorr={res1.SecondBestCorr:F3} margin={res1.CorrMargin:F3} search={res1.SearchWidth}x{res1.SearchHeight} pattern={res1.PatternWidth}x{res1.PatternHeight}");
-                        if (localAnalyze.ThrM1 < 70) LogToFileAndUI($"[PATTERN][WARN] low threshold role=M1 threshold={localAnalyze.ThrM1} score={res1.Score} mode={res1.ModeUsed} risk='false-positive'");
+                            patternLog, "M1");
+                        m1Detail = res1;
+                        if (localAnalyze.ThrM1 < 70) LogToFileAndUI($"[PATTERN][WARN] low threshold role=M1 threshold={localAnalyze.ThrM1} score={res1.Score} requested={res1.ModeRequested} used={res1.ModeUsed} risk='false-positive'");
                         if (res1.Center.HasValue)
                         {
                             m1 = new SWPoint(res1.Center.Value.X, res1.Center.Value.Y);
@@ -11296,8 +11305,9 @@ namespace BrakeDiscInspector_GUI_ROI
 
                         var res2 = LocalMatcher.MatchInSearchROIWithDetails(img, localM2Pattern, localM2Search,
                             localAnalyze.FeatureM2, localAnalyze.ThrM2, localAnalyze.RotRange, localAnalyze.ScaleMin, localAnalyze.ScaleMax, m2Override,
-                            LogToFileAndUI, "M2");
-                        LogToFileAndUI($"[PATTERN][SUMMARY] role=M2 requested={res2.ModeRequested} used={res2.ModeUsed} fallback={res2.UsedFallback} score={res2.Score} thr={localAnalyze.ThrM2} acceptedByThreshold={res2.AcceptedByThreshold} center=({res2.Center?.X:F3},{res2.Center?.Y:F3}) angle={res2.AngleDeg:F3} scale={res2.BestScale:F3} bestCorr={res2.BestCorr:F3} secondCorr={res2.SecondBestCorr:F3} margin={res2.CorrMargin:F3} kpsImg={res2.ImageKeypoints} kpsPat={res2.PatternKeypoints} good={res2.GoodMatches} inliers={res2.Inliers} avgDist={res2.AvgDistance:F1} search={res2.SearchWidth}x{res2.SearchHeight} pattern={res2.PatternWidth}x{res2.PatternHeight}");
+                            patternLog, "M2");
+                        m2Detail = res2;
+                        if (localAnalyze.ThrM2 < 70) LogToFileAndUI($"[PATTERN][WARN] low threshold role=M2 threshold={localAnalyze.ThrM2} score={res2.Score} requested={res2.ModeRequested} used={res2.ModeUsed} risk='false-positive'");
                         matchSw.Stop();
                         matchMsLocal = matchSw.ElapsedMilliseconds;
                         if (res2.Center.HasValue)
@@ -11328,7 +11338,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     logs.Add($"[local matcher] ERROR: {ex.Message}");
                 }
 
-                return (m1: m1, m2: m2, score1: score1, score2: score2, angle1: angle1, angle2: angle2, loadMs: loadMsLocal, matchMs: matchMsLocal, logs: logs, disableLocal: disableLocal);
+                return (m1: m1, m2: m2, score1: score1, score2: score2, angle1: angle1, angle2: angle2, m1Detail: m1Detail, m2Detail: m2Detail, loadMs: loadMsLocal, matchMs: matchMsLocal, logs: logs, disableLocal: disableLocal);
             });
 
             foreach (var log in localResult.logs)
@@ -11369,6 +11379,27 @@ namespace BrakeDiscInspector_GUI_ROI
                 c2 = localResult.m2;
                 s2 = localResult.score2;
                 a2 = localResult.angle2;
+            }
+            if (localResult.m1Detail != null)
+            {
+                LogPatternSummary("M1", localResult.m1Detail.ModeRequested, localAnalyze.ThrM1, localResult.m1Detail, localResult.m1.HasValue);
+            }
+            if (localResult.m2Detail != null)
+            {
+                LogPatternSummary("M2", localResult.m2Detail.ModeRequested, localAnalyze.ThrM2, localResult.m2Detail, localResult.m2.HasValue);
+                if (string.Equals(localAnalyze.FeatureM2, "auto", StringComparison.OrdinalIgnoreCase))
+                {
+                    var cause = localResult.m2Detail.Failure ?? string.Empty;
+                    var causeFeat = cause.Contains("feat=") ? cause.Split(';').FirstOrDefault(x => x.StartsWith("feat="))?.Substring(5) : localResult.m2Detail.Failure;
+                    var causeTm = cause.Contains("tm=") ? cause.Split(';').FirstOrDefault(x => x.StartsWith("tm="))?.Substring(3) : string.Empty;
+                    var decision = localResult.m2Detail.ModeUsed switch
+                    {
+                        "features" => "features accepted",
+                        "tm_fallback" => "features rejected, template fallback accepted",
+                        _ => "both rejected"
+                    };
+                    LogToFileAndUI($"[PATTERN][M2_AUTO_DECISION] requested=auto used={localResult.m2Detail.ModeUsed} fallback={localResult.m2Detail.UsedFallback} featureScore={localResult.m2Detail.FeatureScore:F0} templateScore={localResult.m2Detail.TemplateScore:F0} threshold={localAnalyze.ThrM2} decision='{decision}' causeFeat='{(string.IsNullOrWhiteSpace(causeFeat) ? "<none>" : causeFeat)}' causeTm='{(string.IsNullOrWhiteSpace(causeTm) ? "<none>" : causeTm)}'");
+                }
             }
 
             loadMs = localResult.loadMs;
@@ -11730,6 +11761,15 @@ namespace BrakeDiscInspector_GUI_ROI
             var stamped = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}";
             Debug.WriteLine(stamped);
 #endif
+        }
+
+        private static string FormatCenter(OpenCvSharp.Point2d? center)
+            => center.HasValue ? $"({center.Value.X:F3},{center.Value.Y:F3})" : "(null,null)";
+
+        private void LogPatternSummary(string role, string requested, int threshold, LocalMatcher.LocalMatchResult result, bool acceptedFinal)
+        {
+            var failure = string.IsNullOrWhiteSpace(result.Failure) ? "<none>" : result.Failure;
+            LogToFileAndUI($"[PATTERN][SUMMARY] role={role} requested={requested} used={result.ModeUsed} fallback={result.UsedFallback} usedFeatures={result.UsedFeatures} score={result.Score} thr={threshold} acceptedByThreshold={result.AcceptedByThreshold} acceptedFinal={acceptedFinal} center={FormatCenter(result.Center)} angle={result.AngleDeg:F3} bestAngle={result.BestAngleDeg:F3} scale={result.BestScale:F3} bestCorr={result.BestCorr:F4} secondCorr={result.SecondBestCorr:F4} margin={result.CorrMargin:F4} featureScore={result.FeatureScore:F0} templateScore={result.TemplateScore:F0} kpsImg={result.ImageKeypoints} kpsPat={result.PatternKeypoints} good={result.GoodMatches} inliers={result.Inliers} avgDist={result.AvgDistance:F3} search={result.SearchWidth}x{result.SearchHeight} pattern={result.PatternWidth}x{result.PatternHeight} failure='{failure}'");
         }
 
         private void AppendLogLine(string line)


### PR DESCRIPTION
### Motivation
- Las detecciones de Master1/Master2 no dejaban rastro inequívoco del algoritmo realmente usado (`features` vs `tm_rot`/`tm_fallback`), lo que dificulta diagnóstico de fallos y análisis de casos `auto`.
- Se requiere observabilidad adicional en `roi_analyze_master.log` sin cambiar la lógica funcional de detección ni tocar backend/DINO/PatchCore/otros módulos.

### Description
- Instrumenté `LocalMatcher` para emitir líneas explícitas `[PATTERN][TM]`, `[PATTERN][EDGES]`, `[PATTERN][FEATURE]`, `[PATTERN][AUTO]` y `[PATTERN][NOHIT]` con `requested`, `used`, `fallback`, `threshold`, `acceptedByThreshold`, métricas de TM (`bestCorr`, `second`, `margin`, `bestAngle`, `bestScale`) y métricas de features (`kpsImg`, `kpsPat`, `good`, `inliers`, `avgDist`).
- Aseguré que todos los retornos de `MatchInSearchROIWithDetails` rellenan `ModeRequested`, `ModeUsed`, `UsedFallback`, `Failure`, `FeatureScore`, `TemplateScore`, y campos asociados sin cambiar decisiones o umbrales existentes.
- Cableé un `Action<string> patternLog` desde `AnalyzeMastersCoreAsync` hacia `LocalMatcher` para que los mensajes del matcher lleguen a `VisConfLog.AnalyzeMaster` y `GuiLog.Info` de forma segura, y añadí `LogToFileAndUI`-side summaries: `[PATTERN][CONFIG]`, `[PATTERN][SUMMARY]` por master, y `[PATTERN][M2_AUTO_DECISION]` para responder si `M2` en `auto` usó `features` o `tm_fallback` y por qué.
- Ajusté el log geométrico a campos más claros (`angTolDeg`, `posTolPx`, `acceptedFinal`) y añadí advertencias de baja confianza (`[PATTERN][WARN] low threshold`) cuando `thr < 70`.
- Añadí tests unitarios en `gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs` que verifican `tm_rot` metadata y que `auto` siempre establece `ModeUsed` (posibles valores: `features` / `tm_fallback` / `auto_fail`).

### Testing
- Añadí/actualicé tests en `gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs` but did not execute them successfully in this environment.
- Intenté ejecutar `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj` y la ejecución falló por entorno con el error `/bin/bash: dotnet: command not found`.
- Verifiqué por inspección que los nuevos logs se escriben por medio de la ruta existente de `LogToFileAndUI` y que `LocalMatchResult` conserva compatibilidad con campos previos (`Center`, `Score`, `AngleDeg`, `UsedFeatures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a047ed68134832ba5133f30e6a2750f)