### PR TITLE
Restore pattern diagnostics in roi_analyze_master.log

### DIFF
--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -785,6 +785,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             try { _log(message); } catch { }
             try { GuiLog.Info(message); } catch { }
+            try { VisConfLog.AnalyzeMaster(FormattableStringFactory.Create("{0}", message)); } catch { }
         }
 
         private static string PatternBool(bool value) => value ? "True" : "False";


### PR DESCRIPTION
### Motivation
- Restaurar la escritura directa de los mensajes `[PATTERN][...]` en `%LOCALAPPDATA%\BrakeDiscInspector\logs\roi_analyze_master.log` porque PR #813 eliminó la llamada a `VisConfLog.AnalyzeMaster(...)` dentro de `PatternLog`, haciendo que las líneas de diagnóstico de patrón dejen de aparecer de forma fiable.

### Description
- Se volvió a añadir exactamente `try { VisConfLog.AnalyzeMaster(FormattableStringFactory.Create("{0}", message)); } catch { }` dentro de `PatternLog` en `gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs`, sin alterar lógica de detección, thresholds, geometría, backend ni comportamiento del matcher, y no se añadió deduplicación en esta PR para mantener la emisión explícita de `[PATTERN]`.

### Testing
- Intenté compilar con `dotnet build gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj -v minimal` pero falló en este contenedor con `/bin/bash: dotnet: command not found`, por lo que no fue posible ejecutar las pruebas Windows/WPF automáticas ni producir un `roi_analyze_master.log` real; el cambio fue committeado localmente y la validación end-to-end debe realizarse en Windows siguiendo los pasos de la especificación (borrar logs, ejecutar Analyze Masters y verificar que aparecen las líneas `[PATTERN][CONFIG]`, `[PATTERN][SUMMARY] role=M1`, `[PATTERN][SUMMARY] role=M2`, `[PATTERN][M2_AUTO_DECISION]` y `[PATTERN][GEOM]`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05987d8984832b9ee616747051ea09)