### PR TITLE
Fix pattern-geometry tolerance diagnostics and remove duplicate master log writes

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -785,7 +785,6 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             try { _log(message); } catch { }
             try { GuiLog.Info(message); } catch { }
-            try { VisConfLog.AnalyzeMaster(FormattableStringFactory.Create("{0}", message)); } catch { }
         }
 
         private static string PatternBool(bool value) => value ? "True" : "False";
@@ -6406,9 +6405,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             var angleDeltaDeg = detAngle - baseAngle;
             while (angleDeltaDeg <= -180.0) angleDeltaDeg += 360.0;
             while (angleDeltaDeg > 180.0) angleDeltaDeg -= 360.0;
-            var dM1 = 0.0;
-            var dM2 = 0.0;
-            var hasLast = false;
+            var dM1 = Math.Sqrt(Math.Pow(_m1Detection.Center.Value.X - m1Base.cx, 2) + Math.Pow(_m1Detection.Center.Value.Y - m1Base.cy, 2));
+            var dM2 = Math.Sqrt(Math.Pow(_m2Detection.Center.Value.X - m2Base.cx, 2) + Math.Pow(_m2Detection.Center.Value.Y - m2Base.cy, 2));
+            var hasLast = true;
             var reason = acceptedFinal ? "accepted_by_threshold" : "rejected_by_threshold";
             LogPatternGeometry(imagePath, distBase, distDet, rawScale, analyze.ScaleMin, analyze.ScaleMax, angleDeltaDeg, angTolDeg, dM1, dM2, posTolPx, hasLast, acceptedFinal, reason);
 


### PR DESCRIPTION
### Motivation
- Corregir el cálculo de desplazamiento de anclajes para que `LogPatternGeometry` evalúe `posInTol` con valores reales en lugar de `dM1/dM2` hardcodeados y así evitar diagnósticos falseados.
- Evitar duplicación de líneas en `roi_analyze_master.log` eliminando la escritura redundante cuando `_log` ya persiste mediante `AppendLog`.

### Description
- En `WorkflowViewModel.cs` se eliminó la llamada `VisConfLog.AnalyzeMaster(FormattableStringFactory.Create("{0}", message))` dentro de `PatternLog` para evitar escribir dos veces la misma línea.
- Antes de invocar `LogPatternGeometry` se calcularon `dM1` y `dM2` como las distancias reales entre los centros detectados y los centros base, y se fijó `hasLast = true` para que la evaluación de tolerancias posicionales use datos reales.

### Testing
- Ejecuté `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj -v minimal`, que falló en este entorno porque `dotnet` no está disponible (build failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a056a18a488832ba680fb7961ed1265)