### PR TITLE
[codex] Update GUI workflow and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,22 @@ jobs:
 
       - name: Build Docker image
         run: docker build -t brakedisc-backend -f docker/Dockerfile .
+
+  gui-ci:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore GUI tests
+        run: dotnet restore gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj
+
+      - name: Build GUI tests
+        run: dotnet build gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj --configuration Release --no-restore
+
+      - name: Run GUI tests
+        run: dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj --configuration Release --no-build --verbosity normal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ Every PR must include:
 
 ## 4. Tests
 - Backend: run `pytest` if you change backend logic.
-- GUI: manual checklist (load image, edit ROI, run `fit_ok`, `calibrate`, `infer`, batch folder).
+- GUI automated: run `dotnet test gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj -v:minimal`.
+- GUI manual checklist: load layout, open image folder, select a thumbnail, verify heatmap/HUD behavior, edit ROI before dataset creation, verify inspection ROI dataset lock after samples exist, run `fit_ok`, `calibrate`, `infer`, and batch folder.
 
 ## 5. Contracts
 - Do not rename `/health`, `/fit_ok`, `/calibrate_ng`, `/infer` or their fields without updating `docs/API_CONTRACTS.md` and the GUI client.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,8 +6,20 @@ This document covers how to run the **backend** and connect the GUI.
 
 ### Standalone (GUI + backend on one machine)
 1. Install Python 3.11+ and (optionally) CUDA.
-2. Run the backend (`uvicorn backend.app:app --host 0.0.0.0 --port 8000`).
+2. Either run the backend manually (`uvicorn backend.app:app --host 0.0.0.0 --port 8000`) or enable GUI backend auto-start in `config/appsettings.json`.
 3. Launch the GUI and point `Backend.BaseUrl` to `http://127.0.0.1:8000`.
+
+### GUI backend auto-start (WSL)
+The GUI can start the backend automatically when `Backend.AutoStart=true`.
+
+Important keys in `config/appsettings.json`:
+- `Backend.AutoStartMode`: `WslVenv`, `WslConda`, or `WslAuto`.
+- `Backend.WslDistro`: WSL distro name, for example `Ubuntu`.
+- `Backend.WslVenvPath`: virtualenv path for `WslVenv` / `WslAuto`.
+- `Backend.WslCondaEnvironment`: conda environment for `WslConda` / `WslAuto`.
+- `Backend.AutoStartWorkingDirectory`: optional repo/backend working directory override.
+- `Backend.AutoStartModelsDirectory`: optional value exported as `BDI_MODELS_DIR`.
+- `Backend.StartupTimeoutSeconds`: health-check wait budget.
 
 ### Separate backend server
 1. Provision a Linux host with NVIDIA drivers if GPU is required.
@@ -27,6 +39,12 @@ This document covers how to run the **backend** and connect the GUI.
 ## Storage and volumes
 - Model artifacts and datasets are stored under `BDI_MODELS_DIR`.
 - For Docker or multi-worker deployments, mount a shared volume for `BDI_MODELS_DIR`.
+
+## PLC/camera integration
+- Use `Comms.Plc.Mode=Simulation` and `Comms.Camera.Provider=Folder` for no-hardware integration tests.
+- Use `Comms.Plc.Mode=S7` with the configured IP/rack/slot/DB for Siemens S7-1200.
+- `FlirBlackfly` and `Cognex` camera providers are placeholders until the vendor SDK/protocol integration is wired.
+- The camera `Source` path is used only by the `Folder` provider.
 
 ## Logs
 - GUI logs: `%LOCALAPPDATA%\BrakeDiscInspector\logs\`.

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -1,31 +1,40 @@
-# Logging guide (source of truth)
+# Logging Guide (source of truth)
 
-This document describes **where logs are written** and **what they contain** in the current codebase.
+This document describes where logs are written and what they contain in the current codebase.
 
-## GUI logs (WPF)
-**Directory:** `%LOCALAPPDATA%\BrakeDiscInspector\logs\` (created on startup). The GUI clears and recreates core log files at startup. (See `gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs`.)
+## GUI Logs (WPF)
+**Directory:** `%LOCALAPPDATA%\BrakeDiscInspector\logs\` (created on startup). The GUI clears and recreates core log files at startup. See `gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs`.
 
 **Files created by the GUI:**
-- `gui.log` — main GUI log (`GuiLog.Info/Warn/Error`).
-- `gui_heatmap.log` — heatmap overlay placement/debug.
-- `roi_load_coords.log` — ROI load/save diagnostics.
-- `roi_analyze_master.log` — master detection diagnostics.
-- `gui_setup.log` — GUI setup persistence (`GuiSetupSettingsService`).
+- `gui.log` - main GUI log (`GuiLog.Info/Warn/Error`).
+- `gui_heatmap.log` - heatmap overlay placement/debug.
+- `roi_load_coords.log` - ROI load/save diagnostics.
+- `roi_analyze_master.log` - master detection diagnostics.
+- `gui_setup.log` - GUI setup persistence (`GuiSetupSettingsService`).
+
+**Common GUI log prefixes:**
+- `[backend-autostart]` - WSL backend launch, environment activation, health-check wait.
+- `[comms]`, `[plc]`, `[camera-folder]` - PLC/camera connection and acquisition cycle events.
+- `[workflow-edit]` - ROI edit workflow decisions, including inspection ROI dataset locks.
+- `[batch-hm]`, `[heatmap]` - batch/manual heatmap selection, decoding, and placement.
 
 **Format:**
-```
+
+```text
 YYYY-MM-DD HH:mm:ss.fff [LEVEL] message
 ```
+
 Example:
-```
+
+```text
 2025-01-05 12:34:56.789 [INFO] [infer] ROI=... score=... threshold=...
 ```
 
 **Notes:**
-- GUI logs are **plain text** and do not include a `request_id` by default.
+- GUI logs are plain text and do not include a `request_id` by default.
 - If a file disappears during the session, the GUI will recreate it on the next write.
 
-## Backend diagnostics logs (FastAPI)
+## Backend Diagnostics Logs (FastAPI)
 **Format:** JSON Lines (`.jsonl`) written by `backend/diagnostics.py` via `diag_event(...)`.
 
 **Default filename:** `backend_diagnostics.jsonl`.
@@ -40,20 +49,22 @@ If none of the above paths are writable, diagnostics logging is disabled and a w
 
 **Common fields:**
 - `ts` (epoch seconds)
-- `event` (e.g., `startup`, `http`, `fit_ok.request`, `infer.response`)
+- `event` (for example `startup`, `http`, `fit_ok.request`, `infer.response`)
 - `request_id` (if present in request context)
 - `recipe_id`, `role_id`, `roi_id`, `model_key` (when relevant)
 
 **Example line:**
+
 ```json
 {"ts": 1720000000.123, "event": "infer.response", "request_id": "...", "recipe_id": "default", "score": 0.42, "threshold": 0.9, "elapsed_ms": 123}
 ```
 
-## Correlation tips
+## Correlation Tips
 - Backend responses always include `request_id` and `recipe_id` in the JSON body.
 - The backend also sets the `X-Request-Id` response header for correlation.
 - Use time proximity between GUI log timestamps and backend JSONL entries when no request id is available in the GUI logs.
+- For PLC-triggered runs, correlate `[comms]` / `[camera-*]` acquisition entries with the following `[infer]` and backend `infer.*` diagnostics.
 
-## Related docs
-- `docs/BACKEND.md` — backend configuration and storage details.
-- `docs/TROUBLESHOOTING.md` — common failure modes and log pointers.
+## Related Docs
+- `docs/BACKEND.md` - backend configuration and storage details.
+- `docs/TROUBLESHOOTING.md` - common failure modes and log pointers.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The GUI is the **source of truth for ROI geometry and canonical crops**; the bac
 - **ROI drawing and export (GUI):** ROIs are drawn in WPF and exported as canonical crops (post-rotation) with a `shape` JSON mask that matches the exported image space.
 - **Dataset management (backend):** OK/NG samples are uploaded to the backend dataset endpoints and persisted under `BDI_MODELS_DIR` (see `docs/BACKEND.md`). The GUI caches previews locally under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
 - **Training and inference (backend):** The backend runs PatchCore + DINOv2, stores model artifacts per `recipe_id` and `model_key`, and returns `score`, `threshold`, optional `heatmap_png_base64`, and `regions`.
+- **Operator GUI workflow:** the GUI can open a folder as an image collection, show thumbnails under the canvas, load a selected image, analyze masters, and evaluate enabled inspection ROIs when a layout is loaded.
+- **Production communication:** the GUI includes a Siemens S7-1200 communication layer, a simulation PLC, and camera provider slots for `Folder`, `FlirBlackfly`, and `Cognex` (see `docs/COMMS.md`).
 
 ## Quick start
 
@@ -19,6 +21,8 @@ The GUI is the **source of truth for ROI geometry and canonical crops**; the bac
 - **Backend:** Python 3.11+; CUDA GPU is required by default (`BDI_REQUIRE_CUDA=1`). Set `BDI_REQUIRE_CUDA=0` for CPU-only startup.
 
 ### Launch the backend
+The GUI can auto-start the backend through WSL when `Backend.AutoStart=true` in `config/appsettings.json`, using either a WSL venv or conda environment. Manual launch is still supported:
+
 ```bash
 cd backend
 python -m venv .venv
@@ -31,13 +35,17 @@ Config keys are defined in `backend/config.py` and `backend/app.py` (see `docs/B
 ### Launch the GUI
 1. Open `gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` in Visual Studio.
 2. Update `config/appsettings.json` or set `BDI_BACKEND_BASEURL` if the backend is not running on `http://127.0.0.1:8000`.
-3. Run the app. Layouts and master patterns are stored under `<exe>/Recipes/<LayoutName>/`.
+3. Run the app. If backend auto-start is enabled, the GUI checks `/health` and starts the configured WSL backend if needed.
+4. Layouts and master patterns are stored under `<exe>/Recipes/<LayoutName>/`.
 
 ### Minimal end-to-end run
-1. Load an image, define Master 1/2 ROIs and at least one inspection ROI.
-2. Add OK/NG samples (uploads the canonical ROI to the backend dataset).
-3. Run **fit_ok** and **calibrate** from the dataset tab (backend operations).
-4. Evaluate a single image or run batch analysis.
+1. Load a layout, then open an image folder from the canvas thumbnail strip or load an image through an acquisition provider.
+2. Define Master 1/2 ROIs and at least one inspection ROI.
+3. Add OK/NG samples (uploads the canonical ROI to the backend dataset).
+4. Run **fit_ok** and **calibrate** from the dataset tab (backend operations).
+5. Evaluate a single image or run batch analysis.
+
+Once a dataset exists for an inspection ROI, that inspection ROI is locked against geometry edits, resize/move operations, shape changes, removal, and canvas clearing. Additional dataset images can still be added. Master ROIs remain editable because they do not invalidate trained inspection models.
 
 ## Documentation map
 - [`docs/INDEX.md`](docs/INDEX.md) — complete documentation index.
@@ -45,6 +53,7 @@ Config keys are defined in `backend/config.py` and `backend/app.py` (see `docs/B
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — component boundaries and data flow.
 - [`docs/FRONTEND.md`](docs/FRONTEND.md) — WPF UI behavior, ROI workflows, UI specs.
 - [`docs/BACKEND.md`](docs/BACKEND.md) — FastAPI configuration, persistence, failure modes.
+- [`docs/COMMS.md`](docs/COMMS.md) — PLC/camera communication modes and signal map.
 - [`docs/API_CONTRACTS.md`](docs/API_CONTRACTS.md) — exact HTTP contracts.
 - [`LOGGING.md`](LOGGING.md) — **source of truth** for logs and diagnostics.
 

--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -1,6 +1,16 @@
 {
   "Backend": {
-    "BaseUrl": "http://127.0.0.1:8000"
+    "BaseUrl": "http://127.0.0.1:8000",
+    "AutoStart": true,
+    "AutoStartMode": "WslVenv",
+    "WslDistro": "Ubuntu",
+    "WslCondaEnvironment": "BrakeDisc",
+    "WslVenvPath": "/home/millylinux/venv",
+    "AutoStartWorkingDirectory": "",
+    "AutoStartModelsDirectory": "/mnt/c/Users/corre/source/repos/Backend_BDI_V2/backend/models",
+    "AutoStartHost": "0.0.0.0",
+    "AutoStartPort": 8000,
+    "StartupTimeoutSeconds": 45
   },
   "Dataset": {
     "Root": ""
@@ -12,5 +22,25 @@
   },
   "UI": {
     "HeatmapOverlayOpacity": 0.6
+  },
+  "Comms": {
+    "Enabled": true,
+    "AutoConnectOnStartup": false,
+    "AutoRunInspectionOnTrigger": false,
+    "RequirePartPresent": true,
+    "Plc": {
+      "Mode": "Simulation",
+      "IpAddress": "192.168.0.10",
+      "Rack": 0,
+      "Slot": 1,
+      "DbNumber": 1,
+      "PollIntervalMs": 100
+    },
+    "Camera": {
+      "Provider": "Disabled",
+      "Source": "",
+      "OutputDirectory": "",
+      "TimeoutMs": 5000
+    }
   }
 }

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -2,9 +2,11 @@
 
 This guide is optimized for new contributors and other AI agents. It is aligned with current code and avoids unverifiable claims.
 
-## 10-minute quickstart
+## 10-minute Quickstart
 
 ### 1) Start the backend
+The GUI can auto-start the backend through WSL when `Backend.AutoStart=true`, but manual startup is useful for debugging:
+
 ```bash
 cd backend
 python -m venv .venv
@@ -16,30 +18,35 @@ uvicorn backend.app:app --host 0.0.0.0 --port 8000
 ### 2) Start the GUI
 1. Open `gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.sln` in Visual Studio.
 2. Verify `config/appsettings.json` points to `http://127.0.0.1:8000` or set `BDI_BACKEND_BASEURL`.
-3. Run the app.
+3. Run the app. If auto-start is enabled, the GUI launches the configured WSL backend when `/health` is not ready.
 
 ### 3) Minimal flow
-1. Load an image and draw Master 1/2 and at least one inspection ROI.
-2. Add OK/NG samples (uploads to backend dataset).
-3. Run **fit_ok** (train from dataset) and **calibrate**.
-4. Run **Evaluate** (single image) or **Batch**.
+1. Load a layout.
+2. Open an image folder from the canvas thumbnail strip and select an image.
+3. Draw Master 1/2 and at least one inspection ROI.
+4. Add OK/NG samples (uploads to backend dataset).
+5. Run **fit_ok** (train from dataset) and **calibrate**.
+6. Run **Evaluate** (single image) or **Batch**.
 
-## Architecture: GUI vs backend
-- **GUI (WPF)**: ROI drawing, canonical crop/warp, layout persistence, master patterns, batch visualization.
-- **Backend (FastAPI)**: dataset/model storage, `fit_ok`, calibration, inference, heatmaps.
+## Architecture: GUI vs Backend
+- **GUI (WPF):** ROI drawing, canonical crop/warp, layout persistence, master patterns, batch visualization, backend auto-start, and PLC/camera communication state.
+- **Backend (FastAPI):** dataset/model storage, `fit_ok`, calibration, inference, heatmaps.
 
-The backend does **not** crop or rotate images; it consumes the canonical crop and `shape` JSON that the GUI produces.
+The backend does not crop or rotate images; it consumes the canonical crop and `shape` JSON that the GUI produces.
 
-## Flow: dataset → fit_ok → calibrate → evaluate → batch
-1. **Dataset**: GUI uploads ROI crops to `/datasets/ok/upload` or `/datasets/ng/upload`.
-2. **fit_ok**: GUI calls `/fit_ok` with `use_dataset=true`.
-3. **Calibrate**: GUI calls `/calibrate_dataset` (or `/calibrate_ng` if using precomputed scores).
-4. **Evaluate**: GUI sends a single ROI crop to `/infer`.
-5. **Batch**: GUI aligns ROIs with master anchors and repeats `/infer` per ROI per image.
+## Flow: Dataset to Fit to Calibrate to Evaluate to Batch
+1. **Dataset:** GUI uploads ROI crops to `/datasets/ok/upload` or `/datasets/ng/upload`.
+2. **fit_ok:** GUI calls `/fit_ok` with `use_dataset=true`.
+3. **Calibrate:** GUI calls `/calibrate_dataset` or `/calibrate_ng` if using precomputed scores.
+4. **Evaluate:** GUI sends a single ROI crop to `/infer`.
+5. **Batch:** GUI aligns ROIs with master anchors and repeats `/infer` per ROI per image.
+
+Important workflow rule: after an inspection ROI has dataset samples, its geometry is locked. Users may add more samples, but cannot edit, move, resize, remove, recreate, change shape, or clear that inspection ROI. Master ROIs are still editable.
 
 ## Persistence (backend)
 Artifacts are stored under `BDI_MODELS_DIR` (default `models/`):
-```
+
+```text
 <BDI_MODELS_DIR>/
   recipes/<recipe_id>/<model_key>/
     <base_name>.npz
@@ -47,6 +54,7 @@ Artifacts are stored under `BDI_MODELS_DIR` (default `models/`):
     <base_name>_calib.json
   recipes/<recipe_id>/datasets/<base_name>/{ok,ng}/*
 ```
+
 - `base_name = base64(role_id) + "__" + base64(roi_id)` (urlsafe, no padding).
 - `model_key` defaults to `roi_id`.
 
@@ -55,17 +63,22 @@ Artifacts are stored under `BDI_MODELS_DIR` (default `models/`):
 - Reserved: `last` (HTTP 400 if used).
 - Stored case-insensitively (normalized to lowercase).
 
-## Debugging cookbook
+## Debugging Cookbook
 
 ### HasFitOk (legacy)
 - `HasFitOk` may appear in old layout files.
-- It is removed during layout load and should be treated as **stale**.
-- Backend state (via `/state` or `/manifest`) is authoritative.
+- It is removed during layout load and should be treated as stale.
+- Backend state via `/state` or `/manifest` is authoritative.
 
-### ROI2 batch heatmap missing
-- Known issue: ROI2 may not show after the first batch image.
-- Check `gui.log` and `gui_heatmap.log` for ROI2 placement messages.
-- TODO: verify and fix placement guard if ROI2 shares ROI1 geometry.
+### Inspection ROI locked
+- Message: `Inspection ROIs can't be modified once Dataset is created`.
+- Cause: that inspection ROI already has OK/NG dataset samples.
+- Allowed: add more dataset images.
+- Not allowed: geometry edits, move/resize, shape changes, deletion/recreation, or canvas clear affecting that ROI.
+
+### Batch heatmap missing or misplaced
+- Check `gui.log` and `gui_heatmap.log` for ROI index, canvas rectangle, and placement guard messages.
+- Batch heatmaps are stored per ROI index; verify the selected heatmap ROI matches the result you expect to see.
 
 ### mm_per_px mismatch (HTTP 409)
 - The backend locks `mm_per_px` per `recipe_id` when training or dataset metadata includes it.
@@ -77,12 +90,13 @@ Artifacts are stored under `BDI_MODELS_DIR` (default `models/`):
 - Backend responses include `request_id` and `recipe_id` for correlation.
 
 ## Glossary
-- **recipe_id**: backend namespace for datasets/models; validated and normalized.
-- **role_id**: logical role (Master1, Master2, Inspection).
-- **roi_id**: logical ROI identifier (often `inspection-<n>`).
-- **model_key**: backend model slot, defaults to `roi_id`.
-- **dataset**: OK/NG samples stored in the backend under `BDI_MODELS_DIR`.
-- **fit_ok**: PatchCore training step (OK-only memory/coreset).
-- **calibrate**: threshold selection using OK/NG scores or dataset sampling.
-- **evaluate**: run `/infer` on a single ROI crop.
-- **Enabled**: GUI-only toggle for whether a ROI participates in evaluation.
+- **recipe_id:** backend namespace for datasets/models; validated and normalized.
+- **role_id:** logical role (Master1, Master2, Inspection).
+- **roi_id:** logical ROI identifier (often `inspection-<n>`).
+- **model_key:** backend model slot, defaults to `roi_id`.
+- **dataset:** OK/NG samples stored in the backend under `BDI_MODELS_DIR`.
+- **fit_ok:** PatchCore training step (OK-only memory/coreset).
+- **calibrate:** threshold selection using OK/NG scores or dataset sampling.
+- **evaluate:** run `/infer` on a single ROI crop.
+- **Enabled:** GUI-only toggle for whether a ROI participates in evaluation.
+- **Folder camera provider:** no-hardware camera mode that copies the next image from a configured source folder.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document summarizes **how the current codebase is wired** and where data lives. It only describes behavior that is visible in the repository.
+This document summarizes how the current codebase is wired and where data lives. It only describes behavior that is visible in the repository.
 
 ## Components
 
@@ -9,12 +9,14 @@ This document summarizes **how the current codebase is wired** and where data li
 - ROI drawing and editing (rect/circle/annulus).
 - Canonical ROI export (crop + rotation) and `shape` JSON generation in canonical ROI coordinates.
 - Master patterns, inspection ROI layout, batch visualization.
-- UI state, layout persistence, and local previews.
+- UI state, layout persistence, local previews, and image-folder thumbnail workflow.
+- Backend auto-start orchestration for local WSL deployments.
+- Production-cell communication state for PLC/camera integration.
 
 **On-disk GUI artifacts:**
 - Layout and master assets live under `<exe>/Recipes/<LayoutName>/` (see `RecipePathHelper`).
 - Master patterns are saved under `<exe>/Recipes/<LayoutName>/Master/`.
-- Dataset *previews* are cached under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
+- Dataset previews are cached under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
 
 ### FastAPI backend (`backend/`)
 **Responsibilities (source of truth):**
@@ -23,26 +25,41 @@ This document summarizes **how the current codebase is wired** and where data li
 - Recipe-aware storage and artifact resolution with fallback to legacy layouts.
 
 **Key modules:**
-- `app.py` — FastAPI routes and request validation.
-- `storage.py` — `ModelStore` persistence layout and recipe rules.
-- `features.py`, `patchcore.py`, `infer.py`, `calib.py` — PatchCore + DINOv2 pipeline.
-- `diagnostics.py` — structured JSONL diagnostics.
+- `app.py` - FastAPI routes and request validation.
+- `storage.py` - `ModelStore` persistence layout and recipe rules.
+- `features.py`, `patchcore.py`, `infer.py`, `calib.py` - PatchCore + DINOv2 pipeline.
+- `diagnostics.py` - structured JSONL diagnostics.
 
-## GUI ↔ backend boundary
-- **GUI** exports **canonical ROI crops** and supplies `shape` masks in the crop's coordinate system.
-- **Backend** **does not** crop or rotate images; it trusts the GUI-provided crop and `shape` mask.
+### Communication layer (`gui/BrakeDiscInspector_GUI_ROI/Comms/`)
+**Responsibilities:**
+- Abstract PLC polling and output writes through `IPlcClient`.
+- Provide simulation mode for development without wiring.
+- Provide Siemens S7-1200 connectivity through S7.NetPlus.
+- Abstract image acquisition through `ICameraClient`.
+- Implement the `Folder` camera provider for integration testing and expose `FlirBlackfly` / `Cognex` placeholders until vendor SDK wiring is selected.
+
+## GUI to Backend Boundary
+- The GUI exports canonical ROI crops and supplies `shape` masks in the crop's coordinate system.
+- The backend does not crop or rotate images; it trusts the GUI-provided crop and `shape` mask.
 
 This separation is fundamental for consistent overlays and debugging.
 
-## Data flow (high level)
-1. **Manual inspection**: GUI exports a canonical ROI crop → backend `/infer` → GUI overlays result.
-2. **Batch inspection**: GUI aligns ROIs using master anchors → exports crops per image → backend `/infer` per ROI.
-3. **Dataset management**: GUI uploads samples to backend `/datasets/*` → backend persists dataset → GUI downloads previews for display.
+## Data Flow
+1. **Manual inspection:** GUI exports a canonical ROI crop, backend `/infer` evaluates it, GUI overlays the result.
+2. **Batch inspection:** GUI aligns ROIs using master anchors, exports crops per image, and calls backend `/infer` per ROI.
+3. **Dataset management:** GUI uploads samples to backend `/datasets/*`, backend persists the dataset, GUI downloads previews for display.
+4. **PLC-triggered inspection:** PLC start edge, GUI acquires a camera frame, GUI loads/analyzes/evaluates, GUI writes ready/busy/result/error bits back to the PLC.
 
-## Persistence layout (backend)
+## ROI Edit Policy
+- Inspection ROI geometry is mutable until a dataset exists for that ROI.
+- After a dataset exists, the GUI locks inspection ROI geometry to protect the backend model contract.
+- Additional OK/NG samples can still be uploaded to the dataset.
+- Master ROIs remain mutable because they are GUI-only alignment assets and are never uploaded as backend model geometry.
+
+## Persistence Layout (backend)
 Artifacts are stored under `BDI_MODELS_DIR` (default `models/`).
 
-```
+```text
 <BDI_MODELS_DIR>/
   recipes/<recipe_id>/<model_key>/
     <base_name>.npz
@@ -54,15 +71,16 @@ Artifacts are stored under `BDI_MODELS_DIR` (default `models/`).
 ```
 
 Where:
-- `recipe_id` is validated, lowercased, and **must not** be `last`.
+- `recipe_id` is validated, lowercased, and must not be `last`.
 - `model_key` defaults to `roi_id` and is sanitized for filesystem use.
 - `base_name` is `base64(role_id) + "__" + base64(roi_id)` (urlsafe base64 without `=` padding).
 
 Legacy fallbacks still exist for older layouts (`models/datasets/<role>/<roi>`, `models/<role>_<roi>.npz`, etc.).
 
-## Caching (current implementation)
-- **Backend caches** model memory and calibration per worker process. Cache size is capped by `BDI_CACHE_MAX_ENTRIES`.
-- **GUI caches** master patterns by path + `mtime` + size to avoid reloading identical images; stale caches are invalidated when files change.
+## Caching
+- Backend caches model memory and calibration per worker process. Cache size is capped by `BDI_CACHE_MAX_ENTRIES`.
+- GUI caches master patterns by path + `mtime` + size to avoid reloading identical images; stale caches are invalidated when files change.
+- GUI master matching caches rotated/scaled template variants for batch alignment.
 
 ## Logging
 Logging is centralized in `LOGGING.md` and should be treated as the single source of truth.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,27 @@
 # Changelog (selected)
 
 ## Implemented
+- Windows GUI CI now restores, builds, and runs the WPF test project on `windows-latest`.
+- GUI backend auto-start can launch the configured WSL backend environment and wait for `/health`.
+- Siemens S7-1200 communication scaffolding, simulation PLC, and camera provider abstractions are available in the GUI. `Folder` is implemented for no-hardware testing; `FlirBlackfly` and `Cognex` are explicit placeholders until vendor SDK wiring is selected.
+- The camera `Source` field is active only for the `Folder` provider and is selected through a folder browser.
+- The canvas image workflow now uses an image-folder thumbnail strip under the canvas. Selecting a thumbnail loads that image; collection loading shows a wait message.
+- Heatmap opacity/scale controls and Object Visibility HUD are shown only when an image is loaded, with translucent backgrounds for readability.
+- The Object Visibility HUD uses modern vertical toggles and black/dark-gray ROI visibility styling.
+- Dark/light theme handling and Setup GUI color configuration were updated so buttons, list boxes, and common controls remain readable.
+- Setup GUI color fields can be selected from an in-app color palette and persisted as custom GUI settings.
+- ROI rotation affordances are shown through a corner rotate symbol.
+- OK/NG status is displayed as an integrated canvas badge, and snackbar text is larger for operator visibility.
+- Edit mode now shows a yellow canvas frame and `Edit Mode` label while ROI editing is active.
+- Loading an image with a layout triggers master analysis and enabled ROI evaluation; loading an image without a layout shows `Please load a layout`.
+- Inspection ROI datasets refresh after layout load so dataset counts/previews are restored.
+- Inspection ROIs are locked after a dataset exists; users can add more dataset images, but cannot edit, resize, move, delete, recreate, change shape, or clear those inspection ROIs. Master ROIs remain editable.
+- Master pattern matching now caches rotated/scaled template variants to reduce repeated work during batch alignment.
 - Recipe-aware backend storage under `BDI_MODELS_DIR/recipes/<recipe_id>/...` with legacy fallback.
 - Reserved `recipe_id` `last` rejected with HTTP 400.
 - Dataset-only training gate via `BDI_TRAIN_DATASET_ONLY` and minimum OK samples via `BDI_MIN_OK_SAMPLES`.
 - Backend diagnostics written as JSONL (`backend_diagnostics.jsonl`) in a resolved log directory.
 
 ## Planned / Spec
-- Heatmap overlay rule: **only show red overlay when result is NG and heatmap is the cause of NG**.
-- OK/NG badge spec: square badge with bold white `OK`/`NG` on green/red background.
-- Batch issue: ROI2 heatmap missing after the first image — investigate and add regression guard.
+- FLIR Blackfly and Cognex providers still need final vendor SDK/protocol integration before real hardware acquisition can replace the placeholders.
+- Heatmap overlay policy remains: **only show red overlay when result is NG and heatmap is the cause of NG**.

--- a/docs/COMMS.md
+++ b/docs/COMMS.md
@@ -1,0 +1,78 @@
+# Communications
+
+The GUI owns the production-cell communication layer. It can run without hardware by using simulation modes, and it is prepared for a Siemens S7-1200 PLC plus one industrial camera provider.
+
+## PLC
+
+Supported modes:
+- `Simulation`: in-memory PLC for development without wiring.
+- `S7`: Siemens S7-1200 via S7.NetPlus.
+
+Default PLC settings live in `gui/BrakeDiscInspector_GUI_ROI/appsettings.json` and `config/appsettings.json`:
+
+```json
+"Comms": {
+  "Plc": {
+    "Mode": "Simulation",
+    "IpAddress": "192.168.0.10",
+    "Rack": 0,
+    "Slot": 1,
+    "DbNumber": 1,
+    "PollIntervalMs": 100
+  }
+}
+```
+
+PLC DB bit map:
+
+| Signal | Direction | DB byte.bit |
+|---|---|---|
+| Start inspection | PLC to GUI | DBX0.0 |
+| Stop inspection | PLC to GUI | DBX0.1 |
+| Part present | PLC to GUI | DBX0.2 |
+| Reset error | PLC to GUI | DBX0.3 |
+| System ready | GUI to PLC | DBX2.0 |
+| Busy | GUI to PLC | DBX2.1 |
+| Result OK | GUI to PLC | DBX2.2 |
+| Result NG | GUI to PLC | DBX2.3 |
+| Error | GUI to PLC | DBX2.4 |
+
+The GUI detects a rising edge on `Start inspection`. If `RequirePartPresent` is enabled, `Part present` must also be true.
+
+## Camera
+
+Supported providers:
+- `Disabled`: no acquisition.
+- `Folder`: development provider that copies the next image from a folder into the capture output directory.
+- `FlirBlackfly`: placeholder for FLIR Spinnaker SDK wiring.
+- `Cognex`: placeholder for the selected Cognex SDK/protocol wiring.
+
+`Folder` is the safe no-hardware path for integration testing. The GUI only enables the camera `Source` selector and browse button when this provider is active; for FLIR/Cognex that field is not used. Set:
+
+```json
+"Camera": {
+  "Provider": "Folder",
+  "Source": "C:\\path\\to\\sample-images",
+  "OutputDirectory": "C:\\path\\to\\captures"
+}
+```
+
+## Cycle
+
+When `AutoRunInspectionOnTrigger` is true, the cycle is:
+
+1. PLC rising edge: `Start inspection`.
+2. GUI writes `Busy=true`, clears result bits.
+3. Camera acquires an image.
+4. GUI loads the image, analyzes masters, and evaluates enabled inspection ROIs.
+5. GUI writes `Busy=false` plus `Result OK` or `Result NG`.
+6. On failure, GUI writes `Error=true`.
+
+Real FLIR/Cognex acquisition requires the vendor SDK choice and installed native/.NET assemblies before those providers can replace their placeholders.
+
+## UI behavior
+- The communications panel can run against the simulated PLC and `Folder` camera without hardware.
+- `AutoConnectOnStartup` controls whether the GUI connects automatically.
+- `AutoRunInspectionOnTrigger` controls whether a PLC start edge loads the acquired image and evaluates enabled inspection ROIs.
+- `RequirePartPresent` requires the PLC `Part present` signal before accepting a start edge.
+- Provider changes rebuild the camera client; the `Source` path is only meaningful for `Folder`.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,75 +1,114 @@
-# Front-end (WPF) reference
+# Front-end (WPF) Reference
 
 This document describes the WPF GUI under `gui/` as implemented in the repository.
 
-## Responsibilities (GUI vs backend)
+## Responsibilities (GUI vs Backend)
 **GUI (source of truth for geometry):**
 - ROI drawing and editing (rect/circle/annulus).
 - Canonical ROI export (crop + rotation) and `shape` JSON generation.
-- Master patterns, layout persistence, batch visualization.
+- Master patterns, layout persistence, batch visualization, image collection workflow, and communication UI.
 
 **Backend (source of truth for data):**
 - Datasets, models, calibration, and inference. See `docs/BACKEND.md`.
 
-## Layouts and local storage
+## Layouts and Local Storage
 - Layouts and master assets are stored under `<exe>/Recipes/<LayoutName>/`.
 - Master patterns are saved under `<exe>/Recipes/<LayoutName>/Master/`.
 - Dataset previews are cached under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...`.
 
-> The GUI still creates local dataset folders (`<exe>/Recipes/<LayoutName>/Dataset/...`) for legacy compatibility, but the **authoritative dataset** is the backend dataset under `BDI_MODELS_DIR`.
+The GUI still creates local dataset folders (`<exe>/Recipes/<LayoutName>/Dataset/...`) for legacy compatibility, but the authoritative dataset is the backend dataset under `BDI_MODELS_DIR`.
 
-## Dataset workflow (backend source of truth)
+## Backend Startup from the GUI
+- On startup, the GUI reads `config/appsettings.json` / `appsettings.json` through `AppConfig`.
+- When `Backend.AutoStart=true`, the GUI probes `<Backend.BaseUrl>/health`.
+- If the backend is not healthy, it launches the configured WSL backend with `Backend.AutoStartMode` (`WslVenv`, `WslConda`, or `WslAuto`) and waits up to `Backend.StartupTimeoutSeconds`.
+- `Backend.AutoStartModelsDirectory` is exported as `BDI_MODELS_DIR` when configured.
+
+The backend can still be started manually; auto-start is only a convenience for operator launch.
+
+## Canvas Image Workflow
+- The canvas has an image-folder button and a thumbnail strip under the main image.
+- Opening a folder loads supported image files into the strip and shows a loading message while thumbnails are prepared.
+- Selecting a thumbnail loads that image into the canvas.
+- Heatmap scale/opacity controls and the Object Visibility HUD are only shown when an image is loaded.
+- If an image is loaded before any layout is active, the GUI shows `Please load a layout`.
+- If a layout is active, image load triggers master analysis and evaluation of enabled inspection ROIs.
+
+## Dataset Workflow (backend source of truth)
 - **Upload:** the GUI exports the canonical ROI and uploads it to `/datasets/ok/upload` or `/datasets/ng/upload`.
 - **List/preview:** the GUI calls `/datasets/list` and downloads thumbnails via `/datasets/file` into its local cache.
 - **Delete:** the GUI deletes remote files via `/datasets/file` (DELETE) and removes cached copies.
 
-## Training and inference flows
+### Inspection ROI Dataset Lock
+Once a dataset exists for an inspection ROI, that inspection ROI geometry is locked.
+- Users can still add more OK/NG images to the dataset.
+- Users cannot enter edit mode, move, resize, save geometry changes, delete/recreate the ROI, change its shape, clear it through canvas clear, or clear persisted geometry.
+- The warning message is: `Inspection ROIs can't be modified once Dataset is created`.
+- Master ROIs remain editable because changing them does not invalidate backend inspection models.
+
+## Training and Inference Flows
 - **fit_ok:** GUI calls `/fit_ok` with `use_dataset=true` to train from backend datasets.
 - **calibrate:** GUI calls `/calibrate_dataset` or `/calibrate_ng` depending on the workflow.
 - **infer:** GUI calls `/infer` for a single ROI crop, always including the `shape` JSON.
 
 Exact HTTP contracts live in `docs/API_CONTRACTS.md`.
 
-## Enabled vs backend fitted state
-Each inspection ROI has a local **Enabled** toggle that controls **UI participation** in batch/inference.
-- **Enabled** is a GUI-only flag; it does **not** change backend artifacts.
-- Backend readiness is tracked separately (e.g., memory/calibration presence returned by `/state`).
+## Enabled vs Backend Fitted State
+Each inspection ROI has a local **Enabled** toggle that controls UI participation in batch/inference.
+- **Enabled** is a GUI-only flag; it does not change backend artifacts.
+- Backend readiness is tracked separately, for example by memory/calibration presence returned by `/state`.
 
-**Legacy note:** older layout files may include `HasFitOk`. This field is migrated out on load and should be treated as **stale**. The backend is the source of truth for fitted state.
+Legacy note: older layout files may include `HasFitOk`. This field is migrated out on load and should be treated as stale. The backend is the source of truth for fitted state.
 
-### Where Enabled is controlled
+### Where Enabled is Controlled
 - **InspectionDefaultPanel:** checkbox next to each inspection ROI row (main panel).
 - **InspectionDatasetTabView:** an `Enabled` checkbox in the dataset tab.
 
 Both bind to the same `InspectionRoiConfig.Enabled` property and stay synchronized.
 
-## Master patterns (GUI-only)
-- Master patterns are **independent of the backend**.
+## Master Patterns (GUI-only)
+- Master patterns are independent of the backend.
 - Saved as `master1_pattern.png` / `master2_pattern.png` under `<exe>/Recipes/<LayoutName>/Master/`.
 - Older versions are moved to `Master/obsolete/` (no timestamp in the base filename).
+- Master matching caches rotated/scaled template variants for each pattern so batch alignment does not rebuild the same search variants repeatedly.
 
-**Cache risk:** master patterns are cached by **path + mtime + size**. If you overwrite a file without changing its mtime/size, the GUI may reuse a stale cache. Recommended invalidation: update mtime or version the file name (timestamp suffix).
+Cache risk: master patterns are cached by path + `mtime` + size. If you overwrite a file without changing its mtime/size, the GUI may reuse a stale cache. Recommended invalidation: update mtime or version the file name.
 
-## Heatmap & badge UI spec (current expectation)
-> This section is a UI spec. If the current implementation deviates, treat it as TODO and align UI later.
+## Heatmap, HUD, and Badge UI
 
-### Heatmap visibility rules
-- Only show **red zones** when the **final result is NG** and the heatmap is the cause of NG.
-- If the result is **OK**, no heatmap overlay should be shown.
-- Apply the same rule in **manual** and **batch** views.
+### Heatmap Visibility Rules
+- Only show red zones when the final result is NG and the heatmap is the cause of NG.
+- If the result is OK, no heatmap overlay should be shown.
+- Apply the same rule in manual and batch views.
+- Heatmap scale and opacity controls use translucent backgrounds and are only visible with a loaded image.
 
-### OK/NG badge
+### Object Visibility HUD
+- The HUD is titled `OBJECT VISIBILITY`.
+- The HUD uses vertically aligned toggle controls.
+- Selected ROI outlines are black; unselected/hidden styling uses dark gray.
+- The HUD is hidden until an image is loaded.
+
+### OK/NG Badge
 - Square badge (width == height).
 - **NG:** red square, white text `NG`, very bold typography.
 - **OK:** green square, white text `OK`, very bold typography.
+- The badge is placed inside the canvas, near the upper-right quadrant but offset from the edge.
 
-## Known batch issue (ROI2)
-There is a known issue where **ROI2 heatmap may not appear after the first batch image**. The plan is:
-1. Confirm ROI2 placement logs in `gui.log`/`gui_heatmap.log`.
-2. Ensure the batch placement guard does not reuse ROI1 geometry for ROI2.
-3. Add a regression test or manual checklist step once fixed.
+### Edit Mode Indicator
+- Active ROI editing shows a yellow canvas frame.
+- The lower-left canvas label `Edit Mode` is visible only while ROI editing is active.
 
-## Related docs
-- `docs/ROI_AND_HEATMAP_FLOW.md` — ROI export + heatmap pipeline details.
-- `docs/LOGGING.md` — log locations and correlation.
-- `docs/TROUBLESHOOTING.md` — operational checklist.
+## Theme and Setup GUI
+- Light/dark theme switching updates shared WPF brushes used by buttons, list boxes, text inputs, and common controls.
+- Setup GUI can customize key colors through palette buttons next to color fields.
+- Custom colors are persisted only when explicitly changed; changing theme resets custom color overrides.
+
+## Batch Heatmap Placement
+- Batch heatmaps are tracked per ROI index so ROI selection can display the corresponding stored heatmap.
+- Placement diagnostics are written to `gui.log` and `gui_heatmap.log`.
+- If a heatmap disappears or appears on the wrong ROI, check those logs for the ROI index, canvas rectangle, and placement guard messages.
+
+## Related Docs
+- `docs/ROI_AND_HEATMAP_FLOW.md` - ROI export + heatmap pipeline details.
+- `LOGGING.md` - log locations and correlation.
+- `docs/TROUBLESHOOTING.md` - operational checklist.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,26 +1,27 @@
-# Documentation index
+# Documentation Index
 
-Use this page as the **single entry point** for all documentation in the repo.
+Use this page as the single entry point for all documentation in the repo.
 
-## Core docs
-- [`README.md`](../README.md) — project overview and quickstart.
-- [`docs/AI_ONBOARDING.md`](AI_ONBOARDING.md) — 10-minute onboarding + glossary.
-- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — component boundaries and data flow.
-- [`docs/FRONTEND.md`](FRONTEND.md) — WPF UI behaviors and specs.
-- [`docs/BACKEND.md`](BACKEND.md) — FastAPI configuration, persistence, failure modes.
-- [`docs/API_CONTRACTS.md`](API_CONTRACTS.md) — exact HTTP contracts.
-- [`docs/ROI_AND_HEATMAP_FLOW.md`](ROI_AND_HEATMAP_FLOW.md) — ROI export + heatmap flow.
-- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — common issues and fixes.
-- [`LOGGING.md`](../LOGGING.md) — **source of truth for logs**.
-- [`docs/CHANGELOG.md`](CHANGELOG.md) — implemented vs planned.
+## Core Docs
+- [`README.md`](../README.md) - project overview and quickstart.
+- [`docs/AI_ONBOARDING.md`](AI_ONBOARDING.md) - 10-minute onboarding + glossary.
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) - component boundaries, data flow, communication layer, and ROI edit policy.
+- [`docs/FRONTEND.md`](FRONTEND.md) - WPF UI behaviors, ROI workflows, canvas controls, and UI specs.
+- [`docs/BACKEND.md`](BACKEND.md) - FastAPI configuration, persistence, failure modes.
+- [`docs/COMMS.md`](COMMS.md) - PLC/camera communication contract.
+- [`docs/API_CONTRACTS.md`](API_CONTRACTS.md) - exact HTTP contracts.
+- [`docs/ROI_AND_HEATMAP_FLOW.md`](ROI_AND_HEATMAP_FLOW.md) - ROI export + heatmap flow.
+- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) - common issues and fixes.
+- [`LOGGING.md`](../LOGGING.md) - source of truth for logs.
+- [`docs/CHANGELOG.md`](CHANGELOG.md) - implemented vs planned.
 
 ## Operations
-- [`DEPLOYMENT.md`](../DEPLOYMENT.md) — backend deployment guide.
-- [`docker/README.md`](../docker/README.md) — Docker build/run.
+- [`DEPLOYMENT.md`](../DEPLOYMENT.md) - backend deployment, GUI auto-start, and PLC/camera deployment notes.
+- [`docker/README.md`](../docker/README.md) - Docker build/run.
 
-## Contributor / agent guides
-- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contributor workflow.
-- [`agents.md`](../agents.md) — project playbook.
-- [`instructions_codex_gui_workflow.md`](../instructions_codex_gui_workflow.md) — AI workflow checklist.
-- [`backend/README_backend.md`](../backend/README_backend.md) — backend quick reference.
-- [`backend/agents_for_backend.md`](../backend/agents_for_backend.md) — backend playbook.
+## Contributor / Agent Guides
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) - contributor workflow.
+- [`agents.md`](../agents.md) - project playbook.
+- [`instructions_codex_gui_workflow.md`](../instructions_codex_gui_workflow.md) - AI workflow checklist.
+- [`backend/README_backend.md`](../backend/README_backend.md) - backend quick reference.
+- [`backend/agents_for_backend.md`](../backend/agents_for_backend.md) - backend playbook.

--- a/docs/ROI_AND_HEATMAP_FLOW.md
+++ b/docs/ROI_AND_HEATMAP_FLOW.md
@@ -1,22 +1,22 @@
-# ROI and heatmap workflow
+# ROI and Heatmap Workflow
 
-This document focuses on ROI identifiers, canonical ROI export, and heatmap visualization for manual and batch flows.
+This document focuses on ROI identifiers, canonical ROI export, edit locking, master alignment, and heatmap visualization for manual and batch flows.
 
-## ROI identifiers and terminology
-- **role_id**: logical role (`Master1`, `Master2`, `Inspection`, etc.) sent to the backend.
-- **roi_id**: logical ROI identifier, often `inspection-<n>` for inspection slots.
-- **model_key**: backend model slot, defaults to `roi_id` if not provided.
+## ROI Identifiers and Terminology
+- **role_id:** logical role (`Master1`, `Master2`, `Inspection`, etc.) sent to the backend.
+- **roi_id:** logical ROI identifier, often `inspection-<n>` for inspection slots.
+- **model_key:** backend model slot, defaults to `roi_id` if not provided.
 
 The GUI uses inspection defaults like `inspection-1..4` (see `InspectionRoiConfig.ModelKey`). Local dataset folders (legacy) map these to `Inspection_1..4` under `<exe>/Recipes/<LayoutName>/Dataset/`.
 
-## Canonical ROI export
-1. The GUI exports the ROI **after rotation**, producing a canonical crop (PNG) and a `shape` JSON mask.
-2. The `shape` JSON is expressed in **canonical ROI coordinates** (i.e., the crop’s pixel space).
-3. The backend treats the image and `shape` as authoritative and **does not** crop or rotate the source image.
+## Canonical ROI Export
+1. The GUI exports the ROI after rotation, producing a canonical crop (PNG) and a `shape` JSON mask.
+2. The `shape` JSON is expressed in canonical ROI coordinates, i.e. the crop pixel space.
+3. The backend treats the image and `shape` as authoritative and does not crop or rotate the source image.
 
-This ensures heatmaps align with the GUI overlay when rendered back in the same canonical space.
+This keeps backend scores, heatmaps, and GUI overlays aligned in the same canonical space.
 
-## Shape JSON conventions
+## Shape JSON Conventions
 - Rectangle:
   ```json
   {"kind":"rect","x":0,"y":0,"w":W,"h":H}
@@ -30,29 +30,36 @@ This ensures heatmaps align with the GUI overlay when rendered back in the same 
   {"kind":"annulus","cx":CX,"cy":CY,"r":R,"r_inner":R_INNER}
   ```
 
-**Important:** the coordinates must match the crop size that was sent to `/infer`.
+The coordinates must match the crop size sent to `/infer`.
 
-## Master anchors and inspection alignment (batch)
-- Master 1/2 anchors are used to reposition inspection ROIs per batch image.
-- The GUI applies translation/rotation/scale based on the anchor vector and each ROI’s selected anchor (Master1/Master2/Mid).
+## Master Anchors and Inspection Alignment
+- Master 1/2 anchors are used to reposition inspection ROIs per image.
+- The GUI applies translation/rotation/scale based on the anchor vector and each ROI's selected anchor (Master1/Master2/Mid).
 - If anchors are missing or invalid, the GUI leaves ROIs at their saved positions.
+- Master pattern matching caches rotated/scaled template variants to reduce repeated template generation during batch runs.
 
-## Heatmap visualization (spec)
-> This section is a UI spec. If the current implementation deviates, treat it as TODO.
+## Inspection ROI Dataset Lock
+- Inspection ROI geometry can be edited before a dataset exists.
+- Once the backend/local dataset for an inspection ROI has samples, that inspection ROI is locked against edit, move, resize, shape change, delete/recreate, and canvas clear operations.
+- Additional OK/NG images can still be added to the existing dataset.
+- Master ROIs remain editable because they only drive alignment.
+- The warning shown to the operator is: `Inspection ROIs can't be modified once Dataset is created`.
 
-- Show **red** heatmap areas **only** when the final decision is **NG** and the heatmap is the NG cause.
-- If the final decision is **OK**, do **not** render a heatmap overlay.
-- Apply the same rule in **manual** and **batch** views.
+## Heatmap Visualization
+- Show red heatmap areas only when the final decision is NG and the heatmap is the NG cause.
+- If the final decision is OK, do not render a heatmap overlay.
+- Apply the same rule in manual and batch views.
+- Batch heatmaps are stored per ROI index, and the UI selection chooses which ROI heatmap is shown.
+- Heatmap scale/opacity controls are hidden until an image is loaded.
 
-## Batch known issue (ROI2)
-**Observed issue:** ROI2 heatmap may not appear after the first batch image.
-
-**Plan:**
+## Batch Heatmap Regression Checklist
+If a ROI heatmap is missing or assigned to the wrong ROI:
 1. Verify placement logs (`gui.log` / `gui_heatmap.log`).
-2. Ensure ROI2 placement does not reuse ROI1 geometry.
-3. Add a regression checklist once fixed.
+2. Confirm the ROI index stored by the batch result.
+3. Confirm the UI selected ROI index matches the displayed heatmap.
+4. Check for placement guard messages that could suppress overlay placement.
 
-## Related docs
-- `docs/FRONTEND.md` — UI controls and toggle behavior.
-- `docs/API_CONTRACTS.md` — backend `shape` schema and contracts.
-- `LOGGING.md` — log locations and fields.
+## Related Docs
+- `docs/FRONTEND.md` - UI controls and toggle behavior.
+- `docs/API_CONTRACTS.md` - backend `shape` schema and contracts.
+- `LOGGING.md` - log locations and fields.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,33 +2,37 @@
 
 This checklist is derived from current GUI and backend behavior. See `LOGGING.md` for log locations.
 
-## GUI-side issues
+## GUI-side Issues
 - **Backend offline:** verify `Backend.BaseUrl` (`config/appsettings.json`) and network connectivity. Check `gui.log` for `[backend]` and `[infer]` entries.
+- **Backend auto-start does not launch:** check `Backend.AutoStart`, `Backend.AutoStartMode`, `Backend.WslDistro`, `Backend.WslVenvPath` / `Backend.WslCondaEnvironment`, and `Backend.AutoStartWorkingDirectory`. Check `gui.log` for `[backend-autostart]`.
 - **Dataset preview empty:** ensure dataset samples exist in the backend (`/datasets/list`) and that the GUI cache under `%LOCALAPPDATA%\BrakeDiscInspector\cache\datasets\...` is writable.
 - **Cannot add a sample:** confirm a source image is loaded and the ROI is valid; see `gui.log` for `AddToDataset` messages.
-- **Heatmap missing:**
-  - If the result is **OK**, the spec requires *no overlay*.
-  - For NG results, check `gui_heatmap.log` for placement errors.
-- **ROI disabled unexpectedly:** check the **Enabled** checkbox in both the inspection panel and the dataset tab (they are bound to the same property).
+- **Cannot edit an inspection ROI:** if the message is `Inspection ROIs can't be modified once Dataset is created`, the ROI already has dataset samples. Add more images to the dataset or create a new ROI/model slot; master ROIs remain editable.
+- **Image thumbnails take time to appear:** the folder loader is building thumbnails. The canvas should show a loading message while the collection is prepared.
+- **Heatmap missing:** if the result is OK, the spec requires no overlay. For NG results, check `gui_heatmap.log` for placement errors.
+- **ROI disabled unexpectedly:** check the **Enabled** checkbox in both the inspection panel and the dataset tab; they are bound to the same property.
+- **Camera source is disabled:** the `Source` browser is only active when the camera provider is `Folder`. `FlirBlackfly` and `Cognex` do not use that field until their vendor SDK/protocol integration is wired.
 
 ### Enabled vs fitted
-- **Enabled** is UI-only; it does **not** imply the backend has a fitted model.
-- Legacy `HasFitOk` fields in layout files are ignored and should be treated as **stale**.
+- **Enabled** is UI-only; it does not imply the backend has a fitted model.
+- Legacy `HasFitOk` fields in layout files are ignored and should be treated as stale.
 
-## Backend-side issues
-- **HTTP 400: "Memoria no encontrada"** — no fitted memory at the expected path. Run `/fit_ok` or verify `recipe_id` + `model_key`.
-- **HTTP 409: mm_per_px mismatch** — the recipe is locked to a different `mm_per_px`. Align GUI `mm_per_px` or delete recipe metadata to reset.
-- **Insufficient OK samples** — `BDI_MIN_OK_SAMPLES` not met for dataset-based training.
-- **Calibration missing** — `/infer` returns `threshold=null` if no calibration is stored.
+## Backend-side Issues
+- **HTTP 400: "Memoria no encontrada"** - no fitted memory at the expected path. Run `/fit_ok` or verify `recipe_id` + `model_key`.
+- **HTTP 409: mm_per_px mismatch** - the recipe is locked to a different `mm_per_px`. Align GUI `mm_per_px` or delete recipe metadata to reset.
+- **Insufficient OK samples** - `BDI_MIN_OK_SAMPLES` not met for dataset-based training.
+- **Calibration missing** - `/infer` returns `threshold=null` if no calibration is stored.
 
-## Batch issue: ROI2
-If ROI2 heatmaps are missing after the first batch image:
-1. Inspect `gui.log` / `gui_heatmap.log` for ROI2 placement messages.
-2. Confirm ROI2 is enabled.
-3. Check for guard messages indicating ROI2 geometry reuse.
+## Batch Heatmaps
+If a ROI heatmap is missing or appears on the wrong ROI:
+1. Inspect `gui.log` / `gui_heatmap.log` for placement messages.
+2. Confirm the ROI is enabled.
+3. Confirm the selected batch heatmap ROI index matches the result being inspected.
+4. Check for guard messages indicating placement suppression or stale canvas geometry.
 
-## Logs to inspect
+## Logs to Inspect
 1. `%LOCALAPPDATA%\BrakeDiscInspector\logs\gui.log`
 2. `%LOCALAPPDATA%\BrakeDiscInspector\logs\gui_heatmap.log`
 3. `%LOCALAPPDATA%\BrakeDiscInspector\logs\roi_analyze_master.log`
-4. Backend `backend_diagnostics.jsonl` (see `LOGGING.md`)
+4. `%LOCALAPPDATA%\BrakeDiscInspector\logs\gui_setup.log`
+5. Backend `backend_diagnostics.jsonl` (see `LOGGING.md`)

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/BackendPayloadBuilderTests.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Reflection;
 using System.Text.Json;
 using BrakeDiscInspector_GUI_ROI;
+using OpenCvSharp;
 using Xunit;
 
 namespace BrakeDiscInspector_GUI_ROI.Tests;
@@ -9,31 +8,36 @@ namespace BrakeDiscInspector_GUI_ROI.Tests;
 public class BackendPayloadBuilderTests
 {
     [Fact]
-    public void SerializeRoiToJson_EmitsCenterCoordinates()
+    public void TryPrepareCanonicalRoi_RectangleShapeUsesCanonicalCropDimensions()
     {
+        using var src = new Mat(new Size(220, 180), MatType.CV_8UC3, Scalar.Black);
         var roi = new RoiModel
         {
             Shape = RoiShape.Rectangle,
             Width = 48,
             Height = 32,
-            AngleDeg = 37.5
+            AngleDeg = 0
         };
         roi.Left = 120;
         roi.Top = 80;
 
-        string json = InvokeSerializeRoiToJson(roi);
+        Assert.True(BackendAPI.TryPrepareCanonicalRoi(src, roi, out var payload, out _));
+        Assert.NotNull(payload);
 
-        using var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(payload!.ShapeJson ?? "{}");
         var root = doc.RootElement;
 
-        Assert.Equal(roi.X, root.GetProperty("x").GetDouble());
-        Assert.Equal(roi.Y, root.GetProperty("y").GetDouble());
-        Assert.Equal(roi.AngleDeg, root.GetProperty("angle_deg").GetDouble());
+        Assert.Equal("rect", root.GetProperty("kind").GetString());
+        Assert.Equal(0, root.GetProperty("x").GetDouble());
+        Assert.Equal(0, root.GetProperty("y").GetDouble());
+        Assert.Equal(payload.Width, root.GetProperty("w").GetDouble());
+        Assert.Equal(payload.Height, root.GetProperty("h").GetDouble());
     }
 
     [Fact]
-    public void SerializeRoiToJson_AnnulusIncludesInnerRadius()
+    public void TryPrepareCanonicalRoi_AnnulusShapeIncludesInnerRadius()
     {
+        using var src = new Mat(new Size(260, 220), MatType.CV_8UC3, Scalar.Black);
         var roi = new RoiModel
         {
             Shape = RoiShape.Annulus,
@@ -41,21 +45,22 @@ public class BackendPayloadBuilderTests
             CY = 120,
             R = 48,
             RInner = 20,
-            AngleDeg = 15
+            AngleDeg = 0
         };
 
-        string json = InvokeSerializeRoiToJson(roi);
+        Assert.True(BackendAPI.TryPrepareCanonicalRoi(src, roi, out var payload, out _));
+        Assert.NotNull(payload);
 
-        using var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(payload!.ShapeJson ?? "{}");
         var root = doc.RootElement;
 
-        Assert.Equal("annulus", root.GetProperty("shape").GetString());
+        Assert.Equal("annulus", root.GetProperty("kind").GetString());
         Assert.Equal(roi.R, root.GetProperty("r").GetDouble());
-        Assert.Equal(roi.RInner, root.GetProperty("ri").GetDouble());
+        Assert.Equal(roi.RInner, root.GetProperty("r_inner").GetDouble());
     }
 
     [Fact]
-    public void TryGetSearchRect_UsesLeftTopForRectangle()
+    public void TryBuildRoiCropInfo_UsesLeftTopForRectangle()
     {
         var roi = new RoiModel
         {
@@ -66,30 +71,10 @@ public class BackendPayloadBuilderTests
         roi.Left = 50;
         roi.Top = 30;
 
-        object[] args = { roi, 0, 0, 0, 0 };
-        bool ok = (bool)TryGetSearchRectMethod().Invoke(null, args)!;
-
-        Assert.True(ok);
-        Assert.Equal((int)Math.Round(roi.Left), (int)args[1]);
-        Assert.Equal((int)Math.Round(roi.Top), (int)args[2]);
-        Assert.Equal((int)Math.Round(roi.Width), (int)args[3]);
-        Assert.Equal((int)Math.Round(roi.Height), (int)args[4]);
-    }
-
-    private static string InvokeSerializeRoiToJson(RoiModel roi)
-    {
-        return (string)SerializeRoiToJsonMethod().Invoke(null, new object[] { roi })!;
-    }
-
-    private static MethodInfo SerializeRoiToJsonMethod()
-    {
-        return typeof(MainWindow).GetMethod("SerializeRoiToJson", BindingFlags.NonPublic | BindingFlags.Static)
-               ?? throw new InvalidOperationException("SerializeRoiToJson not found");
-    }
-
-    private static MethodInfo TryGetSearchRectMethod()
-    {
-        return typeof(BackendAPI).GetMethod("TryGetSearchRect", BindingFlags.NonPublic | BindingFlags.Static)
-               ?? throw new InvalidOperationException("TryGetSearchRect not found");
+        Assert.True(RoiCropUtils.TryBuildRoiCropInfo(roi, out var info));
+        Assert.Equal(roi.Left, info.Left);
+        Assert.Equal(roi.Top, info.Top);
+        Assert.Equal(roi.Width, info.Width);
+        Assert.Equal(roi.Height, info.Height);
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/BrakeDiscInspector_GUI_ROI.Tests.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
   </ItemGroup>
 
   <ItemGroup>

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/LocalMatcherTests.cs
@@ -30,7 +30,7 @@ namespace BrakeDiscInspector_GUI_ROI.Tests
                 patternRoi,
                 searchRoi,
                 feature: "tm_rot",
-                thr: 0,
+                threshold: 0,
                 rotRange: 0,
                 scaleMin: 1.0,
                 scaleMax: 1.0);
@@ -78,7 +78,7 @@ namespace BrakeDiscInspector_GUI_ROI.Tests
                 patternRoi,
                 searchRoi,
                 feature: "tm_rot",
-                thr: 0,
+                threshold: 0,
                 rotRange: 0,
                 scaleMin: 1.0,
                 scaleMax: 1.0,
@@ -109,6 +109,47 @@ namespace BrakeDiscInspector_GUI_ROI.Tests
             Assert.True(result.AcceptedByThreshold);
             Assert.Equal(result.Score, (int)result.TemplateScore);
             Assert.True(result.BestCorr > 0);
+        }
+
+        [Fact]
+        public void MatchInSearchROIWithDetails_TmRot_CanReusePrebuiltTemplateVariants()
+        {
+            using var fullImage = new Mat(new Size(160, 160), MatType.CV_8UC3, Scalar.Black);
+            var patternRect = new Rect(65, 75, 34, 26);
+            Cv2.Rectangle(fullImage, patternRect, new Scalar(20, 180, 210), -1);
+            Cv2.Line(fullImage, new Point(patternRect.X, patternRect.Bottom - 1), new Point(patternRect.Right - 1, patternRect.Y), new Scalar(240, 30, 40), 2);
+
+            var pattern = new RoiModel
+            {
+                Shape = RoiShape.Rectangle,
+                X = patternRect.X + patternRect.Width / 2.0,
+                Y = patternRect.Y + patternRect.Height / 2.0,
+                Width = patternRect.Width,
+                Height = patternRect.Height
+            };
+            var search = new RoiModel { Shape = RoiShape.Rectangle, X = 80, Y = 80, Width = 100, Height = 100 };
+
+            using var patternView = new Mat(fullImage, patternRect);
+            using var patternOverride = patternView.Clone();
+            using var variants = LocalMatcher.BuildTemplateVariantSet(patternOverride, 4, 1.0, 1.0);
+
+            var result = LocalMatcher.MatchInSearchROIWithDetails(
+                fullImage,
+                pattern,
+                search,
+                "tm_rot",
+                40,
+                4,
+                1.0,
+                1.0,
+                patternOverride,
+                templateVariants: variants);
+
+            Assert.Equal(5, variants.Count);
+            Assert.Equal("tm_rot", result.ModeUsed);
+            Assert.True(result.AcceptedByThreshold);
+            Assert.InRange(result.Center!.Value.X, pattern.X - 0.5, pattern.X + 0.5);
+            Assert.InRange(result.Center.Value.Y, pattern.Y - 0.5, pattern.Y + 0.5);
         }
 
         [Fact]

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiAdornerTests.cs
@@ -34,7 +34,7 @@ public class RoiAdornerTests
         Canvas.SetLeft(annulus, 0);
         Canvas.SetTop(annulus, 0);
 
-        var adorner = new RoiAdorner(annulus, (_, _) => { }, _ => { });
+        var adorner = new RoiAdorner(annulus, new RoiOverlay(), (_, _) => { }, _ => { });
 
         InvokeResizeByCorner(adorner, 20.0, -20.0, "NE");
 
@@ -73,7 +73,7 @@ public class RoiAdornerTests
         Canvas.SetLeft(circle, 0);
         Canvas.SetTop(circle, 0);
 
-        var adorner = new RoiAdorner(circle, (_, _) => { }, _ => { });
+        var adorner = new RoiAdorner(circle, new RoiOverlay(), (_, _) => { }, _ => { });
 
         InvokeResizeByCorner(adorner, 30.0, -10.0, "NE");
 

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiCropUtilsTests.cs
@@ -77,7 +77,7 @@ public class RoiCropUtilsTests
         using var _ = crop;
 
         var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
-        using var rotation = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
+        using var rotation = Cv2.GetRotationMatrix2D(pivot, angleDeg, 1.0);
 
         static Point2f Apply(Mat matrix, Point2f p)
         {
@@ -119,7 +119,7 @@ public class RoiCropUtilsTests
     private static Mat BuildExpectedCrop(Mat source, RoiCropInfo info, double angleDeg, Rect expectedRect)
     {
         var pivot = new Point2f((float)info.PivotX, (float)info.PivotY);
-        using var rotation = Cv2.GetRotationMatrix2D(pivot, -angleDeg, 1.0);
+        using var rotation = Cv2.GetRotationMatrix2D(pivot, angleDeg, 1.0);
         var border = source.Channels() == 4 ? new Scalar(0, 0, 0, 0) : Scalar.All(0);
         using var rotated = new Mat();
         Cv2.WarpAffine(source, rotated, rotation, source.Size(), InterpolationFlags.Linear, BorderTypes.Constant, border);

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiPlacementEngineTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/RoiPlacementEngineTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BrakeDiscInspector_GUI_ROI;
+using BrakeDiscInspector_GUI_ROI.Models;
 using BrakeDiscInspector_GUI_ROI.Workflow;
 using Xunit;
 

--- a/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/App.xaml.cs
@@ -18,9 +18,13 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             ResetLogsOnStartup();
             var guiSettings = GuiSetupSettingsService.LoadOrDefault();
+            var themePreference = string.IsNullOrWhiteSpace(guiSettings.Theme)
+                ? Settings.Default.ThemePreference
+                : guiSettings.Theme;
+            guiSettings.Theme = themePreference;
             CurrentGuiSetup = guiSettings;
-            GuiSetupSettingsService.Apply(guiSettings);
-            ApplyThemePreference(guiSettings.Theme);
+            ApplyThemePreference(themePreference);
+            GuiSetupSettingsService.ApplyThemeBrushes(themePreference);
             GuiSetupSettingsService.Apply(CurrentGuiSetup);
             base.OnStartup(e);
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
@@ -11,10 +11,21 @@ namespace BrakeDiscInspector_GUI_ROI
         public DatasetConfig Dataset { get; set; } = new();
         public AnalyzeConfig Analyze { get; set; } = new();
         public UiConfig UI { get; set; } = new();
+        public CommsConfig Comms { get; set; } = new();
 
         public sealed class BackendConfig
         {
             public string BaseUrl { get; set; } = "http://127.0.0.1:8000";
+            public bool AutoStart { get; set; }
+            public string AutoStartMode { get; set; } = "WslVenv";
+            public string WslDistro { get; set; } = "Ubuntu";
+            public string WslCondaEnvironment { get; set; } = "BrakeDisc";
+            public string WslVenvPath { get; set; } = "/home/millylinux/venv";
+            public string AutoStartWorkingDirectory { get; set; } = string.Empty;
+            public string AutoStartModelsDirectory { get; set; } = string.Empty;
+            public string AutoStartHost { get; set; } = "0.0.0.0";
+            public int AutoStartPort { get; set; } = 8000;
+            public int StartupTimeoutSeconds { get; set; } = 45;
         }
 
         public sealed class DatasetConfig
@@ -33,6 +44,34 @@ namespace BrakeDiscInspector_GUI_ROI
         public sealed class UiConfig
         {
             public double HeatmapOverlayOpacity { get; set; } = 0.6;
+        }
+
+        public sealed class CommsConfig
+        {
+            public bool Enabled { get; set; } = true;
+            public bool AutoConnectOnStartup { get; set; }
+            public bool AutoRunInspectionOnTrigger { get; set; }
+            public bool RequirePartPresent { get; set; } = true;
+            public PlcSettings Plc { get; set; } = new();
+            public CameraSettings Camera { get; set; } = new();
+        }
+
+        public sealed class PlcSettings
+        {
+            public string Mode { get; set; } = "Simulation";
+            public string IpAddress { get; set; } = "192.168.0.10";
+            public short Rack { get; set; } = 0;
+            public short Slot { get; set; } = 1;
+            public int DbNumber { get; set; } = 1;
+            public int PollIntervalMs { get; set; } = 100;
+        }
+
+        public sealed class CameraSettings
+        {
+            public string Provider { get; set; } = "Disabled";
+            public string Source { get; set; } = string.Empty;
+            public string OutputDirectory { get; set; } = string.Empty;
+            public int TimeoutMs { get; set; } = 5000;
         }
     }
 
@@ -84,6 +123,56 @@ namespace BrakeDiscInspector_GUI_ROI
                 target.Backend.BaseUrl = source.Backend.BaseUrl;
             }
 
+            if (source.Backend != null)
+            {
+                target.Backend.AutoStart = source.Backend.AutoStart;
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.AutoStartMode))
+                {
+                    target.Backend.AutoStartMode = source.Backend.AutoStartMode;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.WslDistro))
+                {
+                    target.Backend.WslDistro = source.Backend.WslDistro;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.WslCondaEnvironment))
+                {
+                    target.Backend.WslCondaEnvironment = source.Backend.WslCondaEnvironment;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.WslVenvPath))
+                {
+                    target.Backend.WslVenvPath = source.Backend.WslVenvPath;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.AutoStartWorkingDirectory))
+                {
+                    target.Backend.AutoStartWorkingDirectory = source.Backend.AutoStartWorkingDirectory;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.AutoStartModelsDirectory))
+                {
+                    target.Backend.AutoStartModelsDirectory = source.Backend.AutoStartModelsDirectory;
+                }
+
+                if (!string.IsNullOrWhiteSpace(source.Backend.AutoStartHost))
+                {
+                    target.Backend.AutoStartHost = source.Backend.AutoStartHost;
+                }
+
+                if (source.Backend.AutoStartPort > 0)
+                {
+                    target.Backend.AutoStartPort = source.Backend.AutoStartPort;
+                }
+
+                if (source.Backend.StartupTimeoutSeconds > 0)
+                {
+                    target.Backend.StartupTimeoutSeconds = source.Backend.StartupTimeoutSeconds;
+                }
+            }
+
             if (source.Dataset != null && !string.IsNullOrWhiteSpace(source.Dataset.Root))
             {
                 target.Dataset.Root = source.Dataset.Root;
@@ -113,17 +202,98 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 target.UI.HeatmapOverlayOpacity = Clamp01(source.UI.HeatmapOverlayOpacity);
             }
+
+            if (source.Comms != null)
+            {
+                target.Comms.Enabled = source.Comms.Enabled;
+                target.Comms.AutoConnectOnStartup = source.Comms.AutoConnectOnStartup;
+                target.Comms.AutoRunInspectionOnTrigger = source.Comms.AutoRunInspectionOnTrigger;
+                target.Comms.RequirePartPresent = source.Comms.RequirePartPresent;
+
+                if (source.Comms.Plc != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(source.Comms.Plc.Mode))
+                    {
+                        target.Comms.Plc.Mode = source.Comms.Plc.Mode;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(source.Comms.Plc.IpAddress))
+                    {
+                        target.Comms.Plc.IpAddress = source.Comms.Plc.IpAddress;
+                    }
+
+                    target.Comms.Plc.Rack = source.Comms.Plc.Rack;
+                    target.Comms.Plc.Slot = source.Comms.Plc.Slot;
+
+                    if (source.Comms.Plc.DbNumber > 0)
+                    {
+                        target.Comms.Plc.DbNumber = source.Comms.Plc.DbNumber;
+                    }
+
+                    if (source.Comms.Plc.PollIntervalMs > 0)
+                    {
+                        target.Comms.Plc.PollIntervalMs = source.Comms.Plc.PollIntervalMs;
+                    }
+                }
+
+                if (source.Comms.Camera != null)
+                {
+                    if (!string.IsNullOrWhiteSpace(source.Comms.Camera.Provider))
+                    {
+                        target.Comms.Camera.Provider = source.Comms.Camera.Provider;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(source.Comms.Camera.Source))
+                    {
+                        target.Comms.Camera.Source = source.Comms.Camera.Source;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(source.Comms.Camera.OutputDirectory))
+                    {
+                        target.Comms.Camera.OutputDirectory = source.Comms.Camera.OutputDirectory;
+                    }
+
+                    if (source.Comms.Camera.TimeoutMs > 0)
+                    {
+                        target.Comms.Camera.TimeoutMs = source.Comms.Camera.TimeoutMs;
+                    }
+                }
+            }
         }
 
         private static void ApplyEnvironmentOverrides(AppConfig config)
         {
             OverrideString("BDI_BACKEND_BASEURL", value => config.Backend.BaseUrl = value);
+            OverrideBool("BDI_BACKEND_AUTOSTART", value => config.Backend.AutoStart = value);
+            OverrideString("BDI_BACKEND_AUTOSTART_MODE", value => config.Backend.AutoStartMode = value);
+            OverrideString("BDI_BACKEND_WSL_DISTRO", value => config.Backend.WslDistro = value);
+            OverrideString("BDI_BACKEND_WSL_ENV", value => config.Backend.WslCondaEnvironment = value);
+            OverrideString("BDI_BACKEND_WSL_VENV", value => config.Backend.WslVenvPath = value);
+            OverrideString("BDI_BACKEND_WORKDIR", value => config.Backend.AutoStartWorkingDirectory = value);
+            OverrideString("BDI_BACKEND_MODELS_DIR", value => config.Backend.AutoStartModelsDirectory = value);
+            OverrideString("BDI_BACKEND_HOST", value => config.Backend.AutoStartHost = value);
+            OverrideInt("BDI_BACKEND_PORT", value => config.Backend.AutoStartPort = value);
+            OverrideInt("BDI_BACKEND_STARTUP_TIMEOUT_SECONDS", value => config.Backend.StartupTimeoutSeconds = value);
             OverrideString("BDI_DATASET_ROOT", value => config.Dataset.Root = value);
             OverrideDouble("BDI_ANALYZE_POS_TOL_PX", value => config.Analyze.PosTolPx = value);
             OverrideDouble("BDI_ANALYZE_ANG_TOL_DEG", value => config.Analyze.AngTolDeg = value);
             OverrideBool("BDI_SCALELOCK_DEFAULT", value => config.Analyze.ScaleLockDefault = value);
             OverrideInt("BDI_ANCHOR_SCORE_MIN", value => config.Analyze.AnchorScoreMin = value);
             OverrideDouble("BDI_HEATMAP_OPACITY", value => config.UI.HeatmapOverlayOpacity = Clamp01(value));
+            OverrideBool("BDI_COMMS_ENABLED", value => config.Comms.Enabled = value);
+            OverrideBool("BDI_COMMS_AUTOCONNECT", value => config.Comms.AutoConnectOnStartup = value);
+            OverrideBool("BDI_COMMS_AUTO_INSPECT", value => config.Comms.AutoRunInspectionOnTrigger = value);
+            OverrideBool("BDI_COMMS_REQUIRE_PART_PRESENT", value => config.Comms.RequirePartPresent = value);
+            OverrideString("BDI_PLC_MODE", value => config.Comms.Plc.Mode = value);
+            OverrideString("BDI_PLC_IP", value => config.Comms.Plc.IpAddress = value);
+            OverrideInt("BDI_PLC_RACK", value => config.Comms.Plc.Rack = (short)value);
+            OverrideInt("BDI_PLC_SLOT", value => config.Comms.Plc.Slot = (short)value);
+            OverrideInt("BDI_PLC_DB", value => config.Comms.Plc.DbNumber = Math.Max(1, value));
+            OverrideInt("BDI_PLC_POLL_MS", value => config.Comms.Plc.PollIntervalMs = Math.Max(50, value));
+            OverrideString("BDI_CAMERA_PROVIDER", value => config.Comms.Camera.Provider = value);
+            OverrideString("BDI_CAMERA_SOURCE", value => config.Comms.Camera.Source = value);
+            OverrideString("BDI_CAMERA_OUTPUT_DIR", value => config.Comms.Camera.OutputDirectory = value);
+            OverrideInt("BDI_CAMERA_TIMEOUT_MS", value => config.Comms.Camera.TimeoutMs = Math.Max(1, value));
         }
 
         private static void OverrideString(string envVar, Action<string> assign)

--- a/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
+++ b/gui/BrakeDiscInspector_GUI_ROI/BrakeDiscInspector_GUI_ROI.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
         <PropertyGroup>
                 <OutputType>WinExe</OutputType>
                 <TargetFramework>net8.0-windows</TargetFramework>
                 <UseWPF>true</UseWPF>
                 <UseWindowsForms>true</UseWindowsForms>
                 <EnableWindowsTargeting>true</EnableWindowsTargeting>
+                <Nullable>annotations</Nullable>
 
                 <!-- Arquitectura fija x64 para que cargue los nativos -->
                 <PlatformTarget>x64</PlatformTarget>
@@ -51,5 +52,3 @@
         </ItemGroup>
 
 </Project>
-
-

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CameraClientFactory.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CameraClientFactory.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public static class CameraClientFactory
+    {
+        public static ICameraClient Create(CameraConfig config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            return config.Provider.Trim() switch
+            {
+                CameraProviders.Folder => new FolderCameraClient(config),
+                CameraProviders.FlirBlackfly => new UnavailableCameraClient(
+                    config,
+                    "FLIR Blackfly requires the FLIR Spinnaker SDK .NET assemblies to be installed and wired before this provider can acquire images."),
+                CameraProviders.Cognex => new UnavailableCameraClient(
+                    config,
+                    "Cognex requires the selected Cognex SDK/protocol adapter to be installed and wired before this provider can acquire images."),
+                _ => new UnavailableCameraClient(config, "Camera provider is disabled.")
+            };
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CameraDefinitions.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CameraDefinitions.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public sealed class CameraConfig
+    {
+        public CameraConfig(
+            string provider,
+            string source,
+            string outputDirectory,
+            int timeoutMs = 5000)
+        {
+            Provider = string.IsNullOrWhiteSpace(provider) ? CameraProviders.Disabled : provider.Trim();
+            Source = source?.Trim() ?? string.Empty;
+            OutputDirectory = outputDirectory?.Trim() ?? string.Empty;
+            TimeoutMs = timeoutMs > 0 ? timeoutMs : 5000;
+        }
+
+        public string Provider { get; }
+
+        public string Source { get; }
+
+        public string OutputDirectory { get; }
+
+        public int TimeoutMs { get; }
+    }
+
+    public sealed class CameraFrame
+    {
+        public CameraFrame(string filePath, DateTimeOffset acquiredAt, string provider)
+        {
+            FilePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            AcquiredAt = acquiredAt;
+            Provider = provider ?? string.Empty;
+        }
+
+        public string FilePath { get; }
+
+        public DateTimeOffset AcquiredAt { get; }
+
+        public string Provider { get; }
+    }
+
+    public static class CameraProviders
+    {
+        public const string Disabled = "Disabled";
+        public const string Folder = "Folder";
+        public const string FlirBlackfly = "FlirBlackfly";
+        public const string Cognex = "Cognex";
+
+        public static readonly string[] All =
+        {
+            Disabled,
+            Folder,
+            FlirBlackfly,
+            Cognex
+        };
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BrakeDiscInspector_GUI_ROI.Util;
 using BrakeDiscInspector_GUI_ROI.Workflow;
+using Forms = System.Windows.Forms;
 
 namespace BrakeDiscInspector_GUI_ROI.Comms
 {
@@ -54,15 +55,45 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
     public sealed class CommsViewModel : INotifyPropertyChanged, IDisposable
     {
-        private readonly Func<PlcConfig, IPlcClient> _clientFactory;
+        private readonly Func<PlcConfig, string, IPlcClient> _clientFactory;
+        private readonly Func<CameraConfig, ICameraClient> _cameraFactory;
+        private readonly Func<string, CancellationToken, Task<bool?>>? _inspectImageAsync;
         private IPlcClient _client;
+        private ICameraClient _camera;
+        private string _clientMode;
         private readonly SynchronizationContext? _uiContext;
         private CancellationTokenSource? _pollingCts;
         private Task? _pollingTask;
+        private readonly int _pollIntervalMs;
+        private readonly bool _requirePartPresent;
+        private readonly object _cycleSync = new();
+        private readonly Dictionary<PlcSignalId, bool> _lastSignals = new();
+        private CancellationTokenSource? _cycleCts;
         private string _plcIpAddress;
+        private short _rack;
+        private short _slot;
+        private int _dbNumber;
+        private string _plcMode;
         private string _connectionStatus = "Disconnected";
+        private string _cameraProvider;
+        private string _cameraSource;
+        private string _cameraOutputDirectory;
+        private string _cameraStatus = "Camera disconnected";
+        private string _lastAcquiredImagePath = string.Empty;
+        private string _cycleStatus = "Idle";
+        private bool _autoRunInspection;
+        private bool _cycleInProgress;
 
-        public CommsViewModel(PlcConfig config, Func<PlcConfig, IPlcClient> clientFactory)
+        public CommsViewModel(
+            PlcConfig config,
+            string plcMode,
+            Func<PlcConfig, string, IPlcClient> clientFactory,
+            CameraConfig cameraConfig,
+            Func<CameraConfig, ICameraClient> cameraFactory,
+            Func<string, CancellationToken, Task<bool?>>? inspectImageAsync,
+            int pollIntervalMs,
+            bool requirePartPresent,
+            bool autoRunInspection)
         {
             if (config == null)
             {
@@ -70,11 +101,23 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
 
             _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
-            _client = _clientFactory(config);
+            _cameraFactory = cameraFactory ?? throw new ArgumentNullException(nameof(cameraFactory));
+            _inspectImageAsync = inspectImageAsync;
+            _clientMode = NormalizePlcMode(plcMode);
+            _client = _clientFactory(config, _clientMode);
+            _camera = _cameraFactory(cameraConfig ?? new CameraConfig(BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled, string.Empty, string.Empty));
             _uiContext = SynchronizationContext.Current;
+            _pollIntervalMs = Math.Max(50, pollIntervalMs);
+            _requirePartPresent = requirePartPresent;
             _plcIpAddress = config.IpAddress;
-            Rack = config.Rack;
-            Slot = config.Slot;
+            _rack = config.Rack;
+            _slot = config.Slot;
+            _dbNumber = config.DbNumber;
+            _plcMode = _clientMode;
+            _cameraProvider = cameraConfig?.Provider ?? BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled;
+            _cameraSource = cameraConfig?.Source ?? string.Empty;
+            _cameraOutputDirectory = cameraConfig?.OutputDirectory ?? string.Empty;
+            _autoRunInspection = autoRunInspection;
 
             Inputs = new ObservableCollection<PlcIoPointViewModel>();
             Outputs = new ObservableCollection<PlcIoPointViewModel>();
@@ -96,11 +139,33 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             DisconnectCommand = new AsyncCommand(_ => DisconnectAsync());
             ToggleOutputCommand = new AsyncCommand(param => ToggleOutputAsync(param));
             ToggleInputCommand = new AsyncCommand(param => ToggleInputAsync(param));
+            ConnectCameraCommand = new AsyncCommand(_ => ConnectCameraAsync());
+            DisconnectCameraCommand = new AsyncCommand(_ => DisconnectCameraAsync());
+            AcquireImageCommand = new AsyncCommand(_ => AcquireImageCycleAsync("manual"));
+            BrowseCameraSourceCommand = new AsyncCommand(_ => BrowseCameraSourceAsync(), _ => IsFolderCameraProvider);
         }
 
         public ObservableCollection<PlcIoPointViewModel> Inputs { get; }
 
         public ObservableCollection<PlcIoPointViewModel> Outputs { get; }
+
+        public IReadOnlyList<string> PlcModes { get; } = new[] { "Simulation", "S7" };
+
+        public IReadOnlyList<string> CameraProviders { get; } = BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.All;
+
+        public string PlcMode
+        {
+            get => _plcMode;
+            set
+            {
+                var normalized = NormalizePlcMode(value);
+                if (_plcMode != normalized)
+                {
+                    _plcMode = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public string PlcIpAddress
         {
@@ -115,9 +180,45 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
         }
 
-        public short Rack { get; }
+        public short Rack
+        {
+            get => _rack;
+            set
+            {
+                if (_rack != value)
+                {
+                    _rack = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
-        public short Slot { get; }
+        public short Slot
+        {
+            get => _slot;
+            set
+            {
+                if (_slot != value)
+                {
+                    _slot = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int DbNumber
+        {
+            get => _dbNumber;
+            set
+            {
+                var normalized = Math.Max(1, value);
+                if (_dbNumber != normalized)
+                {
+                    _dbNumber = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         public string ConnectionStatus
         {
@@ -132,6 +233,110 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
         }
 
+        public string CameraProvider
+        {
+            get => _cameraProvider;
+            set
+            {
+                var normalized = string.IsNullOrWhiteSpace(value) ? BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled : value.Trim();
+                if (_cameraProvider != normalized)
+                {
+                    _cameraProvider = normalized;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(IsFolderCameraProvider));
+                    OnPropertyChanged(nameof(CameraSourceDisplay));
+                    BrowseCameraSourceCommand?.RaiseCanExecuteChanged();
+                }
+            }
+        }
+
+        public bool IsFolderCameraProvider
+            => string.Equals(CameraProvider, BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Folder, StringComparison.OrdinalIgnoreCase);
+
+        public string CameraSource
+        {
+            get => _cameraSource;
+            set
+            {
+                if (_cameraSource != value)
+                {
+                    _cameraSource = value ?? string.Empty;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(CameraSourceDisplay));
+                }
+            }
+        }
+
+        public string CameraSourceDisplay
+            => IsFolderCameraProvider
+                ? (string.IsNullOrWhiteSpace(CameraSource) ? "No source folder selected" : CameraSource)
+                : "Source is only used by the Folder provider";
+
+        public string CameraOutputDirectory
+        {
+            get => _cameraOutputDirectory;
+            set
+            {
+                if (_cameraOutputDirectory != value)
+                {
+                    _cameraOutputDirectory = value ?? string.Empty;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool AutoRunInspection
+        {
+            get => _autoRunInspection;
+            set
+            {
+                if (_autoRunInspection != value)
+                {
+                    _autoRunInspection = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string CameraStatus
+        {
+            get => _cameraStatus;
+            private set
+            {
+                if (_cameraStatus != value)
+                {
+                    _cameraStatus = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string LastAcquiredImagePath
+        {
+            get => _lastAcquiredImagePath;
+            private set
+            {
+                if (_lastAcquiredImagePath != value)
+                {
+                    _lastAcquiredImagePath = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string CycleStatus
+        {
+            get => _cycleStatus;
+            private set
+            {
+                if (_cycleStatus != value)
+                {
+                    _cycleStatus = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public AsyncCommand ConnectCommand { get; }
 
         public AsyncCommand DisconnectCommand { get; }
@@ -139,6 +344,14 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         public AsyncCommand ToggleOutputCommand { get; }
 
         public AsyncCommand ToggleInputCommand { get; }
+
+        public AsyncCommand ConnectCameraCommand { get; }
+
+        public AsyncCommand DisconnectCameraCommand { get; }
+
+        public AsyncCommand AcquireImageCommand { get; }
+
+        public AsyncCommand BrowseCameraSourceCommand { get; }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -158,6 +371,12 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             {
                 await _client.ConnectAsync().ConfigureAwait(false);
                 ConnectionStatus = "Connected";
+                await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+                {
+                    [PlcSignalId.SystemReady] = true,
+                    [PlcSignalId.Busy] = false,
+                    [PlcSignalId.Error] = false
+                }).ConfigureAwait(false);
                 StartPolling();
             }
             catch (Exception ex)
@@ -173,6 +392,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
             try
             {
+                CancelCycle("disconnect");
                 await _client.DisconnectAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -218,7 +438,81 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             var vm = Inputs.FirstOrDefault(i => i.Id == signalId);
             if (vm != null)
             {
-                vm.IsOn = !vm.IsOn;
+                var newValue = !vm.IsOn;
+                vm.IsOn = newValue;
+                if (_client is ISimulatedPlcClient sim)
+                {
+                    return sim.SetInputAsync(signalId, newValue);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async Task ConnectCameraAsync()
+        {
+            EnsureCameraMatchesConfig();
+
+            if (_camera.IsConnected)
+            {
+                CameraStatus = "Camera connected";
+                return;
+            }
+
+            CameraStatus = "Camera connecting...";
+            try
+            {
+                await _camera.ConnectAsync().ConfigureAwait(false);
+                CameraStatus = "Camera connected";
+            }
+            catch (Exception ex)
+            {
+                CameraStatus = $"Camera disconnected: {ex.Message}";
+                GuiLog.Error("[camera] Connection failed", ex);
+            }
+        }
+
+        public async Task DisconnectCameraAsync()
+        {
+            try
+            {
+                await _camera.DisconnectAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                GuiLog.Error("[camera] Disconnect failed", ex);
+            }
+
+            CameraStatus = "Camera disconnected";
+        }
+
+        public async Task AcquireImageCycleAsync(string reason = "manual")
+        {
+            await RunInspectionCycleAsync(reason, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private Task BrowseCameraSourceAsync()
+        {
+            if (!IsFolderCameraProvider)
+            {
+                return Task.CompletedTask;
+            }
+
+            using var dialog = new Forms.FolderBrowserDialog
+            {
+                Description = "Select the folder used by the Folder camera provider.",
+                UseDescriptionForTitle = true,
+                ShowNewFolderButton = false
+            };
+
+            if (!string.IsNullOrWhiteSpace(CameraSource) && System.IO.Directory.Exists(CameraSource))
+            {
+                dialog.SelectedPath = CameraSource;
+            }
+
+            if (dialog.ShowDialog() == Forms.DialogResult.OK && !string.IsNullOrWhiteSpace(dialog.SelectedPath))
+            {
+                CameraSource = dialog.SelectedPath;
             }
 
             return Task.CompletedTask;
@@ -229,6 +523,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             var payload = new Dictionary<PlcSignalId, bool>
             {
                 [PlcSignalId.Busy] = true,
+                [PlcSignalId.Error] = false,
                 [PlcSignalId.ResultOk] = false,
                 [PlcSignalId.ResultNg] = false
             };
@@ -285,7 +580,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                     {
                         var values = await _client.ReadAsync(token).ConfigureAwait(false);
                         UpdateSignals(values);
-                        await Task.Delay(100, token).ConfigureAwait(false);
+                        await HandleInputTransitionsAsync(values, token).ConfigureAwait(false);
+                        await Task.Delay(_pollIntervalMs, token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -345,21 +641,203 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
         }
 
+        private async Task HandleInputTransitionsAsync(IDictionary<PlcSignalId, bool> values, CancellationToken ct)
+        {
+            var startNow = values.TryGetValue(PlcSignalId.StartInspection, out var start) && start;
+            var startWas = _lastSignals.TryGetValue(PlcSignalId.StartInspection, out var previousStart) && previousStart;
+            var stopNow = values.TryGetValue(PlcSignalId.StopInspection, out var stop) && stop;
+            var stopWas = _lastSignals.TryGetValue(PlcSignalId.StopInspection, out var previousStop) && previousStop;
+            var partPresent = values.TryGetValue(PlcSignalId.PartPresent, out var present) && present;
+            var resetError = values.TryGetValue(PlcSignalId.ResetError, out var reset) && reset;
+
+            foreach (var kvp in values)
+            {
+                _lastSignals[kvp.Key] = kvp.Value;
+            }
+
+            if (resetError)
+            {
+                await NotifyError(false).ConfigureAwait(false);
+            }
+
+            if (stopNow && !stopWas)
+            {
+                CancelCycle("plc-stop");
+            }
+
+            if (!startNow || startWas)
+            {
+                return;
+            }
+
+            if (_requirePartPresent && !partPresent)
+            {
+                CycleStatus = "Start ignored: part not present";
+                GuiLog.Warn("[plc] StartInspection ignored because PartPresent is false");
+                return;
+            }
+
+            StartCycleFromPolling("plc-start", ct);
+            await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        private void StartCycleFromPolling(string reason, CancellationToken pollingToken)
+        {
+            lock (_cycleSync)
+            {
+                if (_cycleInProgress)
+                {
+                    CycleStatus = "Cycle already running";
+                    GuiLog.Warn($"[comms] cycle ignored reason={reason}: already running");
+                    return;
+                }
+
+                _cycleCts?.Dispose();
+                _cycleCts = CancellationTokenSource.CreateLinkedTokenSource(pollingToken);
+                var cycleToken = _cycleCts.Token;
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await RunInspectionCycleAsync(reason, cycleToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        GuiLog.Error("[comms] background cycle failed", ex);
+                    }
+                }, CancellationToken.None);
+            }
+        }
+
+        private void CancelCycle(string reason)
+        {
+            try
+            {
+                _cycleCts?.Cancel();
+                CycleStatus = $"Cycle cancel requested ({reason})";
+            }
+            catch
+            {
+                // Ignore cancellation errors.
+            }
+        }
+
+        private async Task RunInspectionCycleAsync(string reason, CancellationToken ct)
+        {
+            lock (_cycleSync)
+            {
+                if (_cycleInProgress)
+                {
+                    CycleStatus = "Cycle already running";
+                    GuiLog.Warn($"[comms] cycle ignored reason={reason}: already running");
+                    return;
+                }
+
+                _cycleInProgress = true;
+            }
+
+            try
+            {
+                CycleStatus = $"Cycle starting ({reason})";
+                await NotifyInspectionStarted().ConfigureAwait(false);
+
+                if (!_camera.IsConnected)
+                {
+                    await ConnectCameraAsync().ConfigureAwait(false);
+                }
+
+                var frame = await _camera.AcquireAsync(ct).ConfigureAwait(false);
+                LastAcquiredImagePath = frame.FilePath;
+                CycleStatus = $"Image acquired: {System.IO.Path.GetFileName(frame.FilePath)}";
+
+                bool? ok = null;
+                if (AutoRunInspection && _inspectImageAsync != null)
+                {
+                    CycleStatus = "Inspection running";
+                    ok = await _inspectImageAsync(frame.FilePath, ct).ConfigureAwait(false);
+                }
+
+                if (ok.HasValue)
+                {
+                    await NotifyInspectionFinished(ok.Value).ConfigureAwait(false);
+                    CycleStatus = ok.Value ? "Cycle finished: OK" : "Cycle finished: NG";
+                }
+                else
+                {
+                    await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+                    {
+                        [PlcSignalId.Busy] = false
+                    }).ConfigureAwait(false);
+                    CycleStatus = AutoRunInspection ? "Cycle finished: result unknown" : "Image acquired";
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                CycleStatus = "Cycle cancelled";
+                await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+                {
+                    [PlcSignalId.Busy] = false
+                }).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                CycleStatus = $"Cycle error: {ex.Message}";
+                GuiLog.Error("[comms] Inspection cycle failed", ex);
+                await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+                {
+                    [PlcSignalId.Busy] = false,
+                    [PlcSignalId.Error] = true
+                }).ConfigureAwait(false);
+            }
+            finally
+            {
+                lock (_cycleSync)
+                {
+                    _cycleInProgress = false;
+                }
+            }
+        }
+
         private void EnsureClientMatchesConfig()
         {
-            var desired = new PlcConfig(PlcIpAddress, Rack, Slot);
+            var desiredMode = NormalizePlcMode(PlcMode);
+            var desired = new PlcConfig(PlcIpAddress, Rack, Slot, DbNumber);
 
             if (_client.Config.IpAddress == desired.IpAddress &&
                 _client.Config.Rack == desired.Rack &&
-                _client.Config.Slot == desired.Slot)
+                _client.Config.Slot == desired.Slot &&
+                _client.Config.DbNumber == desired.DbNumber &&
+                string.Equals(_clientMode, desiredMode, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
 
             StopPolling();
             _client.Dispose();
-            _client = _clientFactory(desired);
+            _clientMode = desiredMode;
+            _client = _clientFactory(desired, desiredMode);
+            _lastSignals.Clear();
         }
+
+        private void EnsureCameraMatchesConfig()
+        {
+            var desired = new CameraConfig(CameraProvider, CameraSource, CameraOutputDirectory);
+            if (string.Equals(_camera.Config.Provider, desired.Provider, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_camera.Config.Source, desired.Source, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(_camera.Config.OutputDirectory, desired.OutputDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _camera.Dispose();
+            _camera = _cameraFactory(desired);
+        }
+
+        private static string NormalizePlcMode(string? mode)
+            => string.Equals(mode, "S7", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(mode, "SiemensS7", StringComparison.OrdinalIgnoreCase)
+                    ? "S7"
+                    : "Simulation";
 
         private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
         {
@@ -369,8 +847,11 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         public void Dispose()
         {
             StopPolling();
+            CancelCycle("dispose");
             _pollingCts?.Dispose();
+            _cycleCts?.Dispose();
             _client.Dispose();
+            _camera.Dispose();
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/FolderCameraClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/FolderCameraClient.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BrakeDiscInspector_GUI_ROI.Util;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public sealed class FolderCameraClient : ICameraClient
+    {
+        private static readonly string[] ImageExtensions = { ".bmp", ".png", ".jpg", ".jpeg", ".tif", ".tiff" };
+        private readonly object _sync = new();
+        private string[] _files = Array.Empty<string>();
+        private int _nextIndex;
+        private bool _disposed;
+        private bool _isConnected;
+
+        public FolderCameraClient(CameraConfig config)
+        {
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public CameraConfig Config { get; }
+
+        public bool IsConnected
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return !_disposed && _isConnected;
+                }
+            }
+        }
+
+        public Task ConnectAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                ThrowIfDisposed();
+                if (string.IsNullOrWhiteSpace(Config.Source) || !Directory.Exists(Config.Source))
+                {
+                    throw new DirectoryNotFoundException($"Camera folder source not found: '{Config.Source}'");
+                }
+
+                _files = Directory.EnumerateFiles(Config.Source)
+                    .Where(path => ImageExtensions.Contains(Path.GetExtension(path), StringComparer.OrdinalIgnoreCase))
+                    .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                if (_files.Length == 0)
+                {
+                    throw new InvalidOperationException($"Camera folder source contains no images: '{Config.Source}'");
+                }
+
+                _nextIndex = 0;
+                _isConnected = true;
+            }
+
+            GuiLog.Info($"[camera-folder] Connected source='{Config.Source}' images={_files.Length}");
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            lock (_sync)
+            {
+                if (_disposed)
+                {
+                    return Task.CompletedTask;
+                }
+
+                _isConnected = false;
+            }
+
+            GuiLog.Info("[camera-folder] Disconnected");
+            return Task.CompletedTask;
+        }
+
+        public async Task<CameraFrame> AcquireAsync(CancellationToken ct = default)
+        {
+            string src;
+            lock (_sync)
+            {
+                EnsureConnected();
+                src = _files[_nextIndex];
+                _nextIndex = (_nextIndex + 1) % _files.Length;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            var acquiredAt = DateTimeOffset.Now;
+            var dst = ResolveOutputPath(src, acquiredAt);
+            Directory.CreateDirectory(Path.GetDirectoryName(dst)!);
+            await Task.Run(() => File.Copy(src, dst, overwrite: true), ct).ConfigureAwait(false);
+            GuiLog.Info($"[camera-folder] Acquired src='{src}' dst='{dst}'");
+            return new CameraFrame(dst, acquiredAt, CameraProviders.Folder);
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                _disposed = true;
+                _isConnected = false;
+                _files = Array.Empty<string>();
+            }
+        }
+
+        private string ResolveOutputPath(string sourcePath, DateTimeOffset acquiredAt)
+        {
+            var outputDirectory = Config.OutputDirectory;
+            if (string.IsNullOrWhiteSpace(outputDirectory))
+            {
+                outputDirectory = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "BrakeDiscInspector",
+                    "captures");
+            }
+
+            var extension = Path.GetExtension(sourcePath);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                extension = ".bmp";
+            }
+
+            var name = $"capture_{acquiredAt:yyyyMMdd_HHmmss_fff}{extension}";
+            return Path.Combine(outputDirectory, name);
+        }
+
+        private void EnsureConnected()
+        {
+            ThrowIfDisposed();
+            if (!_isConnected)
+            {
+                throw new InvalidOperationException("Camera folder provider is not connected");
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(FolderCameraClient));
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/ICameraClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/ICameraClient.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public interface ICameraClient : IDisposable
+    {
+        CameraConfig Config { get; }
+
+        bool IsConnected { get; }
+
+        Task ConnectAsync(CancellationToken ct = default);
+
+        Task DisconnectAsync();
+
+        Task<CameraFrame> AcquireAsync(CancellationToken ct = default);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/IPlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/IPlcClient.cs
@@ -7,11 +7,12 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 {
     public sealed class PlcConfig
     {
-        public PlcConfig(string ipAddress, short rack, short slot)
+        public PlcConfig(string ipAddress, short rack, short slot, int dbNumber = 1)
         {
             IpAddress = ipAddress;
             Rack = rack;
             Slot = slot;
+            DbNumber = dbNumber > 0 ? dbNumber : 1;
         }
 
         public string IpAddress { get; }
@@ -19,6 +20,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         public short Rack { get; }
 
         public short Slot { get; }
+
+        public int DbNumber { get; }
     }
 
     public interface IPlcClient : IDisposable

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/ISimulatedPlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/ISimulatedPlcClient.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public interface ISimulatedPlcClient
+    {
+        Task SetInputAsync(PlcSignalId signalId, bool value, CancellationToken ct = default);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/PlcDefinitions.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/PlcDefinitions.cs
@@ -45,7 +45,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
     public static class PlcSignals
     {
-        public const int DbNumber = 1;
+        public const int DefaultDbNumber = 1;
 
         public static readonly IReadOnlyList<PlcSignalDefinition> Definitions = new[]
         {

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
@@ -42,7 +42,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                     try
                     {
                         _plc.Open();
-                        GuiLog.Info($"[plc] Connected to {Config.IpAddress} rack={Config.Rack} slot={Config.Slot}");
+                        GuiLog.Info($"[plc] Connected to {Config.IpAddress} rack={Config.Rack} slot={Config.Slot} db={Config.DbNumber}");
                     }
                     catch (Exception ex)
                     {
@@ -87,7 +87,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 byte[] buffer;
                 lock (_sync)
                 {
-                    buffer = _plc.ReadBytes(DataType.DataBlock, PlcSignals.DbNumber, 0, 4) ?? Array.Empty<byte>();
+                    buffer = _plc.ReadBytes(DataType.DataBlock, Config.DbNumber, 0, 4) ?? Array.Empty<byte>();
                 }
 
                 var data = buffer.Length >= 4 ? buffer : buffer.Concat(new byte[4 - buffer.Length]).ToArray();
@@ -118,7 +118,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 byte[] buffer;
                 lock (_sync)
                 {
-                    buffer = _plc.ReadBytes(DataType.DataBlock, PlcSignals.DbNumber, 0, 4) ?? new byte[4];
+                    buffer = _plc.ReadBytes(DataType.DataBlock, Config.DbNumber, 0, 4) ?? new byte[4];
                 }
 
                 if (buffer.Length < 4)
@@ -139,7 +139,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
                 lock (_sync)
                 {
-                    _plc.WriteBytes(DataType.DataBlock, PlcSignals.DbNumber, 0, buffer);
+                    _plc.WriteBytes(DataType.DataBlock, Config.DbNumber, 0, buffer);
                 }
             }, ct);
         }

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/SimulatedPlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/SimulatedPlcClient.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BrakeDiscInspector_GUI_ROI.Util;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public sealed class SimulatedPlcClient : IPlcClient, ISimulatedPlcClient
+    {
+        private readonly object _sync = new();
+        private readonly Dictionary<PlcSignalId, bool> _signals = new();
+        private bool _disposed;
+        private bool _isConnected;
+
+        public SimulatedPlcClient(PlcConfig config)
+        {
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            foreach (var definition in PlcSignals.Definitions)
+            {
+                _signals[definition.Id] = false;
+            }
+        }
+
+        public PlcConfig Config { get; }
+
+        public bool IsConnected
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return !_disposed && _isConnected;
+                }
+            }
+        }
+
+        public IReadOnlyList<PlcSignalDefinition> SignalDefinitions => PlcSignals.Definitions;
+
+        public Task ConnectAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                ThrowIfDisposed();
+                _isConnected = true;
+                _signals[PlcSignalId.SystemReady] = true;
+            }
+
+            GuiLog.Info($"[plc-sim] Connected db={Config.DbNumber}");
+            return Task.CompletedTask;
+        }
+
+        public Task DisconnectAsync()
+        {
+            lock (_sync)
+            {
+                if (_disposed)
+                {
+                    return Task.CompletedTask;
+                }
+
+                _isConnected = false;
+            }
+
+            GuiLog.Info("[plc-sim] Disconnected");
+            return Task.CompletedTask;
+        }
+
+        public Task<IDictionary<PlcSignalId, bool>> ReadAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                EnsureConnected();
+                return Task.FromResult((IDictionary<PlcSignalId, bool>)_signals.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+            }
+        }
+
+        public Task WriteOutputsAsync(IDictionary<PlcSignalId, bool> outputs, CancellationToken ct = default)
+        {
+            if (outputs == null || outputs.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            ct.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                EnsureConnected();
+                foreach (var kvp in outputs)
+                {
+                    var definition = PlcSignals.Definitions.FirstOrDefault(d => d.Id == kvp.Key);
+                    if (definition?.Direction == PlcSignalDirection.Output)
+                    {
+                        _signals[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task SetInputAsync(PlcSignalId signalId, bool value, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                EnsureConnected();
+                var definition = PlcSignals.Definitions.FirstOrDefault(d => d.Id == signalId);
+                if (definition?.Direction == PlcSignalDirection.Input)
+                {
+                    _signals[signalId] = value;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                _disposed = true;
+                _isConnected = false;
+            }
+        }
+
+        private void EnsureConnected()
+        {
+            ThrowIfDisposed();
+            if (!_isConnected)
+            {
+                throw new InvalidOperationException("PLC simulator is not connected");
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SimulatedPlcClient));
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/UnavailableCameraClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/UnavailableCameraClient.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BrakeDiscInspector_GUI_ROI.Comms
+{
+    public sealed class UnavailableCameraClient : ICameraClient
+    {
+        private readonly string _reason;
+
+        public UnavailableCameraClient(CameraConfig config, string reason)
+        {
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            _reason = string.IsNullOrWhiteSpace(reason) ? "Camera provider is not configured." : reason;
+        }
+
+        public CameraConfig Config { get; }
+
+        public bool IsConnected => false;
+
+        public Task ConnectAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new NotSupportedException(_reason);
+        }
+
+        public Task DisconnectAsync()
+            => Task.CompletedTask;
+
+        public Task<CameraFrame> AcquireAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new NotSupportedException(_reason);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/LocalMatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using OpenCvSharp;
@@ -7,6 +8,73 @@ namespace BrakeDiscInspector_GUI_ROI
 {
     public static class LocalMatcher
     {
+        internal sealed class TemplateVariant : IDisposable
+        {
+            public TemplateVariant(Mat image, double scale, int angleDeg)
+            {
+                Image = image;
+                Scale = scale;
+                AngleDeg = angleDeg;
+            }
+
+            public Mat Image { get; }
+            public double Scale { get; }
+            public int AngleDeg { get; }
+
+            public void Dispose() => Image.Dispose();
+        }
+
+        public sealed class TemplateVariantSet : IDisposable
+        {
+            private readonly System.Collections.Generic.List<TemplateVariant> _variants = new();
+            private bool _disposed;
+
+            internal TemplateVariantSet(Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax)
+            {
+                PatternWidth = patternGray.Width;
+                PatternHeight = patternGray.Height;
+                PatternType = patternGray.Type();
+                RotRangeDeg = rotRangeDeg;
+                ScaleMin = Math.Min(scaleMin, scaleMax);
+                ScaleMax = Math.Max(scaleMin, scaleMax);
+            }
+
+            public int PatternWidth { get; }
+            public int PatternHeight { get; }
+            public MatType PatternType { get; }
+            public int RotRangeDeg { get; }
+            public double ScaleMin { get; }
+            public double ScaleMax { get; }
+            public int Count => _variants.Count;
+
+            internal IReadOnlyList<TemplateVariant> Variants => _variants;
+
+            internal void Add(Mat image, double scale, int angleDeg)
+                => _variants.Add(new TemplateVariant(image, scale, angleDeg));
+
+            public bool Matches(Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax)
+            {
+                if (_disposed || patternGray == null || patternGray.Empty()) return false;
+                return PatternWidth == patternGray.Width
+                       && PatternHeight == patternGray.Height
+                       && PatternType == patternGray.Type()
+                       && RotRangeDeg == rotRangeDeg
+                       && NearlyEqual(ScaleMin, Math.Min(scaleMin, scaleMax))
+                       && NearlyEqual(ScaleMax, Math.Max(scaleMin, scaleMax));
+            }
+
+            public void Dispose()
+            {
+                if (_disposed) return;
+                _disposed = true;
+                foreach (var variant in _variants)
+                {
+                    variant.Dispose();
+                }
+                _variants.Clear();
+            }
+        }
+
         public sealed class LocalMatchResult
         {
             public Point2d? Center { get; init; }
@@ -38,6 +106,40 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         private static void Log(Action<string>? log, string message) => log?.Invoke(message);
+
+        private static bool NearlyEqual(double a, double b) => Math.Abs(a - b) <= 1e-9;
+
+        private static IEnumerable<double> GenerateScales(double scaleMin, double scaleMax)
+        {
+            var minScale = Math.Min(scaleMin, scaleMax);
+            var maxScale = Math.Max(scaleMin, scaleMax);
+            const int steps = 5;
+            return Enumerable.Range(0, steps + 1)
+                             .Select(i => minScale + i * (maxScale - minScale) / Math.Max(steps, 1))
+                             .Distinct();
+        }
+
+        public static TemplateVariantSet BuildTemplateVariantSet(Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax)
+        {
+            if (patternGray == null) throw new ArgumentNullException(nameof(patternGray));
+
+            using var converted = patternGray.Channels() == 1 ? null : ToGray(patternGray);
+            var source = converted ?? patternGray;
+            var variants = new TemplateVariantSet(source, rotRangeDeg, scaleMin, scaleMax);
+
+            foreach (var scale in GenerateScales(scaleMin, scaleMax))
+            {
+                for (int angle = -rotRangeDeg; angle <= rotRangeDeg; angle += 2)
+                {
+                    Mat image = NearlyEqual(angle, 0) && NearlyEqual(scale, 1.0)
+                        ? source.Clone()
+                        : RotateAndScale(source, angle, scale);
+                    variants.Add(image, scale, angle);
+                }
+            }
+
+            return variants;
+        }
 
         private static Mat PackPoints(Point2f[] pts)
         {
@@ -84,7 +186,7 @@ namespace BrakeDiscInspector_GUI_ROI
         }
 
         private static (Point2d? center, int score, string? failure, double bestCorr, double secondBestCorr, double corrMargin, double bestScale, double bestAngleDeg, Point bestLoc, int candidatesEvaluated) MatchTemplateRot(
-            Mat imageGray, Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax, Action<string>? log, string roleTag)
+            Mat imageGray, Mat patternGray, int rotRangeDeg, double scaleMin, double scaleMax, Action<string>? log, string roleTag, TemplateVariantSet? templateVariants = null)
         {
             if (imageGray.Empty() || patternGray.Empty())
                 return (null, 0, "imgs vacías", 0, 0, 0, 1.0, 0.0, new Point(), 0);
@@ -96,38 +198,46 @@ namespace BrakeDiscInspector_GUI_ROI
             double bestScale = 1.0;
             var candidates = new System.Collections.Generic.List<(double corr, Point loc, double scale, double angle, int w, int h)>();
 
-            var minScale = Math.Min(scaleMin, scaleMax);
-            var maxScale = Math.Max(scaleMin, scaleMax);
-            int steps = 5;
-            var scales = Enumerable.Range(0, steps + 1)
-                                   .Select(i => minScale + i * (maxScale - minScale) / Math.Max(steps, 1))
-                                   .Distinct();
+            TemplateVariantSet? generatedVariants = null;
+            var activeVariants = templateVariants != null && templateVariants.Matches(patternGray, rotRangeDeg, scaleMin, scaleMax)
+                ? templateVariants
+                : null;
 
-            foreach (var scale in scales)
+            if (activeVariants == null)
             {
-                for (int angle = -rotRangeDeg; angle <= rotRangeDeg; angle += 2)
+                generatedVariants = BuildTemplateVariantSet(patternGray, rotRangeDeg, scaleMin, scaleMax);
+                activeVariants = generatedVariants;
+            }
+
+            try
+            {
+                foreach (var variant in activeVariants.Variants)
                 {
-                    using var rotated = RotateAndScale(patternGray, angle, scale);
+                    var rotated = variant.Image;
                     if (rotated.Width > imageGray.Width || rotated.Height > imageGray.Height)
                     {
-                        Log(log, $"[TM] skip: rotPat({rotated.Width}x{rotated.Height}) > img({imageGray.Width}x{imageGray.Height}) @ang={angle},scale={scale:F3}");
+                        Log(log, $"[TM] skip: rotPat({rotated.Width}x{rotated.Height}) > img({imageGray.Width}x{imageGray.Height}) @ang={variant.AngleDeg},scale={variant.Scale:F3}");
                         continue;
                     }
 
                     using var response = new Mat();
                     Cv2.MatchTemplate(imageGray, rotated, response, TemplateMatchModes.CCoeffNormed);
                     Cv2.MinMaxLoc(response, out _, out double maxVal, out _, out Point maxLoc);
-                    candidates.Add((maxVal, maxLoc, scale, angle, rotated.Width, rotated.Height));
+                    candidates.Add((maxVal, maxLoc, variant.Scale, variant.AngleDeg, rotated.Width, rotated.Height));
 
                     if (maxVal > best)
                     {
                         best = maxVal;
                         bestPoint = new Point2d(maxLoc.X + rotated.Width / 2.0, maxLoc.Y + rotated.Height / 2.0);
-                        bestAngle = angle;
-                        bestScale = scale;
+                        bestAngle = variant.AngleDeg;
+                        bestScale = variant.Scale;
                         bestLoc = maxLoc;
                     }
                 }
+            }
+            finally
+            {
+                generatedVariants?.Dispose();
             }
 
             string? failure = bestPoint == null ? "sin correlación" : $"maxCorr={Math.Max(best, 0):F4}";
@@ -304,9 +414,10 @@ namespace BrakeDiscInspector_GUI_ROI
             double scaleMax,
             Mat? patternOverride = null,
             Action<string>? log = null,
-            string role = "")
+            string role = "",
+            TemplateVariantSet? templateVariants = null)
         {
-            var detailed = MatchInSearchROIWithDetails(fullImageBgr, patternRoi, searchRoi, feature, threshold, rotRange, scaleMin, scaleMax, patternOverride, log, role);
+            var detailed = MatchInSearchROIWithDetails(fullImageBgr, patternRoi, searchRoi, feature, threshold, rotRange, scaleMin, scaleMax, patternOverride, log, role, templateVariants);
             return (detailed.Center, detailed.Score);
         }
 
@@ -321,7 +432,8 @@ namespace BrakeDiscInspector_GUI_ROI
             double scaleMax,
             Mat? patternOverride = null,
             Action<string>? log = null,
-            string role = "")
+            string role = "",
+            TemplateVariantSet? templateVariants = null)
         {
             if (fullImageBgr == null) throw new ArgumentNullException(nameof(fullImageBgr));
 
@@ -337,7 +449,8 @@ namespace BrakeDiscInspector_GUI_ROI
                 scaleMax,
                 patternOverride,
                 log,
-                role);
+                role,
+                templateVariants);
         }
 
         public static LocalMatchResult MatchInSearchROIWithDetailsGray(
@@ -351,7 +464,8 @@ namespace BrakeDiscInspector_GUI_ROI
             double scaleMax,
             Mat? patternOverride = null,
             Action<string>? log = null,
-            string role = "")
+            string role = "",
+            TemplateVariantSet? templateVariants = null)
         {
             if (fullImageGray == null) throw new ArgumentNullException(nameof(fullImageGray));
             if (searchRoi == null) throw new ArgumentNullException(nameof(searchRoi));
@@ -509,7 +623,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
                     if (mode == "tm_rot")
                     {
-                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
+                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag, templateVariants);
 
                         bool acceptedByThreshold = tm.center is not null && tm.score >= threshold;
                         Log(log, $"[PATTERN][TM] role={roleTag} requested=tm_rot used=tm_rot search={searchRect.Width}x{searchRect.Height} pattern={patternGray.Width}x{patternGray.Height} candidates={tm.candidatesEvaluated} best={tm.bestCorr:F4} second={tm.secondBestCorr:F4} margin={tm.corrMargin:F4} score={tm.score} threshold={threshold} angle={tm.bestAngleDeg:F3} scale={tm.bestScale:F3} center=({(tm.center?.X):F3},{(tm.center?.Y):F3}) acceptedByThreshold={acceptedByThreshold}");
@@ -534,7 +648,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     // 2) AUTO: fallback a TM si fallan features
                     if (mode == "auto" && (feat.center is null || feat.score < threshold))
                     {
-                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag);
+                        var tm = MatchTemplateRot(searchGray, patternGray, rotRange, scaleMin, scaleMax, log, roleTag, templateVariants);
                         bool tmAcceptedByThreshold = tm.center is not null && tm.score >= threshold;
                         Log(log, $"[PATTERN][AUTO] role={roleTag} requested=auto used=tm_fallback fallback=True causeFeat={feat.failure ?? "<none>"} featScore={feat.score} tmScore={tm.score} threshold={threshold} acceptedByThreshold={tmAcceptedByThreshold}");
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using BrakeDiscInspector_GUI_ROI.Comms;
 
@@ -12,15 +14,80 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             try
             {
-                var config = new PlcConfig("192.168.0.10", 0, 1);
-                _commsVm = new CommsViewModel(config, cfg => new S7PlcClient(cfg));
+                if (_appConfig.Comms?.Enabled == false)
+                {
+                    Util.GuiLog.Info("[comms] Disabled by configuration");
+                    return;
+                }
+
+                var plcSettings = _appConfig.Comms?.Plc ?? new AppConfig.PlcSettings();
+                var cameraSettings = _appConfig.Comms?.Camera ?? new AppConfig.CameraSettings();
+                var config = new PlcConfig(
+                    plcSettings.IpAddress,
+                    plcSettings.Rack,
+                    plcSettings.Slot,
+                    plcSettings.DbNumber);
+                var cameraConfig = new CameraConfig(
+                    cameraSettings.Provider,
+                    cameraSettings.Source,
+                    cameraSettings.OutputDirectory,
+                    cameraSettings.TimeoutMs);
+
+                _commsVm = new CommsViewModel(
+                    config,
+                    plcSettings.Mode,
+                    CreatePlcClient,
+                    cameraConfig,
+                    CameraClientFactory.Create,
+                    RunCommsInspectionAsync,
+                    plcSettings.PollIntervalMs,
+                    _appConfig.Comms?.RequirePartPresent ?? true,
+                    _appConfig.Comms?.AutoRunInspectionOnTrigger ?? false);
 
                 CommsRoot.DataContext = _commsVm;
+
+                if (_appConfig.Comms?.AutoConnectOnStartup == true)
+                {
+                    _ = _commsVm.ConnectAsync();
+                    _ = _commsVm.ConnectCameraAsync();
+                }
             }
             catch (Exception ex)
             {
-                Util.GuiLog.Error("[plc] InitComms failed", ex);
+                Util.GuiLog.Error("[comms] InitComms failed", ex);
             }
+        }
+
+        private static IPlcClient CreatePlcClient(PlcConfig config, string mode)
+        {
+            return string.Equals(mode, "S7", StringComparison.OrdinalIgnoreCase)
+                ? new S7PlcClient(config)
+                : new SimulatedPlcClient(config);
+        }
+
+        private async Task<bool?> RunCommsInspectionAsync(string imagePath, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(imagePath) || !System.IO.File.Exists(imagePath))
+            {
+                Util.GuiLog.Warn($"[comms] inspection skipped: image not found '{imagePath}'");
+                return null;
+            }
+
+            await Dispatcher.InvokeAsync(() => LoadImage(imagePath, runAutoAnalyze: false));
+            await Dispatcher.InvokeAsync(() => { }, System.Windows.Threading.DispatcherPriority.Render);
+
+            if (HasAllMastersAndInspectionsDefined())
+            {
+                await AnalyzeMastersAsync(showFailureDialog: false).ConfigureAwait(false);
+            }
+
+            var vm = ViewModel;
+            if (vm == null)
+            {
+                return null;
+            }
+
+            return await vm.EvaluateEnabledRoisForAutomationAsync(ct).ConfigureAwait(false);
         }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -26,9 +26,40 @@
         <conv:BatchCellStatusToBrushConverter x:Key="BatchCellStatusToBrush" />
         <conv:RoiPanelModeToVisibilityConverter x:Key="RoiPanelModeToVisibility" />
         <conv:NavKeyEqualsConverter x:Key="NavKeyEquals" />
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
         <SolidColorBrush x:Key="BrushAppBackground" Color="{DynamicResource {x:Static SystemColors.ControlColorKey}}" />
         <SolidColorBrush x:Key="LeftNavSelectedForeground"
                          Color="{DynamicResource {x:Static SystemColors.ControlLightColorKey}}" />
+
+        <ControlTemplate x:Key="HudVisibilityToggleTemplate" TargetType="{x:Type ToggleButton}">
+            <Grid Width="46" Height="24" SnapsToDevicePixels="True">
+                <Border x:Name="SwitchTrack"
+                        CornerRadius="12"
+                        Background="#80555555"/>
+                <Ellipse x:Name="SwitchKnob"
+                         Width="18"
+                         Height="18"
+                         Margin="3"
+                         Fill="White"
+                         Stroke="#33000000"
+                         StrokeThickness="1"
+                         HorizontalAlignment="Left"
+                         VerticalAlignment="Center"/>
+            </Grid>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter TargetName="SwitchTrack" Property="Background" Value="Black"/>
+                    <Setter TargetName="SwitchKnob" Property="HorizontalAlignment" Value="Right"/>
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="SwitchTrack" Property="Opacity" Value="0.82"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="SwitchTrack" Property="Opacity" Value="0.45"/>
+                    <Setter TargetName="SwitchKnob" Property="Opacity" Value="0.7"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
 
         <DropShadowEffect x:Key="LeftNavSelectedShadow"
                           ShadowDepth="0"
@@ -61,17 +92,49 @@
         </Style>
         <Style TargetType="TextBlock" BasedOn="{StaticResource LabelTextStyle}" />
 
+        <ControlTemplate x:Key="ThemedUiButtonTemplate" TargetType="{x:Type ui:Button}">
+            <Border x:Name="ButtonRoot"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="6"
+                    SnapsToDevicePixels="True">
+                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  RecognizesAccessKey="True"
+                                  TextElement.Foreground="{TemplateBinding Foreground}" />
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
+                    <Setter TargetName="ButtonRoot" Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.Accent}" />
+                    <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="ButtonRoot" Property="Opacity" Value="0.45" />
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
         <Style x:Key="AppButtonStyle" TargetType="{x:Type ui:Button}">
             <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ButtonText}" />
             <Setter Property="Padding" Value="10,6" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="12" ShadowDepth="0" Opacity="0.35"
@@ -90,12 +153,14 @@
             <Setter Property="Appearance" Value="Secondary" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ButtonText}" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
             <Setter Property="ToolTipService.ShowDuration" Value="30000" />
             <Setter Property="ContentTemplate">
                 <Setter.Value>
@@ -109,7 +174,7 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.35"
@@ -128,13 +193,16 @@
             <Setter Property="Appearance" Value="Secondary" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="Effect" Value="{x:Null}" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
             <Setter Property="ToolTipService.ShowDuration" Value="30000" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.35"
@@ -155,15 +223,18 @@
             <Setter Property="Height" Value="48" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="BorderBrush" Value="Transparent" />
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Background" Value="Transparent" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="TextElement.Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
             <Setter Property="Padding" Value="12,8" />
             <Setter Property="Margin" Value="0,0,0,8" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
                     <Setter Property="Effect" Value="{StaticResource LeftNavHoverShadow}" />
                 </Trigger>
 
@@ -185,12 +256,12 @@
         <Style x:Key="LayoutPanelButtonStyle"
                TargetType="{x:Type ui:Button}"
                BasedOn="{StaticResource AppButtonStyle}">
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="12"
@@ -206,12 +277,12 @@
         <Style x:Key="LayoutIconTextButtonStyle"
                TargetType="{x:Type ui:Button}"
                BasedOn="{StaticResource IconTextButtonStyle}">
-            <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Effect" Value="{x:Null}" />
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="{DynamicResource BrushAppBackground}" />
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
                     <Setter Property="Effect">
                         <Setter.Value>
                             <DropShadowEffect BlurRadius="12"
@@ -228,18 +299,81 @@
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ControlText}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CaretBrush" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="SelectionBrush" Value="{DynamicResource UI.Brush.Accent}" />
+            <Setter Property="SelectionOpacity" Value="0.35" />
+            <Setter Property="Padding" Value="4,2" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
         </Style>
         <Style TargetType="ComboBox">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ControlText}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="4,2" />
+            <Setter Property="TextElement.Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+        <Style TargetType="ComboBoxItem">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="Padding" Value="6,4" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+                </Trigger>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
         <Style TargetType="CheckBox">
             <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
             <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.CheckBox}" />
             <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        </Style>
+        <Style TargetType="ListBox">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        </Style>
+        <Style TargetType="ListBoxItem">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="Padding" Value="4,2" />
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+                </Trigger>
+                <Trigger Property="IsSelected" Value="True">
+                    <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+        <Style TargetType="DataGrid">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="GridLinesVisibility" Value="Horizontal" />
+            <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            <Setter Property="RowBackground" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="AlternatingRowBackground" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+        </Style>
+        <Style TargetType="DataGridCell">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        </Style>
+        <Style TargetType="DataGridColumnHeader">
+            <Setter Property="Background" Value="{DynamicResource UI.Brush.Surface}" />
+            <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
         </Style>
         <Style TargetType="{x:Type ui:ToggleSwitch}"
                BasedOn="{StaticResource {x:Type ui:ToggleSwitch}}">
@@ -555,112 +689,134 @@
                             <Grid Margin="0,0,0,8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Foreground" VerticalAlignment="Center"/>
-                                <TextBox x:Name="ForegroundColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.Foreground"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.Foreground}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="ForegroundColorBox" Grid.Column="1" Tag="UI.Brush.Foreground" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="ForegroundColorButton" Grid.Column="1" Tag="UI.Brush.Foreground" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.Foreground}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=ForegroundColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                             <Grid Margin="0,0,0,8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Accent" VerticalAlignment="Center"/>
-                                <TextBox x:Name="AccentColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.Accent"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.Accent}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="AccentColorBox" Grid.Column="1" Tag="UI.Brush.Accent" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="AccentColorButton" Grid.Column="1" Tag="UI.Brush.Accent" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.Accent}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=AccentColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                             <Grid Margin="0,0,0,8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Button Background" VerticalAlignment="Center"/>
-                                <TextBox x:Name="ButtonBackgroundColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.ButtonBackground"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.ButtonBackground}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="ButtonBackgroundColorBox" Grid.Column="1" Tag="UI.Brush.ButtonBackground" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="ButtonBackgroundColorButton" Grid.Column="1" Tag="UI.Brush.ButtonBackground" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.ButtonBackground}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=ButtonBackgroundColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                             <Grid Margin="0,0,0,8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Hover Background" VerticalAlignment="Center"/>
-                                <TextBox x:Name="ButtonHoverBackgroundColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.ButtonBackgroundHover"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.ButtonBackgroundHover}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="ButtonHoverBackgroundColorBox" Grid.Column="1" Tag="UI.Brush.ButtonBackgroundHover" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="ButtonHoverBackgroundColorButton" Grid.Column="1" Tag="UI.Brush.ButtonBackgroundHover" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.ButtonBackgroundHover}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=ButtonHoverBackgroundColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                             <Grid Margin="0,0,0,8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Button Foreground" VerticalAlignment="Center"/>
-                                <TextBox x:Name="ButtonForegroundColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.ButtonForeground"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.ButtonForeground}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="ButtonForegroundColorBox" Grid.Column="1" Tag="UI.Brush.ButtonForeground" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="ButtonForegroundColorButton" Grid.Column="1" Tag="UI.Brush.ButtonForeground" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.ButtonForeground}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=ButtonForegroundColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="180"/>
-                                    <ColumnDefinition Width="140"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="220"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Text="Group Header Foreground" VerticalAlignment="Center"/>
-                                <TextBox x:Name="GroupHeaderForegroundColorBox"
-                                         Grid.Column="1"
-                                         Tag="UI.Brush.GroupHeaderForeground"
-                                         LostFocus="ColorTextBox_LostFocus"/>
-                                <Rectangle Grid.Column="2"
-                                           Width="24"
-                                           Height="24"
-                                           Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-                                           Fill="{DynamicResource UI.Brush.GroupHeaderForeground}"
-                                           Margin="8,0,0,0"/>
+                                <TextBox x:Name="GroupHeaderForegroundColorBox" Grid.Column="1" Tag="UI.Brush.GroupHeaderForeground" Visibility="Collapsed" LostFocus="ColorTextBox_LostFocus"/>
+                                <ui:Button x:Name="GroupHeaderForegroundColorButton" Grid.Column="1" Tag="UI.Brush.GroupHeaderForeground" Click="ColorPickerButton_Click" HorizontalContentAlignment="Stretch" Padding="6,4">
+                                    <DockPanel LastChildFill="True">
+                                        <Rectangle DockPanel.Dock="Left" Width="24" Height="24" Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" Fill="{DynamicResource UI.Brush.GroupHeaderForeground}" Margin="0,0,8,0"/>
+                                        <TextBlock Text="{Binding Text, ElementName=GroupHeaderForegroundColorBox}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                    </DockPanel>
+                                </ui:Button>
                             </Grid>
                         </StackPanel>
+
+                        <Popup x:Name="GuiColorPalettePopup"
+                               Placement="Bottom"
+                               StaysOpen="False"
+                               AllowsTransparency="True">
+                            <Border Background="{DynamicResource UI.Brush.Surface}"
+                                    BorderBrush="{DynamicResource UI.Brush.ControlBorder}"
+                                    BorderThickness="1"
+                                    CornerRadius="6"
+                                    Padding="8">
+                                <UniformGrid Columns="8" Rows="4">
+                                    <Button Tag="#FF000000" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF000000"/></Button>
+                                    <Button Tag="#FF404040" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF404040"/></Button>
+                                    <Button Tag="#FF808080" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF808080"/></Button>
+                                    <Button Tag="#FFFFFFFF" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFFFFFF"/></Button>
+                                    <Button Tag="#FFE81123" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFE81123"/></Button>
+                                    <Button Tag="#FFFF8C00" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFF8C00"/></Button>
+                                    <Button Tag="#FFFFD700" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFFD700"/></Button>
+                                    <Button Tag="#FF107C10" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF107C10"/></Button>
+                                    <Button Tag="#FF00CC6A" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF00CC6A"/></Button>
+                                    <Button Tag="#FF00B7C3" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF00B7C3"/></Button>
+                                    <Button Tag="#FF0078D4" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF0078D4"/></Button>
+                                    <Button Tag="#FF5C2D91" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF5C2D91"/></Button>
+                                    <Button Tag="#FFC239B3" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFC239B3"/></Button>
+                                    <Button Tag="#FFFF7EB9" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFF7EB9"/></Button>
+                                    <Button Tag="#FF8E562E" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF8E562E"/></Button>
+                                    <Button Tag="#FF69797E" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF69797E"/></Button>
+                                    <Button Tag="#FFF3F4F6" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFF3F4F6"/></Button>
+                                    <Button Tag="#FFE5E7EB" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFE5E7EB"/></Button>
+                                    <Button Tag="#FFB8C0CC" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFB8C0CC"/></Button>
+                                    <Button Tag="#FF111827" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF111827"/></Button>
+                                    <Button Tag="#FF1F2937" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF1F2937"/></Button>
+                                    <Button Tag="#FF374151" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF374151"/></Button>
+                                    <Button Tag="#FFDDEAFB" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFDDEAFB"/></Button>
+                                    <Button Tag="#FFFFF4CE" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFFF4CE"/></Button>
+                                    <Button Tag="#FFE8F5E9" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFE8F5E9"/></Button>
+                                    <Button Tag="#FFFFE5E5" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFFE5E5"/></Button>
+                                    <Button Tag="#FFF7E8FF" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFF7E8FF"/></Button>
+                                    <Button Tag="#FFE0F2FE" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFE0F2FE"/></Button>
+                                    <Button Tag="#FF1A1A1A" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF1A1A1A"/></Button>
+                                    <Button Tag="#FF2C2C2C" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF2C2C2C"/></Button>
+                                    <Button Tag="#FF3A3A3A" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FF3A3A3A"/></Button>
+                                    <Button Tag="#FFFAFAFA" Click="GuiColorPalette_Click" Margin="2" Padding="0"><Rectangle Width="24" Height="24" Fill="#FFFAFAFA"/></Button>
+                                </UniformGrid>
+                            </Border>
+                        </Popup>
 
                         <TextBlock Text="Diagnostics" Style="{StaticResource HeaderTextStyle}" Margin="0,0,0,6"/>
                         <StackPanel Margin="0,0,0,16">
@@ -709,13 +865,6 @@
                 </ScrollViewer.Resources>
                 <StackPanel Margin="8" Orientation="Vertical">
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                        <ui:Button x:Name="BtnLoadImage"
-                                   Style="{StaticResource LayoutIconTextButtonStyle}"
-                                   MinWidth="140"
-                                   ToolTip="{DynamicResource LoadPictureTooltip}"
-                                   Tag="{x:Static ui:SymbolRegular.Image24}"
-                                   Content="{DynamicResource LoadImage}"
-                                   Click="BtnLoadImage_Click" />
                         <ui:Button x:Name="BtnLoadLayout"
                                    Style="{StaticResource LayoutIconTextButtonStyle}"
                                    MinWidth="140"
@@ -1776,18 +1925,27 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
 
-                    <StackPanel Orientation="Horizontal" Grid.Row="0" Margin="0,0,0,12">
-                        <TextBlock Text="PLC IP:" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                    <WrapPanel Grid.Row="0" Margin="0,0,0,12">
+                        <TextBlock Text="PLC:" VerticalAlignment="Center" Margin="0,0,4,0"/>
+                        <ComboBox Width="110"
+                                  ItemsSource="{Binding PlcModes}"
+                                  SelectedItem="{Binding PlcMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+
+                        <TextBlock Text="IP:" VerticalAlignment="Center" Margin="8,0,4,0"/>
                         <TextBox Width="130"
                                  Text="{Binding PlcIpAddress, UpdateSourceTrigger=PropertyChanged}"/>
 
                         <TextBlock Text="Rack:" VerticalAlignment="Center" Margin="8,0,4,0"/>
                         <TextBox Width="40"
-                                 Text="{Binding Rack}" IsReadOnly="True"/>
+                                 Text="{Binding Rack, UpdateSourceTrigger=PropertyChanged}"/>
 
                         <TextBlock Text="Slot:" VerticalAlignment="Center" Margin="8,0,4,0"/>
                         <TextBox Width="40"
-                                 Text="{Binding Slot}" IsReadOnly="True"/>
+                                 Text="{Binding Slot, UpdateSourceTrigger=PropertyChanged}"/>
+
+                        <TextBlock Text="DB:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                        <TextBox Width="44"
+                                 Text="{Binding DbNumber, UpdateSourceTrigger=PropertyChanged}"/>
 
                         <ui:Button Margin="12,0,0,0"
                                    Padding="10,3"
@@ -1810,10 +1968,11 @@
                         <TextBlock Margin="12,0,0,0"
                                    VerticalAlignment="Center"
                                    Text="{Binding ConnectionStatus}"/>
-                    </StackPanel>
+                    </WrapPanel>
 
                     <Grid Grid.Row="1">
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
@@ -1862,7 +2021,87 @@
                             </Grid>
                         </GroupBox>
 
-                        <GroupBox Header="Inputs" Grid.Row="1" Grid.Column="0" Margin="0,0,8,0">
+                        <GroupBox Header="Camera" Grid.Row="1" Grid.ColumnSpan="2" Margin="0,0,0,12">
+                            <Grid Margin="8">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Text="Provider" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <ComboBox Width="130"
+                                              ItemsSource="{Binding CameraProviders}"
+                                              SelectedItem="{Binding CameraProvider, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                    <CheckBox Content="Auto inspect"
+                                              Margin="12,0,0,0"
+                                              VerticalAlignment="Center"
+                                              IsChecked="{Binding AutoRunInspection, Mode=TwoWay}"/>
+                                </StackPanel>
+
+                                <TextBlock Grid.Row="1" Text="Source" VerticalAlignment="Center" Margin="0,8,8,0"/>
+                                <DockPanel Grid.Row="1" Grid.Column="1" Margin="0,8,0,0"
+                                           IsEnabled="{Binding IsFolderCameraProvider}">
+                                    <ui:Button DockPanel.Dock="Left"
+                                               Padding="10,3"
+                                               Command="{Binding BrowseCameraSourceCommand}">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.FolderOpen24}" Margin="0,0,8,0" FontSize="16"/>
+                                            <TextBlock Text="Browse" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </ui:Button>
+                                    <TextBlock Margin="10,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Text="{Binding CameraSourceDisplay}"
+                                               TextTrimming="CharacterEllipsis"
+                                               ToolTip="{Binding CameraSourceDisplay}"/>
+                                </DockPanel>
+
+                                <TextBlock Grid.Row="2" Text="Output" VerticalAlignment="Center" Margin="0,8,8,0"/>
+                                <TextBox Grid.Row="2" Grid.Column="1" Margin="0,8,0,0"
+                                         Text="{Binding CameraOutputDirectory, UpdateSourceTrigger=PropertyChanged}"/>
+
+                                <WrapPanel Grid.Row="3" Grid.ColumnSpan="2" Margin="0,8,0,0">
+                                    <ui:Button Padding="10,3"
+                                               Command="{Binding ConnectCameraCommand}">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugConnected24}" Margin="0,0,8,0" FontSize="16"/>
+                                            <TextBlock Text="Connect camera" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </ui:Button>
+                                    <ui:Button Margin="4,0,0,0"
+                                               Padding="10,3"
+                                               Command="{Binding DisconnectCameraCommand}">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.PlugDisconnected24}" Margin="0,0,8,0" FontSize="16"/>
+                                            <TextBlock Text="Disconnect" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </ui:Button>
+                                    <ui:Button Margin="4,0,0,0"
+                                               Padding="10,3"
+                                               Command="{Binding AcquireImageCommand}">
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Power24}" Margin="0,0,8,0" FontSize="16"/>
+                                            <TextBlock Text="Acquire" VerticalAlignment="Center"/>
+                                        </StackPanel>
+                                    </ui:Button>
+                                    <TextBlock Margin="12,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Text="{Binding CameraStatus}"/>
+                                    <TextBlock Margin="12,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Text="{Binding CycleStatus}"/>
+                                </WrapPanel>
+                            </Grid>
+                        </GroupBox>
+
+                        <GroupBox Header="Inputs" Grid.Row="2" Grid.Column="0" Margin="0,0,8,0">
                             <ItemsControl ItemsSource="{Binding Inputs}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
@@ -1888,7 +2127,7 @@
                             </ItemsControl>
                         </GroupBox>
 
-                        <GroupBox Header="Outputs" Grid.Row="1" Grid.Column="1">
+                        <GroupBox Header="Outputs" Grid.Row="2" Grid.Column="1">
                             <ItemsControl ItemsSource="{Binding Outputs}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
@@ -2065,12 +2304,59 @@
                         Background="Transparent"
                         IsHitTestVisible="True"
                        Panel.ZIndex="2"/>
-                            <local:RoiOverlay x:Name="RoiOverlay"
+                             <local:RoiOverlay x:Name="RoiOverlay"
+                                   Visibility="Collapsed"
+                                   IsHitTestVisible="False"
+                                   Panel.ZIndex="3"
+                                   HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Stretch"/>
+                            <Border BorderBrush="#FFFFD400"
+                                    BorderThickness="4"
+                                    Background="Transparent"
+                                    IsHitTestVisible="False"
+                                    Panel.ZIndex="360"
+                                    Visibility="{Binding IsRoiEditModeActive, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVisibility}}"/>
+                            <Border HorizontalAlignment="Left"
+                                    VerticalAlignment="Bottom"
+                                    Margin="18"
+                                    Padding="12,7"
+                                    Background="#D9FFD400"
+                                    CornerRadius="4"
+                                    IsHitTestVisible="False"
+                                    Panel.ZIndex="370"
+                                    Visibility="{Binding IsRoiEditModeActive, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock Text="Edit Mode"
+                                           Foreground="Black"
+                                           FontFamily="Segoe UI"
+                                           FontSize="18"
+                                           FontWeight="Black"/>
+                            </Border>
+                            <Grid x:Name="DiskStatusHUD"
+                                  HorizontalAlignment="Right"
+                                  VerticalAlignment="Top"
+                                  Margin="0,24,24,0"
+                                  Panel.ZIndex="950"
                                   Visibility="Collapsed"
-                                  IsHitTestVisible="False"
-                                  Panel.ZIndex="3"
-                                  HorizontalAlignment="Stretch"
-                                  VerticalAlignment="Stretch"/>
+                                  IsHitTestVisible="False">
+                                <Border x:Name="DiskStatusPanel"
+                                        Width="48"
+                                        Height="48"
+                                        Background="Transparent"
+                                        BorderBrush="Transparent"
+                                        BorderThickness="0"
+                                        CornerRadius="0"
+                                        Padding="0">
+                                    <TextBlock x:Name="DiskStatusText"
+                                               Text=""
+                                               FontFamily="Segoe UI"
+                                               FontWeight="Black"
+                                               FontSize="20"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               TextAlignment="Center"
+                                               Foreground="White"/>
+                                </Border>
+                            </Grid>
                         </Grid>
                     </Grid>
                 </AdornerDecorator>
@@ -2081,34 +2367,38 @@
                   HorizontalAlignment="Center"
                   VerticalAlignment="Top"
                   Margin="0,12,0,0"
-                  Padding="10,6"
+                  Padding="20,12"
                   Background="#F22C2C2C"
-                  CornerRadius="6"
+                  CornerRadius="8"
                   Visibility="Collapsed"
                   Panel.ZIndex="900"
                   IsHitTestVisible="False">
                     <TextBlock x:Name="SnackText"
                        Foreground="White"
-                       FontWeight="SemiBold"
-                       TextWrapping="Wrap"
-                       MaxWidth="520"/>
+                        FontWeight="SemiBold"
+                        FontSize="26"
+                        TextWrapping="Wrap"
+                        MaxWidth="900"/>
                 </Border>
 
-                <!-- ===== HUD: ROI list (top-left) ===== -->
+                <!-- ===== HUD: ROI list (top-right) ===== -->
                 <Grid x:Name="RoiHudOverlay"
                 Grid.Row="1"
                 VerticalAlignment="Top"
-                HorizontalAlignment="Left"
-                Margin="12,8,0,0"
+                HorizontalAlignment="Right"
+                Margin="0,36,96,0"
                 Panel.ZIndex="400"
                 IsHitTestVisible="True"
                 Visibility="Collapsed">
                     <Border x:Name="RoiHudPanel"
-                      Background="#CC1A1A1A"
-                      BorderBrush="#39FF14"
-                      BorderThickness="1.2"
+                      Background="#99FFFFFF"
+                      BorderBrush="#33000000"
+                      BorderThickness="1"
                       CornerRadius="8"
-                      Padding="10">
+                      Padding="12">
+                        <Border.LayoutTransform>
+                                            <ScaleTransform ScaleX="0.9375" ScaleY="0.9375"/>
+                        </Border.LayoutTransform>
                         <Border.Effect>
                             <DropShadowEffect Color="#AA000000"
                                     BlurRadius="8"
@@ -2135,84 +2425,185 @@
                                TextTrimming="CharacterEllipsis"/>
                 </Border>
 
-                <StackPanel Grid.Row="2"
-                            Orientation="Horizontal"
-                            HorizontalAlignment="Left"
-                            Margin="12,8,12,12">
-                    <ui:Button x:Name="BtnLoadImageUnderCanvas"
-                               Style="{StaticResource LayoutIconTextButtonStyle}"
-                               MinWidth="140"
-                               ToolTip="{DynamicResource LoadPictureTooltip}"
-                               Tag="{x:Static ui:SymbolRegular.Image24}"
-                               Content="{DynamicResource LoadImage}"
-                               Click="BtnLoadImage_Click" />
-                </StackPanel>
-            </Grid>
-            <Grid x:Name="DiskStatusHUD"
-              HorizontalAlignment="Right"
-              VerticalAlignment="Top"
-              Margin="12"
-              Panel.ZIndex="950"
-              Visibility="Collapsed"
-              IsHitTestVisible="False">
-                <Border x:Name="DiskStatusPanel"
-                  Width="48"
-                  Height="48"
-                  Background="Transparent"
-                  BorderBrush="Transparent"
-                  BorderThickness="0"
-                  CornerRadius="0"
-                  Padding="0">
-                    <TextBlock x:Name="DiskStatusText"
-                       Text=""
-                       FontFamily="Segoe UI"
-                       FontWeight="Black"
-                       FontSize="20"
-                       HorizontalAlignment="Center"
-                       VerticalAlignment="Center"
-                       TextAlignment="Center"
-                       Foreground="White"/>
-                </Border>
-            </Grid>
-            <!-- ===== HUD: bottom-right Heatmap controls ===== -->
-            <Grid x:Name="HudOverlay" Panel.ZIndex="1000" IsHitTestVisible="True">
-                <Border x:Name="HeatmapHUD"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Bottom"
-                  Margin="0,0,16,28"
-                  CornerRadius="8"
-                  Padding="10"
-                  IsHitTestVisible="True">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <TextBlock x:Name="HeatmapScaleLabel"
-                         Text="Heatmap Scale: 1.00"
-                         Foreground="{DynamicResource UI.Brush.ButtonForeground}"
-                         FontFamily="Segoe UI"
-                         FontWeight="SemiBold"
-                         Margin="0,0,8,0"/>
-                        <Slider x:Name="HeatmapScaleSlider"
-                      Width="160"
-                      Minimum="0.10"
-                      Maximum="2.00"
-                      Value="1.00"
-                      Margin="0,0,12,0"/>
-                        <TextBlock Text="Opacity"
-                         Foreground="{DynamicResource UI.Brush.ButtonForeground}"
-                         FontFamily="Segoe UI"
-                         FontWeight="SemiBold"
-                         Margin="0,0,8,0"/>
-                        <Slider x:Name="HeatmapOpacitySlider"
-                      Width="140"
-                      Minimum="0"
-                      Maximum="1"
-                      TickFrequency="0.05"
-                      IsSnapToTickEnabled="True"
-                      Value="{Binding HeatmapOverlayOpacity, ElementName=RootWindow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                    </StackPanel>
+                <!-- ===== HUD: bottom-right Heatmap controls ===== -->
+                <Grid x:Name="HudOverlay"
+                      Grid.Row="1"
+                      Panel.ZIndex="1000"
+                      IsHitTestVisible="True"
+                      Visibility="{Binding IsImageLoaded, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Converter={StaticResource BoolToVisibility}}">
+                    <Border x:Name="HeatmapHUD"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Margin="0,0,16,28"
+                            Background="#99FFFFFF"
+                            BorderBrush="#33000000"
+                            BorderThickness="1"
+                            CornerRadius="8"
+                            Padding="10"
+                            IsHitTestVisible="True">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <TextBlock x:Name="HeatmapScaleLabel"
+                                       Text="Heatmap Scale: 1.00"
+                                       Foreground="Black"
+                                       FontFamily="Segoe UI"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,8,0"/>
+                            <Slider x:Name="HeatmapScaleSlider"
+                                    Width="160"
+                                    Minimum="0.10"
+                                    Maximum="2.00"
+                                    Value="1.00"
+                                    Margin="0,0,12,0"/>
+                            <TextBlock Text="Opacity"
+                                       Foreground="Black"
+                                       FontFamily="Segoe UI"
+                                       FontWeight="SemiBold"
+                                       Margin="0,0,8,0"/>
+                            <Slider x:Name="HeatmapOpacitySlider"
+                                    Width="140"
+                                    Minimum="0"
+                                    Maximum="1"
+                                    TickFrequency="0.05"
+                                    IsSnapToTickEnabled="True"
+                                    Value="{Binding HeatmapOverlayOpacity, ElementName=RootWindow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+
+                <Border Grid.Row="2"
+                        Margin="0,8,0,0"
+                        Padding="8"
+                        MinHeight="150"
+                        Background="{DynamicResource UI.Brush.Surface}"
+                        BorderBrush="{DynamicResource UI.Brush.ControlBorder}"
+                        BorderThickness="1"
+                        CornerRadius="6">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ui:Button x:Name="BtnOpenImageFolder"
+                                   Grid.Row="0"
+                                   Grid.Column="0"
+                                   Style="{StaticResource LayoutIconTextButtonStyle}"
+                                   MinWidth="140"
+                                   ToolTip="{DynamicResource OpenImageFolderTooltip}"
+                                   Tag="{x:Static ui:SymbolRegular.FolderOpen24}"
+                                   Content="{DynamicResource OpenImageFolder}"
+                                   Click="BtnOpenImageFolder_Click"/>
+
+                        <TextBlock Grid.Row="0"
+                                   Grid.Column="1"
+                                   Margin="10,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Text="{Binding ThumbnailFolderDisplay, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip="{Binding ThumbnailFolderDisplay, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"/>
+
+                        <Grid Grid.Row="1" Grid.ColumnSpan="2" Margin="0,8,0,0">
+                            <ListBox x:Name="ThumbnailStripList"
+                                     Height="112"
+                                     ItemsSource="{Binding ImageThumbnails, RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                     SelectedItem="{Binding SelectedThumbnail, RelativeSource={RelativeSource AncestorType={x:Type Window}}, Mode=TwoWay}"
+                                     SelectionChanged="ThumbnailStrip_SelectionChanged"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                     ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                     Background="Transparent"
+                                     BorderThickness="0">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="{x:Type ListBoxItem}">
+                                        <Setter Property="Width" Value="104"/>
+                                        <Setter Property="Height" Value="84"/>
+                                        <Setter Property="Margin" Value="0,0,1,0"/>
+                                        <Setter Property="Padding" Value="2"/>
+                                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                                        <Setter Property="VerticalContentAlignment" Value="Stretch"/>
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid ToolTip="{Binding Path}">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="58"/>
+                                                <RowDefinition Height="Auto"/>
+                                            </Grid.RowDefinitions>
+                                            <Border Grid.Row="0"
+                                                    Background="{DynamicResource UI.Brush.ControlBackground}"
+                                                    BorderBrush="{DynamicResource UI.Brush.ControlBorder}"
+                                                    BorderThickness="1"
+                                                    CornerRadius="4">
+                                                <Image Source="{Binding Thumbnail}"
+                                                       Stretch="Uniform"
+                                                       SnapsToDevicePixels="True"/>
+                                            </Border>
+                                            <TextBlock Grid.Row="1"
+                                                       Margin="0,4,0,0"
+                                                       Text="{Binding FileName}"
+                                                       TextAlignment="Center"
+                                                       FontSize="11"
+                                                       TextTrimming="CharacterEllipsis"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+
+                            <TextBlock Text="{DynamicResource ImageFolderEmpty}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Opacity="0.7">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ImageThumbnails.Count, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" Value="0">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <Border Background="#E6FFFFFF"
+                                    Panel.ZIndex="20"
+                                    CornerRadius="6">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Visibility" Value="Collapsed"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsThumbnailCollectionLoading, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
+                                <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                    <ProgressBar Width="220"
+                                                 Height="8"
+                                                 IsIndeterminate="True"/>
+                                    <TextBlock Margin="0,8,0,0"
+                                               Text="{DynamicResource ImageFolderLoading}"
+                                               Foreground="Black"
+                                               FontWeight="SemiBold"
+                                               TextAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </Grid>
                 </Border>
             </Grid>
         </Grid>
-        <Border Grid.Row="2" Grid.ColumnSpan="4" Padding="12,10" Background="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" BorderThickness="0,1,0,0">
+        <Border Grid.Row="2" Grid.ColumnSpan="4" Padding="12,10" Background="{DynamicResource UI.Brush.Surface}" BorderBrush="{DynamicResource UI.Brush.ControlBorder}" BorderThickness="0,1,0,0">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="2*" />
@@ -2226,7 +2617,7 @@
                              Height="10"
                              Margin="6,0,0,0"
                              VerticalAlignment="Center"
-                             Stroke="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
+                             Stroke="{DynamicResource UI.Brush.ControlBorder}"
                              StrokeThickness="1"
                              Fill="{Binding DataContext.IsBackendOnline, ElementName=WorkflowHost, Converter={StaticResource BoolToBrush}}" />
                     <TextBlock Margin="6,0,0,0"

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using BrakeDiscInspector_GUI_ROI.Workflow;
 using BrakeDiscInspector_GUI_ROI.Overlay;
 using BrakeDiscInspector_GUI_ROI.Util;
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -66,6 +67,7 @@ using CvRect = OpenCvSharp.Rect; // CODEX: alias for OpenCV rectangles.
 using WRect = System.Windows.Rect; // CODEX: alias for WPF rectangles.
 using WPoint = System.Windows.Point; // CODEX: alias for WPF points.
 using WInt32Rect = System.Windows.Int32Rect; // CODEX: alias for WPF Int32Rect.
+using Forms = System.Windows.Forms;
 // --- END: UI/OCV type aliases ---
 using BrakeDiscInspector_GUI_ROI.Properties;
 
@@ -858,6 +860,20 @@ namespace BrakeDiscInspector_GUI_ROI
         private int _imgW, _imgH;
         private bool _hasLoadedImage;
         private bool _isFirstImageLoaded = false;
+        private static readonly HashSet<string> ThumbnailImageExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".bmp",
+            ".tif",
+            ".tiff"
+        };
+        private readonly ObservableCollection<ImageThumbnailItem> _imageThumbnails = new();
+        private ImageThumbnailItem? _selectedThumbnail;
+        private string _thumbnailFolderPath = string.Empty;
+        private bool _updatingThumbnailSelection;
+        private bool _isThumbnailCollectionLoading;
 
         private WorkflowViewModel? _workflowViewModel;
         private WorkflowViewModel? ViewModel => _workflowViewModel;
@@ -903,6 +919,68 @@ namespace BrakeDiscInspector_GUI_ROI
             = new string[] { "default" };
 
         public bool IsImageLoaded => _workflowViewModel?.IsImageLoaded ?? false;
+
+        public bool IsRoiEditModeActive => _editModeActive;
+
+        private void SetEditModeActive(bool value)
+        {
+            if (_editModeActive == value)
+            {
+                return;
+            }
+
+            _editModeActive = value;
+            OnPropertyChanged(nameof(IsRoiEditModeActive));
+        }
+
+        public ObservableCollection<ImageThumbnailItem> ImageThumbnails => _imageThumbnails;
+
+        public ImageThumbnailItem? SelectedThumbnail
+        {
+            get => _selectedThumbnail;
+            set
+            {
+                if (!ReferenceEquals(_selectedThumbnail, value))
+                {
+                    _selectedThumbnail = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string ThumbnailFolderDisplay
+            => string.IsNullOrWhiteSpace(_thumbnailFolderPath)
+                ? "No image folder selected"
+                : _thumbnailFolderPath;
+
+        public bool IsThumbnailCollectionLoading
+        {
+            get => _isThumbnailCollectionLoading;
+            private set
+            {
+                if (_isThumbnailCollectionLoading != value)
+                {
+                    _isThumbnailCollectionLoading = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public sealed class ImageThumbnailItem
+        {
+            public ImageThumbnailItem(string path, ImageSource thumbnail)
+            {
+                Path = path;
+                FileName = System.IO.Path.GetFileName(path);
+                Thumbnail = thumbnail;
+            }
+
+            public string Path { get; }
+
+            public string FileName { get; }
+
+            public ImageSource Thumbnail { get; }
+        }
 
         public RoiModel? Inspection1
         {
@@ -1415,7 +1493,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             ResetInspectionEditingFlags();
             ResetEditState();
-            _editModeActive = false;
+            SetEditModeActive(false);
             UpdateInspectionEditButtons();
 
             ClearInspectionCanvasShapes();
@@ -1448,6 +1526,7 @@ namespace BrakeDiscInspector_GUI_ROI
             AppendLog(FormattableString.Invariant(
                 $"[ANCHOR][VM-AFTER-LAYOUT] count={_workflowViewModel?.InspectionRois?.Count ?? 0} items={FormatInspectionAnchorList(_workflowViewModel?.InspectionRois)}"));
             _workflowViewModel?.AlignDatasetPathsWithCurrentLayout();
+            _ = RefreshInspectionDatasetsAfterLayoutAsync(sourceContext);
             AppendLog(FormattableString.Invariant(
                 $"[layout] Master1PatternImagePath='{_layout?.Master1PatternImagePath}'"));
             AppendLog(FormattableString.Invariant(
@@ -1473,6 +1552,24 @@ namespace BrakeDiscInspector_GUI_ROI
             RequestRoiVisibilityRefresh();
             RedrawOverlaySafe();
             UpdateRoiHud();
+        }
+
+        private async Task RefreshInspectionDatasetsAfterLayoutAsync(string sourceContext)
+        {
+            var vm = _workflowViewModel;
+            if (vm == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await vm.RefreshInspectionDatasetsAsync($"layout:{sourceContext}").ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                GuiLog.Error($"[dataset] refresh after layout failed source='{sourceContext}'", ex);
+            }
         }
 
         private void FreezeAllRois(MasterLayout? layout)
@@ -3457,36 +3554,31 @@ namespace BrakeDiscInspector_GUI_ROI
         private readonly TimeSpan _snackDuration = TimeSpan.FromSeconds(7);
         private DispatcherTimer? _guiSetupSaveTimer;
         private string _pendingGuiSetupSaveReason = "Unknown";
-        private readonly Dictionary<string, object> _defaultGuiResources = new();
         private readonly List<string> _availableFontFamilies = new() { "Segoe UI", "Calibri", "Arial", "Consolas" };
+        private TextBox? _activeGuiColorTextBox;
+        private string? _activeGuiColorResourceKey;
         private bool _isGuiSetupSyncingControls;
         private bool _isGuiSetupInitialized;
         private bool _lastInspectionRepositioned;
-        private static readonly string[] FontFamilyResourceKeys =
-        {
-            "UI.FontFamily.Body",
-            "UI.FontFamily.Header"
-        };
-        private static readonly string[] FontSizeResourceKeys =
-        {
-            "UI.FontSize.WindowTitle",
-            "UI.FontSize.SectionTitle",
-            "UI.FontSize.GroupHeader",
-            "UI.FontSize.ControlLabel",
-            "UI.FontSize.ControlText",
-            "UI.FontSize.ButtonText",
-            "UI.FontSize.CheckBox"
-        };
-        private static readonly string[] BrushResourceKeys =
-        {
-            "BrushAppBackground",
-            "UI.Brush.Foreground",
-            "UI.Brush.Accent",
-            "UI.Brush.ButtonBackground",
-            "UI.Brush.ButtonBackgroundHover",
-            "UI.Brush.ButtonForeground",
-            "UI.Brush.GroupHeaderForeground"
-        };
+
+        private static readonly IReadOnlyDictionary<string, string> DefaultFontFamilies =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["UI.FontFamily.Body"] = "Segoe UI",
+                ["UI.FontFamily.Header"] = "Segoe UI"
+            };
+
+        private static readonly IReadOnlyDictionary<string, double> DefaultFontSizes =
+            new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["UI.FontSize.WindowTitle"] = 20d,
+                ["UI.FontSize.SectionTitle"] = 16d,
+                ["UI.FontSize.GroupHeader"] = 16d,
+                ["UI.FontSize.ControlLabel"] = 13d,
+                ["UI.FontSize.ControlText"] = 13d,
+                ["UI.FontSize.ButtonText"] = 13d,
+                ["UI.FontSize.CheckBox"] = 13d
+            };
 
         private void AppendResizeLog(string msg)
         {
@@ -3517,7 +3609,6 @@ namespace BrakeDiscInspector_GUI_ROI
                 InitializeComponent();
                 GuiLog.Info($"[BOOT] MainWindow ctor → InitializeComponent() OK"); // CODEX: string interpolation compatibility.
 
-                CaptureDefaultGuiResources();
                 InitializeGuiSetupPanel();
 
                 ShowSidePanel(SidePanelMode.RoiManagement);
@@ -3626,12 +3717,13 @@ namespace BrakeDiscInspector_GUI_ROI
             Settings.Default.SidePanelWidth = _lastSidePanelWidth;
             Settings.Default.IsSidePanelCollapsed = _isPanelCollapsed;
             Settings.Default.Save();
+            _commsVm?.Dispose();
             base.OnClosed(e);
         }
 
         private void ConfigureCommandBindings()
         {
-            CommandBindings.Add(new CommandBinding(ApplicationCommands.Open, (_, _) => BtnLoadImage_Click(this, new RoutedEventArgs()), (_, e) => e.CanExecute = CanExecuteWhenIdle()));
+            CommandBindings.Add(new CommandBinding(ApplicationCommands.Open, (_, _) => BtnOpenImageFolder_Click(this, new RoutedEventArgs()), (_, e) => e.CanExecute = CanExecuteWhenIdle()));
             CommandBindings.Add(new CommandBinding(ApplicationCommands.Save, (_, _) => BtnSaveLayout_Click(this, new RoutedEventArgs()), (_, e) => e.CanExecute = CanExecuteWhenIdle()));
             CommandBindings.Add(new CommandBinding(ApplicationCommands.Find, (_, _) => BtnLoadLayout_Click(this, new RoutedEventArgs()), (_, e) => e.CanExecute = CanExecuteWhenIdle()));
             CommandBindings.Add(new CommandBinding(ApplicationCommands.Print, (_, _) => ViewModel?.InferFromCurrentRoiCommand.Execute(null), (_, e) => e.CanExecute = ViewModel?.InferFromCurrentRoiCommand?.CanExecute(null) == true && CanExecuteWhenIdle()));
@@ -3921,10 +4013,14 @@ namespace BrakeDiscInspector_GUI_ROI
                         }
                     }
                 }
-                GuiSetupSettingsService.Apply(App.CurrentGuiSetup);
-                SyncSetupGuiControlsFromResources();
+                var keepCustomColors = App.CurrentGuiSetup.CustomColorsEnabled;
+                App.CurrentGuiSetup = GuiSetupSettingsService.CaptureCurrent(this, keepCustomColors);
+                App.CurrentGuiSetup.Theme = desired;
                 Settings.Default.ThemePreference = desired;
                 Settings.Default.Save();
+                GuiSetupSettingsService.ApplyThemeBrushes(desired, this);
+                GuiSetupSettingsService.Apply(App.CurrentGuiSetup, this);
+                SyncSetupGuiControlsFromResources();
             }
             catch (Exception ex)
             {
@@ -3936,7 +4032,8 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             try
             {
-                var settings = GuiSetupSettingsService.CaptureCurrent(this);
+                var includeCustomColors = ShouldCaptureGuiSetupColors(reason);
+                var settings = GuiSetupSettingsService.CaptureCurrent(this, includeCustomColors);
                 App.CurrentGuiSetup = settings;
                 GuiSetupSettingsService.Log($"[Persist] start reason={reason} path={GuiSetupSettingsService.ConfigPath}");
                 GuiSetupSettingsService.Save(settings);
@@ -3946,6 +4043,29 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 GuiSetupSettingsService.Log($"[Persist] FAIL reason={reason}", ex);
             }
+        }
+
+        private static bool IsGuiSetupColorReason(string reason)
+        {
+            return string.Equals(reason, "ApplyColors", StringComparison.OrdinalIgnoreCase)
+                   || reason.Contains("Color", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ShouldCaptureGuiSetupColors(string reason)
+        {
+            return IsGuiSetupColorReason(reason) || App.CurrentGuiSetup.CustomColorsEnabled;
+        }
+
+        private static void EnableCustomGuiColors()
+        {
+            App.CurrentGuiSetup.CustomColorsEnabled = true;
+        }
+
+        private static void ClearCustomGuiColors()
+        {
+            App.CurrentGuiSetup.CustomColorsEnabled = false;
+            App.CurrentGuiSetup.Brushes = null;
+            App.CurrentGuiSetup.Accent = null;
         }
 
         private void RequestPersistGuiSetup(string reason)
@@ -3984,12 +4104,14 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void ThemeLightButton_Click(object sender, RoutedEventArgs e)
         {
+            ClearCustomGuiColors();
             ApplyTheme("Light");
             RequestPersistGuiSetup("ThemeLight");
         }
 
         private void ThemeDarkButton_Click(object sender, RoutedEventArgs e)
         {
+            ClearCustomGuiColors();
             ApplyTheme("Dark");
             RequestPersistGuiSetup("ThemeDark");
         }
@@ -4012,30 +4134,6 @@ namespace BrakeDiscInspector_GUI_ROI
 
             SyncSetupGuiControlsFromResources();
             _isGuiSetupInitialized = true;
-        }
-
-        private void CaptureDefaultGuiResources()
-        {
-            _defaultGuiResources.Clear();
-            foreach (var key in FontFamilyResourceKeys.Concat(FontSizeResourceKeys).Concat(BrushResourceKeys))
-            {
-                if (!TryGetResourceValue(key, out object? value))
-                {
-                    continue;
-                }
-                if (value is SolidColorBrush brush)
-                {
-                    _defaultGuiResources[key] = new SolidColorBrush(brush.Color);
-                }
-                else if (value is FontFamily family)
-                {
-                    _defaultGuiResources[key] = new FontFamily(family.Source);
-                }
-                else
-                {
-                    _defaultGuiResources[key] = value;
-                }
-            }
         }
 
         private void SyncSetupGuiControlsFromResources()
@@ -4155,44 +4253,126 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 if (TryApplyColorText(textBox, key))
                 {
+                    EnableCustomGuiColors();
                     RequestPersistGuiSetup("ColorTextChanged");
                 }
             }
         }
 
+        private void ColorPickerButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!_isGuiSetupInitialized)
+            {
+                ShouldIgnoreGuiSetupEvent(sender as FrameworkElement, "not-initialized");
+                return;
+            }
+
+            if (GuiSetupPopup != null && !GuiSetupPopup.IsOpen)
+            {
+                ShouldIgnoreGuiSetupEvent(sender as FrameworkElement, "popup-closed");
+                return;
+            }
+
+            if (sender is not FrameworkElement source || source.Tag is not string key)
+            {
+                return;
+            }
+
+            _activeGuiColorResourceKey = key;
+            _activeGuiColorTextBox = ResolveGuiColorTextBox(key);
+
+            if (_activeGuiColorTextBox == null || GuiColorPalettePopup == null)
+            {
+                return;
+            }
+
+            GuiColorPalettePopup.PlacementTarget = source;
+            GuiColorPalettePopup.IsOpen = true;
+            e.Handled = true;
+        }
+
+        private void GuiColorPalette_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not FrameworkElement source
+                || source.Tag is not string colorText
+                || _activeGuiColorTextBox == null
+                || string.IsNullOrWhiteSpace(_activeGuiColorResourceKey))
+            {
+                return;
+            }
+
+            try
+            {
+                if (ColorConverter.ConvertFromString(colorText) is Color color)
+                {
+                    _activeGuiColorTextBox.Text = color.ToString();
+                    if (TryApplyColorText(_activeGuiColorTextBox, _activeGuiColorResourceKey))
+                    {
+                        EnableCustomGuiColors();
+                        RequestPersistGuiSetup("ColorPaletteChanged");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                GuiLog.Warn($"[gui-setup] palette color '{colorText}' failed: {ex.Message}");
+            }
+            finally
+            {
+                if (GuiColorPalettePopup != null)
+                {
+                    GuiColorPalettePopup.IsOpen = false;
+                }
+            }
+
+            e.Handled = true;
+        }
+
+        private TextBox? ResolveGuiColorTextBox(string key)
+        {
+            return key switch
+            {
+                "UI.Brush.Foreground" => ForegroundColorBox,
+                "UI.Brush.Accent" => AccentColorBox,
+                "UI.Brush.ButtonBackground" => ButtonBackgroundColorBox,
+                "UI.Brush.ButtonBackgroundHover" => ButtonHoverBackgroundColorBox,
+                "UI.Brush.ButtonForeground" => ButtonForegroundColorBox,
+                "UI.Brush.GroupHeaderForeground" => GroupHeaderForegroundColorBox,
+                _ => null
+            };
+        }
+
         private void ApplyColorsButton_Click(object sender, RoutedEventArgs e)
         {
-            TryApplyColorText(ForegroundColorBox, "UI.Brush.Foreground");
-            TryApplyColorText(AccentColorBox, "UI.Brush.Accent");
-            TryApplyColorText(ButtonBackgroundColorBox, "UI.Brush.ButtonBackground");
-            TryApplyColorText(ButtonHoverBackgroundColorBox, "UI.Brush.ButtonBackgroundHover");
-            TryApplyColorText(ButtonForegroundColorBox, "UI.Brush.ButtonForeground");
-            TryApplyColorText(GroupHeaderForegroundColorBox, "UI.Brush.GroupHeaderForeground");
-            RequestPersistGuiSetup("ApplyColors");
+            var applied = false;
+            applied |= TryApplyColorText(ForegroundColorBox, "UI.Brush.Foreground");
+            applied |= TryApplyColorText(AccentColorBox, "UI.Brush.Accent");
+            applied |= TryApplyColorText(ButtonBackgroundColorBox, "UI.Brush.ButtonBackground");
+            applied |= TryApplyColorText(ButtonHoverBackgroundColorBox, "UI.Brush.ButtonBackgroundHover");
+            applied |= TryApplyColorText(ButtonForegroundColorBox, "UI.Brush.ButtonForeground");
+            applied |= TryApplyColorText(GroupHeaderForegroundColorBox, "UI.Brush.GroupHeaderForeground");
+            if (applied)
+            {
+                EnableCustomGuiColors();
+                RequestPersistGuiSetup("ApplyColors");
+            }
         }
 
         private void ResetGuiDefaultsButton_Click(object sender, RoutedEventArgs e)
         {
-            foreach (var pair in _defaultGuiResources)
+            foreach (var pair in DefaultFontFamilies)
             {
-                if (pair.Value is SolidColorBrush brush)
-                {
-                    SetBrushResource(pair.Key, brush.Color);
-                }
-                else if (pair.Value is FontFamily family)
-                {
-                    SetFontFamilyResource(pair.Key, family.Source);
-                }
-                else if (pair.Value is double size)
-                {
-                    SetDoubleResource(pair.Key, size);
-                }
-                else
-                {
-                    SetResourceValue(pair.Key, pair.Value);
-                }
+                SetFontFamilyResource(pair.Key, pair.Value);
             }
 
+            foreach (var pair in DefaultFontSizes)
+            {
+                SetDoubleResource(pair.Key, pair.Value);
+            }
+
+            ClearCustomGuiColors();
+            GuiSetupSettingsService.ApplyThemeBrushes(Settings.Default.ThemePreference, this);
+            App.CurrentGuiSetup = GuiSetupSettingsService.CaptureCurrent(this, includeCustomColors: false);
             SyncSetupGuiControlsFromResources();
             RequestPersistGuiSetup("ResetDefaults");
         }
@@ -4286,6 +4466,12 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 if (ColorConverter.ConvertFromString(text) is Color color)
                 {
+                    if (TryGetCurrentResourceColor(key, out var currentColor) && currentColor == color)
+                    {
+                        textBox.Text = color.ToString();
+                        return false;
+                    }
+
                     SetBrushResource(key, color);
                     textBox.Text = color.ToString();
                     return true;
@@ -4297,6 +4483,29 @@ namespace BrakeDiscInspector_GUI_ROI
             }
 
             SetColorTextFromResource(textBox, key);
+            return false;
+        }
+
+        private bool TryGetCurrentResourceColor(string key, out Color color)
+        {
+            color = default;
+            if (!GuiSetupSettingsService.TryGetEffectiveResource(this, key, out var value, out _))
+            {
+                return false;
+            }
+
+            if (value is SolidColorBrush brush)
+            {
+                color = brush.Color;
+                return true;
+            }
+
+            if (value is Color directColor)
+            {
+                color = directColor;
+                return true;
+            }
+
             return false;
         }
 
@@ -4328,6 +4537,11 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void SetResourceValue(string key, object value)
         {
+            if (Resources.Contains(key))
+            {
+                Resources[key] = value;
+            }
+
             if (Application.Current != null)
             {
                 Application.Current.Resources[key] = value;
@@ -4336,7 +4550,8 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void PersistGuiSetupNow(string reason)
         {
-            var settings = GuiSetupSettingsService.CaptureCurrent(this);
+            var includeCustomColors = ShouldCaptureGuiSetupColors(reason);
+            var settings = GuiSetupSettingsService.CaptureCurrent(this, includeCustomColors);
             App.CurrentGuiSetup = settings;
             GuiSetupSettingsService.Log($"[Persist] start reason={reason} path={GuiSetupSettingsService.ConfigPath}");
             GuiSetupSettingsService.Save(settings);
@@ -5291,6 +5506,11 @@ namespace BrakeDiscInspector_GUI_ROI
                     return false;
                 }
 
+                if (InspectionDatasetCreated(cfg))
+                {
+                    return false;
+                }
+
                 return string.Equals(roi.Id, _activeEditableRoiId, StringComparison.OrdinalIgnoreCase);
             }
 
@@ -5366,7 +5586,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 CaptureCurrentUiShapeIntoSlot(exitingId);
             }
 
-            _editModeActive = false;
+            SetEditModeActive(false);
             ResetInspectionEditingFlags();
             ResetEditState();
             RemoveAllRoiAdorners();
@@ -5484,7 +5704,7 @@ namespace BrakeDiscInspector_GUI_ROI
             ResetInspectionEditingFlags();
             _activeEditableRoiId = roiId;
             _globalUnlocked = true;
-            _editModeActive = true;
+            SetEditModeActive(true);
             _editingInspectionSlot = inspectionIndex;
             SetInspectionEditingFlag(inspectionIndex, true);
             UpdateEditableConfigState();
@@ -5530,7 +5750,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             ResetInspectionEditingFlags();
             ResetEditState();
-            _editModeActive = _editingM1 || _editingM2;
+            SetEditModeActive(_editingM1 || _editingM2);
             UpdateInspectionEditButtons();
 
             RemoveAllRoiAdorners();
@@ -5556,9 +5776,79 @@ namespace BrakeDiscInspector_GUI_ROI
             foreach (var cfg in ViewModel.InspectionRois)
             {
                 bool editable = hasActive && !string.IsNullOrWhiteSpace(cfg.Id)
-                    && string.Equals(cfg.Id, _activeEditableRoiId, StringComparison.OrdinalIgnoreCase);
+                    && string.Equals(cfg.Id, _activeEditableRoiId, StringComparison.OrdinalIgnoreCase)
+                    && !InspectionDatasetCreated(cfg);
                 cfg.IsEditable = editable;
             }
+        }
+
+        private const string InspectionDatasetLockedMessage =
+            "Inspection ROIs can't be modified once Dataset is created";
+
+        private bool InspectionDatasetCreated(InspectionRoiConfig? config)
+        {
+            if (config == null)
+            {
+                return false;
+            }
+
+            if (config.DatasetOkCount > 0 || config.DatasetKoCount > 0)
+            {
+                return true;
+            }
+
+            if ((config.OkPreview?.Count ?? 0) > 0 || (config.NgPreview?.Count ?? 0) > 0)
+            {
+                return true;
+            }
+
+            return DatasetPathContainsImages(config.DatasetPath);
+        }
+
+        private bool InspectionDatasetCreated(int index)
+            => InspectionDatasetCreated(GetInspectionConfigByIndex(index));
+
+        private static bool DatasetPathContainsImages(string? datasetPath)
+        {
+            var normalized = DatasetPathHelper.NormalizeDatasetPath(datasetPath);
+            if (string.IsNullOrWhiteSpace(normalized) || !Directory.Exists(normalized))
+            {
+                return false;
+            }
+
+            foreach (var labelDir in new[] { "ok", "ng", "ko" })
+            {
+                var folder = Path.Combine(normalized, labelDir);
+                if (!Directory.Exists(folder))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (Directory.EnumerateFiles(folder)
+                        .Any(file => ThumbnailImageExtensions.Contains(Path.GetExtension(file))))
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // If local enumeration fails, fall back to the backend-refreshed counters above.
+                }
+            }
+
+            return false;
+        }
+
+        private void ShowInspectionDatasetLockedWarning()
+        {
+            AppendLog($"[workflow-edit] blocked: {InspectionDatasetLockedMessage}");
+            MessageBox.Show(
+                InspectionDatasetLockedMessage,
+                "Warning",
+                MessageBoxButton.OK,
+                MessageBoxImage.Warning);
         }
 
         private bool TryClearCurrentStatePersistedRoi(out RoiRole? clearedRole)
@@ -5578,6 +5868,12 @@ namespace BrakeDiscInspector_GUI_ROI
                 MasterState.Ready => RoiRole.Inspection,
                 _ => GetCurrentStateRole()
             };
+
+            if (clearedRole == RoiRole.Inspection && InspectionDatasetCreated(_activeInspectionIndex))
+            {
+                ShowInspectionDatasetLockedWarning();
+                return false;
+            }
 
             switch (state)
             {
@@ -5656,7 +5952,176 @@ namespace BrakeDiscInspector_GUI_ROI
             LoadImage(dlg.FileName);
         }
 
-        private void LoadImage(string path)
+        private async void BtnOpenImageFolder_Click(object sender, RoutedEventArgs e)
+        {
+            using var dialog = new Forms.FolderBrowserDialog
+            {
+                Description = "Select the image folder.",
+                UseDescriptionForTitle = true,
+                ShowNewFolderButton = false
+            };
+
+            var initialFolder = GetInitialThumbnailFolder();
+            if (!string.IsNullOrWhiteSpace(initialFolder) && Directory.Exists(initialFolder))
+            {
+                dialog.SelectedPath = initialFolder;
+            }
+
+            if (dialog.ShowDialog() == Forms.DialogResult.OK && Directory.Exists(dialog.SelectedPath))
+            {
+                await LoadThumbnailFolderAsync(dialog.SelectedPath);
+            }
+        }
+
+        private string GetInitialThumbnailFolder()
+        {
+            if (!string.IsNullOrWhiteSpace(_thumbnailFolderPath) && Directory.Exists(_thumbnailFolderPath))
+            {
+                return _thumbnailFolderPath;
+            }
+
+            if (!string.IsNullOrWhiteSpace(_currentImagePathWin))
+            {
+                var currentFolder = Path.GetDirectoryName(_currentImagePathWin);
+                if (!string.IsNullOrWhiteSpace(currentFolder) && Directory.Exists(currentFolder))
+                {
+                    return currentFolder;
+                }
+            }
+
+            return Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+        }
+
+        private async Task LoadThumbnailFolderAsync(string folderPath)
+        {
+            if (string.IsNullOrWhiteSpace(folderPath) || !Directory.Exists(folderPath))
+            {
+                MessageBox.Show("No se pudo abrir la carpeta de imagenes.");
+                return;
+            }
+
+            IsThumbnailCollectionLoading = true;
+            await Dispatcher.Yield(DispatcherPriority.Render);
+
+            List<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(folderPath, "*.*", SearchOption.TopDirectoryOnly)
+                    .Where(IsSupportedThumbnailImage)
+                    .OrderBy(file => Path.GetFileName(file), StringComparer.CurrentCultureIgnoreCase)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error al leer la carpeta: {ex.Message}");
+                IsThumbnailCollectionLoading = false;
+                return;
+            }
+
+            try
+            {
+                _thumbnailFolderPath = folderPath;
+                OnPropertyChanged(nameof(ThumbnailFolderDisplay));
+
+                _updatingThumbnailSelection = true;
+                try
+                {
+                    SelectedThumbnail = null;
+                    _imageThumbnails.Clear();
+
+                    foreach (var file in files)
+                    {
+                        var thumbnail = TryLoadThumbnail(file);
+                        if (thumbnail != null)
+                        {
+                            _imageThumbnails.Add(new ImageThumbnailItem(file, thumbnail));
+                        }
+                    }
+
+                    SelectThumbnailForPath(_currentImagePathWin);
+                }
+                finally
+                {
+                    _updatingThumbnailSelection = false;
+                }
+
+                AppendLog($"[thumbs] folder='{folderPath}' images={_imageThumbnails.Count}");
+            }
+            finally
+            {
+                IsThumbnailCollectionLoading = false;
+            }
+        }
+
+        private static bool IsSupportedThumbnailImage(string filePath)
+        {
+            var extension = Path.GetExtension(filePath);
+            return !string.IsNullOrWhiteSpace(extension) && ThumbnailImageExtensions.Contains(extension);
+        }
+
+        private ImageSource? TryLoadThumbnail(string filePath)
+        {
+            try
+            {
+                var bitmap = new BitmapImage();
+                bitmap.BeginInit();
+                bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                bitmap.DecodePixelWidth = 144;
+                bitmap.UriSource = new Uri(filePath);
+                bitmap.EndInit();
+                bitmap.Freeze();
+                return bitmap;
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"[thumbs] skip '{Path.GetFileName(filePath)}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private void ThumbnailStrip_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_updatingThumbnailSelection)
+            {
+                return;
+            }
+
+            if (ThumbnailStripList?.SelectedItem is ImageThumbnailItem item && File.Exists(item.Path))
+            {
+                LoadImage(item.Path);
+            }
+        }
+
+        private void SelectThumbnailForPath(string? imagePath)
+        {
+            ImageThumbnailItem? match = null;
+            if (!string.IsNullOrWhiteSpace(imagePath))
+            {
+                match = _imageThumbnails.FirstOrDefault(item =>
+                    string.Equals(item.Path, imagePath, StringComparison.OrdinalIgnoreCase));
+            }
+
+            _updatingThumbnailSelection = true;
+            try
+            {
+                SelectedThumbnail = match;
+
+                if (ThumbnailStripList != null)
+                {
+                    ThumbnailStripList.SelectedItem = match;
+                    if (match != null)
+                    {
+                        ThumbnailStripList.ScrollIntoView(match);
+                    }
+                }
+            }
+            finally
+            {
+                _updatingThumbnailSelection = false;
+            }
+        }
+
+        private void LoadImage(string path, bool runAutoAnalyze = true)
         {
             _currentImagePathWin = path;
             _currentImagePathBackend = path;
@@ -5731,12 +6196,21 @@ namespace BrakeDiscInspector_GUI_ROI
             DumpUiShapesMap("imgload:post-redraw");
             ClearHeatmapOverlay();
 
-            Dispatcher.InvokeAsync(async () =>
+            if (runAutoAnalyze)
+            {
+                Dispatcher.InvokeAsync(async () =>
             {
                 await Dispatcher.Yield(DispatcherPriority.Loaded);
                 SyncOverlayToImage(scheduleResync: true);
                 await Dispatcher.Yield(DispatcherPriority.Render);
                 await Dispatcher.Yield(DispatcherPriority.Background);
+
+                if (ViewModel?.HasLoadedLayout != true)
+                {
+                    AppendLog("[auto-analyze] skipped: layout not loaded");
+                    Snack("Please load a layout");
+                    return;
+                }
 
                 if (HasAllMastersAndInspectionsDefined())
                 {
@@ -5745,6 +6219,7 @@ namespace BrakeDiscInspector_GUI_ROI
                         LogDebug("[auto-analyze] ImageLoaded → AnalyzeMaster()");
                         await AnalyzeMastersAsync(showFailureDialog: false);
                         ScheduleSyncOverlay(force: true, reason: "AutoAnalyzeAfterImageLoad");
+                        await AutoEvaluateEnabledRoisAfterImageLoadAsync();
                     }
                     catch (Exception ex)
                     {
@@ -5752,6 +6227,7 @@ namespace BrakeDiscInspector_GUI_ROI
                     }
                 }
             }, DispatcherPriority.Loaded);
+            }
 
             UpdateRoiHud();
 
@@ -5835,7 +6311,29 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 _workflowViewModel.IsImageLoaded = true;
             }
+            SelectThumbnailForPath(path);
             EnablePresetsTab(true);
+        }
+
+        private async Task AutoEvaluateEnabledRoisAfterImageLoadAsync()
+        {
+            var vm = ViewModel;
+            if (vm?.InferEnabledRoisCommand?.CanExecute(null) != true)
+            {
+                AppendLog("[auto-eval] skipped: no enabled inspection ROIs or workflow busy");
+                return;
+            }
+
+            try
+            {
+                AppendLog("[auto-eval] evaluating enabled ROIs after image load");
+                await vm.EvaluateEnabledRoisForAutomationAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"[auto-eval] failed after image load: {ex.Message}");
+                LogDebug($"[auto-eval] failed after image load: {ex.Message}");
+            }
         }
 
         private bool IsOverlayAligned()
@@ -7700,6 +8198,17 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
+            RoiHudStack.Children.Add(new TextBlock
+            {
+                Text = "OBJECT VISIBILITY",
+                Foreground = Brushes.Black,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 11,
+                FontWeight = FontWeights.Black,
+                Margin = new Thickness(2, 0, 2, 8),
+                TextAlignment = TextAlignment.Center
+            });
+
             // Masters (Patterns)
             if (_layout.Master1Pattern != null && IsRoiSaved(_layout.Master1Pattern))
             {
@@ -7745,12 +8254,21 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private FrameworkElement CreateHudItem(string label, Func<bool> getVisible, Action<bool> setVisible)
         {
+            if (UseModernHudVisibilityToggles)
+            {
+                return CreateHudVisibilityRow(label, getVisible(), now =>
+                {
+                    setVisible(now);
+                    try { RedrawAllRois(); } catch { }
+                });
+            }
+
             bool isVisible = getVisible();
 
             var text = new TextBlock
             {
                 Text = label,
-                Foreground = Brushes.White,
+                Foreground = Brushes.Black,
                 FontFamily = new FontFamily("Segoe UI"),
                 FontSize = 12,
                 FontWeight = FontWeights.SemiBold,
@@ -7761,11 +8279,13 @@ namespace BrakeDiscInspector_GUI_ROI
             var eye = new TextBlock
             {
                 Text = isVisible ? "👁" : "🚫",
-                Foreground = isVisible ? Brushes.Lime : Brushes.Gray,
+                Foreground = isVisible ? Brushes.Black : Brushes.DimGray,
                 FontSize = 12,
+                FontWeight = FontWeights.Bold,
                 Margin = new Thickness(6, 2, 0, 2),
                 VerticalAlignment = VerticalAlignment.Center
             };
+            eye.Text = isVisible ? "ON" : "OFF";
 
             var sp = new StackPanel { Orientation = Orientation.Horizontal };
             sp.Children.Add(text);
@@ -7774,8 +8294,8 @@ namespace BrakeDiscInspector_GUI_ROI
             var border = new Border
             {
                 CornerRadius = new CornerRadius(4),
-                Background = Brushes.Black,
-                BorderBrush = isVisible ? (Brush)new BrushConverter().ConvertFromString("#39FF14") : Brushes.DimGray,
+                Background = new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
+                BorderBrush = isVisible ? Brushes.Black : Brushes.DimGray,
                 BorderThickness = new Thickness(1.5),
                 Margin = new Thickness(0, 0, 0, 6),
                 Child = sp,
@@ -7787,7 +8307,9 @@ namespace BrakeDiscInspector_GUI_ROI
                 bool now = !getVisible();
                 setVisible(now);
                 eye.Text = now ? "👁" : "🚫";
-                border.BorderBrush = now ? (Brush)new BrushConverter().ConvertFromString("#39FF14") : Brushes.DimGray;
+                eye.Text = now ? "ON" : "OFF";
+                eye.Foreground = now ? Brushes.Black : Brushes.DimGray;
+                border.BorderBrush = now ? Brushes.Black : Brushes.DimGray;
                 try { RedrawAllRois(); } catch { }
                 e.Handled = true;
             };
@@ -7798,12 +8320,21 @@ namespace BrakeDiscInspector_GUI_ROI
         private FrameworkElement CreateRoiHudItem(RoiModel roi)
         {
             var labelText = ResolveRoiLabelText(roi) ?? roi.Label ?? "Inspection";
+            if (UseModernHudVisibilityToggles)
+            {
+                return CreateHudVisibilityRow(labelText, IsRoiRoleVisible(roi.Role), now =>
+                {
+                    SetRoiVisibility(roi.Role, now);
+                    try { RedrawAllRois(); } catch { }
+                });
+            }
+
             bool isVisible = IsRoiRoleVisible(roi.Role);
 
             var text = new TextBlock
             {
                 Text = labelText,
-                Foreground = Brushes.White,
+                Foreground = Brushes.Black,
                 FontFamily = new FontFamily("Segoe UI"),
                 FontSize = 12,
                 FontWeight = FontWeights.SemiBold,
@@ -7814,11 +8345,13 @@ namespace BrakeDiscInspector_GUI_ROI
             var eye = new TextBlock
             {
                 Text = isVisible ? "👁" : "🚫",
-                Foreground = isVisible ? (Brush)RoiHudAccentBrush : Brushes.Gray,
+                Foreground = isVisible ? Brushes.Black : Brushes.DimGray,
                 FontSize = 12,
+                FontWeight = FontWeights.Bold,
                 Margin = new Thickness(6, 2, 0, 2),
                 VerticalAlignment = VerticalAlignment.Center
             };
+            eye.Text = isVisible ? "ON" : "OFF";
 
             var stack = new StackPanel { Orientation = Orientation.Horizontal };
             stack.Children.Add(text);
@@ -7827,8 +8360,8 @@ namespace BrakeDiscInspector_GUI_ROI
             var border = new Border
             {
                 CornerRadius = new CornerRadius(4),
-                Background = Brushes.Black,
-                BorderBrush = isVisible ? (Brush)RoiHudAccentBrush : Brushes.DimGray,
+                Background = new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
+                BorderBrush = isVisible ? Brushes.Black : Brushes.DimGray,
                 BorderThickness = new Thickness(1.5),
                 Margin = new Thickness(0, 0, 0, 6),
                 Child = stack,
@@ -7839,10 +8372,97 @@ namespace BrakeDiscInspector_GUI_ROI
             border.MouseLeftButtonUp += (s, e) =>
             {
                 ToggleRoiVisibility(roi.Role);
+                UpdateRoiHud();
                 e.Handled = true;
             };
 
             return border;
+        }
+
+        private static bool UseModernHudVisibilityToggles => true;
+
+        private FrameworkElement CreateHudVisibilityRow(string label, bool isVisible, Action<bool> setVisible)
+        {
+            var text = new TextBlock
+            {
+                Text = label,
+                Foreground = Brushes.Black,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = 12,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 12, 0),
+                VerticalAlignment = VerticalAlignment.Center,
+                TextWrapping = TextWrapping.Wrap
+            };
+
+            var toggle = CreateHudVisibilityToggle(isVisible);
+            var row = new Grid();
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star), MinWidth = 120 });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+            row.Children.Add(text);
+            Grid.SetColumn(toggle, 1);
+            row.Children.Add(toggle);
+
+            var border = new Border
+            {
+                CornerRadius = new CornerRadius(4),
+                Background = new SolidColorBrush(Color.FromArgb(0x4D, 0xFF, 0xFF, 0xFF)),
+                BorderBrush = isVisible ? Brushes.Black : Brushes.DimGray,
+                BorderThickness = new Thickness(1.5),
+                Margin = new Thickness(0, 0, 0, 6),
+                Padding = new Thickness(8, 5, 8, 5),
+                Child = row,
+                Cursor = Cursors.Hand,
+                MinWidth = 180,
+                MaxWidth = 240
+            };
+
+            void Apply(bool now)
+            {
+                setVisible(now);
+                border.BorderBrush = now ? Brushes.Black : Brushes.DimGray;
+                toggle.ToolTip = now ? "Visible" : "Hidden";
+            }
+
+            toggle.Checked += (_, e) =>
+            {
+                Apply(true);
+                e.Handled = true;
+            };
+
+            toggle.Unchecked += (_, e) =>
+            {
+                Apply(false);
+                e.Handled = true;
+            };
+
+            return border;
+        }
+
+        private ToggleButton CreateHudVisibilityToggle(bool isVisible)
+        {
+            var toggle = new ToggleButton
+            {
+                Width = 46,
+                Height = 24,
+                IsChecked = isVisible,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                VerticalAlignment = VerticalAlignment.Center,
+                Background = Brushes.Transparent,
+                BorderBrush = Brushes.Transparent,
+                BorderThickness = new Thickness(0),
+                Padding = new Thickness(0),
+                Cursor = Cursors.Hand,
+                ToolTip = isVisible ? "Visible" : "Hidden",
+                FocusVisualStyle = null
+            };
+
+            if (TryFindResource("HudVisibilityToggleTemplate") is ControlTemplate template)
+            {
+                toggle.Template = template;
+            }
+
+            return toggle;
         }
 
         private void ToggleRoiVisibility(RoiRole role)
@@ -7992,6 +8612,12 @@ namespace BrakeDiscInspector_GUI_ROI
             if (_layout == null)
             {
                 MessageBox.Show("No hay layout cargado.", $"Inspection {index}", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+
+            if (InspectionDatasetCreated(index))
+            {
+                ShowInspectionDatasetLockedWarning();
                 return;
             }
 
@@ -8230,6 +8856,23 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
+            bool isActiveEditing =
+                _editingInspectionSlot.HasValue &&
+                _editingInspectionSlot.Value == index;
+
+            bool makeEditable = !isActiveEditing;
+            if (makeEditable && InspectionDatasetCreated(config))
+            {
+                roiModel.IsFrozen = true;
+                config.IsEditable = false;
+                RemoveAllRoiAdorners();
+                ApplyInspectionInteractionPolicy($"dataset-lock:{roiId}");
+                RedrawOverlaySafe();
+                GuiLog.Warn($"[workflow-edit] ToggleInspectionEdit blocked by dataset lock roi='{roiId}' index={index}");
+                ShowInspectionDatasetLockedWarning();
+                return;
+            }
+
             bool switchingRoi = _editingInspectionSlot.HasValue && _editingInspectionSlot.Value != index;
             if (switchingRoi)
             {
@@ -8249,14 +8892,12 @@ namespace BrakeDiscInspector_GUI_ROI
 
             // Determine if THIS slot is currently the active inspection being edited,
             // using the global state (_editingInspectionSlot), not only config.IsEditable.
-            bool isActiveEditing =
+            isActiveEditing =
                 _editingInspectionSlot.HasValue &&
                 _editingInspectionSlot.Value == index;
 
             // If this ROI is NOT currently active → we want to ENTER edit mode.
             // If it IS the active one → we want to EXIT edit mode.
-            bool makeEditable = !isActiveEditing;
-
             GuiLog.Info(
                 $"[workflow-edit] decision roi='{roiId}' index={index} " +
                 $"isActiveEditing={isActiveEditing} makeEditable={makeEditable} " +
@@ -8329,6 +8970,13 @@ namespace BrakeDiscInspector_GUI_ROI
                 return;
             }
 
+            var config = GetInspectionConfigByIndex(index);
+            if (InspectionDatasetCreated(config))
+            {
+                ShowInspectionDatasetLockedWarning();
+                return;
+            }
+
             if (HasInspectionRoi(index))
             {
                 Snack($"Inspection {index} ya existe.");
@@ -8351,7 +8999,6 @@ namespace BrakeDiscInspector_GUI_ROI
 
             SetActiveInspectionIndex(index);
 
-            var config = GetInspectionConfigByIndex(index);
             if (config != null)
             {
                 ToggleInspectionEdit(config);
@@ -8484,6 +9131,12 @@ namespace BrakeDiscInspector_GUI_ROI
             var roiModel = GetInspectionSlotModel(index);
             if (roiModel == null)
                 return;
+
+            if (InspectionDatasetCreated(index))
+            {
+                ShowInspectionDatasetLockedWarning();
+                return;
+            }
 
             bool wasActive = !string.IsNullOrWhiteSpace(_activeEditableRoiId)
                 && !string.IsNullOrWhiteSpace(roiModel.Id)
@@ -8683,7 +9336,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (changed)
             {
-                _editModeActive = false;
+                SetEditModeActive(false);
             }
 
             UpdateWorkflowMasterEditState();
@@ -8970,6 +9623,17 @@ namespace BrakeDiscInspector_GUI_ROI
 
             WireExistingHeatmapControls();
             SyncDrawToolFromViewModel();
+
+            try
+            {
+                GuiLog.Info($"[BOOT] MainWindow_Loaded -> BackendAutoStarter BEGIN");
+                await BackendAutoStarter.EnsureStartedAsync(_appConfig.Backend);
+                GuiLog.Info($"[BOOT] MainWindow_Loaded -> BackendAutoStarter END");
+            }
+            catch (Exception ex)
+            {
+                GuiLog.Error("[BOOT] MainWindow_Loaded: BackendAutoStarter FAILED", ex);
+            }
 
             try
             {
@@ -9690,6 +10354,24 @@ namespace BrakeDiscInspector_GUI_ROI
                     int.TryParse(tag, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index))
                 {
                     config = GetInspectionConfigByIndex(index);
+                    if (config != null && InspectionDatasetCreated(config))
+                    {
+                        var previousShape = e.RemovedItems.OfType<RoiShape>().FirstOrDefault();
+                        _updatingDrawToolUi = true;
+                        try
+                        {
+                            config.Shape = previousShape;
+                            combo.SelectedItem = previousShape;
+                        }
+                        finally
+                        {
+                            _updatingDrawToolUi = false;
+                        }
+
+                        ShowInspectionDatasetLockedWarning();
+                        return;
+                    }
+
                     if (config != null && config.Shape != shape)
                     {
                         config.Shape = shape;
@@ -10953,7 +11635,7 @@ namespace BrakeDiscInspector_GUI_ROI
             var savedSummary = savedRoi != null
                 ? $"{savedRole}: {DescribeRoi(savedRoi)}"
                 : "<sin ROI>";
-            _editModeActive = false;
+            SetEditModeActive(false);
             Snack($"Guardado. {savedSummary}");
         }
 
@@ -13820,7 +14502,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 ApplyLayout(loaded ?? new MasterLayout(), "manual-load", selectedPath);
                 _dataRoot = EnsureDataRoot();
                 EnsureInspectionDatasetStructure();
-                _editModeActive = false;
+                SetEditModeActive(false);
                 Snack($"Layout loaded: {System.IO.Path.GetFileName(dlg.FileName)}");
             }
             catch (Exception ex)
@@ -14902,7 +15584,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 if (_isSyncRunning)
                 {
                     AppendLog($"[sync] Runner defers (already running) seq={mySeq}");
-                    Dispatcher.BeginInvoke((Action)Runner, System.Windows.Threading.DispatcherPriority.Background);
+                    _ = Dispatcher.BeginInvoke((Action)Runner, System.Windows.Threading.DispatcherPriority.Background);
                     return;
                 }
 
@@ -14920,7 +15602,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 }
             }
 
-            Dispatcher.BeginInvoke((Action)Runner, System.Windows.Threading.DispatcherPriority.Background);
+            _ = Dispatcher.BeginInvoke((Action)Runner, System.Windows.Threading.DispatcherPriority.Background);
         }
 
         private void RunSyncOverlayCore(int seq, string reason)
@@ -15257,7 +15939,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 _activeMaster1Role = null;
             }
 
-            _editModeActive = true;
+            SetEditModeActive(true);
             _state = state;
             var shape = ReadShapeFrom(shapeCombo);
             GuiLog.Info(
@@ -15348,7 +16030,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 if (cleared)
                 {
                     _activeEditableRoiId = null;
-                    _editModeActive = false;
+                    SetEditModeActive(false);
                     _isDrawing = false;
                     _tmpBuffer = null;
                     AppendLog($"[align] cleared {role}");
@@ -15417,7 +16099,7 @@ namespace BrakeDiscInspector_GUI_ROI
 
         private void CancelActiveDrawing()
         {
-            _editModeActive = false;
+            SetEditModeActive(false);
             _editingM1 = false;
             _editingM2 = false;
             _activeEditableRoiId = null;
@@ -15601,12 +16283,12 @@ namespace BrakeDiscInspector_GUI_ROI
                 var targetState = ResolveMasterState(targetRole);
                 SaveFor(targetState);
 
-                _editModeActive = false;
+                SetEditModeActive(false);
                 _isDrawing = false;
                 _activeEditableRoiId = null;
                 _activeMaster1Role = null;
                 _editingM1 = false;
-                _editModeActive = _editingM2;
+                SetEditModeActive(_editingM2);
                 UpdateMasterEditButtonVisuals();
                 _state = MasterState.Ready;
 
@@ -15633,7 +16315,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 _state = MasterState.Ready;
                 _isDrawing = false;
                 _editingM1 = true;
-                _editModeActive = true;
+                SetEditModeActive(true);
                 UpdateMasterEditButtonVisuals();
 
                 RemoveAdornersForMaster(1);
@@ -15649,7 +16331,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 RemoveAdornersForMaster(1);
                 _editingM1 = false;
                 _activeMaster1Role = null;
-                _editModeActive = _editingM2;
+                SetEditModeActive(_editingM2);
                 UpdateMasterEditButtonVisuals();
                 RedrawOverlaySafe();
                 Snack("Master 1 válido.");
@@ -15746,7 +16428,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 _state = MasterState.Ready;
                 _isDrawing = false;
                 _editingM2 = true;
-                _editModeActive = true;
+                SetEditModeActive(true);
                 UpdateMasterEditButtonVisuals();
 
                 RemoveAdornersForMaster(2);
@@ -15762,7 +16444,7 @@ namespace BrakeDiscInspector_GUI_ROI
                 RemoveAdornersForMaster(2);
                 _editingM2 = false;
                 _activeMaster2Role = null;
-                _editModeActive = _editingM1;
+                SetEditModeActive(_editingM1);
                 UpdateMasterEditButtonVisuals();
                 RedrawOverlaySafe();
                 Snack("Master 2 válido.");
@@ -15942,6 +16624,12 @@ namespace BrakeDiscInspector_GUI_ROI
 
             if (result != MessageBoxResult.Yes)
             {
+                return;
+            }
+
+            if (ViewModel?.InspectionRois?.Any(InspectionDatasetCreated) == true)
+            {
+                ShowInspectionDatasetLockedWarning();
                 return;
             }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Models/InspectionRoiConfig.cs
@@ -151,6 +151,9 @@ namespace BrakeDiscInspector_GUI_ROI.Models
         [JsonIgnore]
         public bool HasDatasetPath => !string.IsNullOrWhiteSpace(_datasetPath);
 
+        [JsonIgnore]
+        public bool HasDatasetSamples => DatasetOkCount + DatasetKoCount > 0;
+
         public bool TrainMemoryFit
         {
             get => _trainMemoryFit;
@@ -322,6 +325,7 @@ namespace BrakeDiscInspector_GUI_ROI.Models
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(DatasetCountsText));
                 OnPropertyChanged(nameof(OkCount));
+                OnPropertyChanged(nameof(HasDatasetSamples));
             }
         }
 
@@ -336,6 +340,7 @@ namespace BrakeDiscInspector_GUI_ROI.Models
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(DatasetCountsText));
                 OnPropertyChanged(nameof(NgCount));
+                OnPropertyChanged(nameof(HasDatasetSamples));
             }
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/Resources/Strings.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Resources/Strings.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
     <sys:String x:Key="LoadImage">Load Image</sys:String>
+    <sys:String x:Key="OpenImageFolder">Open Folder</sys:String>
     <sys:String x:Key="LoadLayout">Load Layout</sys:String>
     <sys:String x:Key="SaveLayout">Save Layout</sys:String>
     <sys:String x:Key="LayoutAutosave">Layout Autosave</sys:String>
@@ -19,6 +20,9 @@
     <sys:String x:Key="StatusBusy">Working</sys:String>
     <sys:String x:Key="StatusIdle">Idle</sys:String>
     <sys:String x:Key="LoadPictureTooltip">Open an image file (Ctrl+O)</sys:String>
+    <sys:String x:Key="OpenImageFolderTooltip">Open an image folder (Ctrl+O)</sys:String>
+    <sys:String x:Key="ImageFolderEmpty">Open a folder to show image thumbnails.</sys:String>
+    <sys:String x:Key="ImageFolderLoading">Cargando coleccion de imagenes...</sys:String>
     <sys:String x:Key="SaveLayoutTooltip">Save the current layout (Ctrl+S)</sys:String>
     <sys:String x:Key="LoadLayoutTooltip">Load an existing layout (Ctrl+L)</sys:String>
     <sys:String x:Key="PrimaryActions">Primary actions</sys:String>

--- a/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/RoiAdorner.cs
@@ -45,6 +45,7 @@ namespace BrakeDiscInspector_GUI_ROI
         private Point _rotationPivotWorld;
         private UIElement? _rotationReferenceElement;
         private double _rotationPointerAngleAtDragStartDeg;
+        private const double RotationThumbSize = 28.0;
 
         public RoiAdorner(UIElement adornedElement, RoiOverlay overlay, Action<RoiAdornerChangeKind, RoiModel> onChanged, Action<string> log)
             : base(adornedElement)
@@ -55,6 +56,7 @@ namespace BrakeDiscInspector_GUI_ROI
             _log = log ?? (_ => { });
 
             IsHitTestVisible = true;
+            ClipToBounds = false;
 
             // Estilos básicos
             StyleThumb(_moveThumb, 0, 0, 0, 0, Cursors.Arrow, 0.0, 0.0, 0.0, 0.0);
@@ -216,7 +218,17 @@ namespace BrakeDiscInspector_GUI_ROI
             for (int i = 0; i < _corners.Length; i++)
             {
                 Point corner = cornerPositions[i];
-                _corners[i].Arrange(new Rect(corner.X - r, corner.Y - r, 2 * r, 2 * r));
+                if (_corners[i] == _rotationThumb)
+                {
+                    double size = RotationThumbSize;
+                    _rotationThumb.Visibility = Visibility.Visible;
+                    _rotationThumb.IsHitTestVisible = true;
+                    _rotationThumb.Arrange(new Rect(corner.X - size * 0.35, corner.Y - size * 0.65, size, size));
+                }
+                else
+                {
+                    _corners[i].Arrange(new Rect(corner.X - r, corner.Y - r, 2 * r, 2 * r));
+                }
             }
 
             bool hideEdges = isAnnulus || isCircle;
@@ -599,15 +611,16 @@ namespace BrakeDiscInspector_GUI_ROI
         private static void StyleRotationThumb(Thumb thumb)
         {
             thumb.Cursor = Cursors.Hand;
-            thumb.Width = 14;
-            thumb.Height = 14;
-            thumb.MinWidth = 14;
-            thumb.MinHeight = 14;
+            thumb.Width = RotationThumbSize;
+            thumb.Height = RotationThumbSize;
+            thumb.MinWidth = RotationThumbSize;
+            thumb.MinHeight = RotationThumbSize;
             thumb.Background = Brushes.Transparent;
             thumb.BorderBrush = Brushes.Transparent;
             thumb.BorderThickness = new Thickness(0);
             thumb.Opacity = 1.0;
             thumb.Margin = new Thickness(0);
+            thumb.ClipToBounds = false;
             thumb.Template = CreateArcThumbTemplate();
         }
 
@@ -626,23 +639,36 @@ namespace BrakeDiscInspector_GUI_ROI
         {
             var template = new ControlTemplate(typeof(Thumb));
             var canvas = new FrameworkElementFactory(typeof(Canvas));
-            canvas.SetValue(FrameworkElement.WidthProperty, 22.0);
-            canvas.SetValue(FrameworkElement.HeightProperty, 22.0);
+            canvas.SetValue(FrameworkElement.WidthProperty, RotationThumbSize);
+            canvas.SetValue(FrameworkElement.HeightProperty, RotationThumbSize);
+            canvas.SetValue(UIElement.ClipToBoundsProperty, false);
+
+            var background = new FrameworkElementFactory(typeof(Ellipse));
+            background.SetValue(FrameworkElement.WidthProperty, 24.0);
+            background.SetValue(FrameworkElement.HeightProperty, 24.0);
+            background.SetValue(Canvas.LeftProperty, 2.0);
+            background.SetValue(Canvas.TopProperty, 2.0);
+            background.SetValue(Shape.FillProperty, new SolidColorBrush(Color.FromArgb(230, 255, 255, 255)));
+            background.SetValue(Shape.StrokeProperty, Brushes.Black);
+            background.SetValue(Shape.StrokeThicknessProperty, 1.2);
+            canvas.AppendChild(background);
 
             var arcPath = new FrameworkElementFactory(typeof(Path));
-            arcPath.SetValue(Shape.StrokeProperty, Brushes.SteelBlue);
-            arcPath.SetValue(Shape.StrokeThicknessProperty, 1.5);
-            arcPath.SetValue(Path.DataProperty, Geometry.Parse("M5,14 A7,7 0 0 1 17,14"));
+            arcPath.SetValue(Shape.StrokeProperty, Brushes.Black);
+            arcPath.SetValue(Shape.StrokeThicknessProperty, 2.0);
+            arcPath.SetValue(Shape.StrokeStartLineCapProperty, PenLineCap.Round);
+            arcPath.SetValue(Shape.StrokeEndLineCapProperty, PenLineCap.Round);
+            arcPath.SetValue(Path.DataProperty, Geometry.Parse("M8,18 A8,8 0 0 1 20,10"));
             canvas.AppendChild(arcPath);
 
             var arrowStart = new FrameworkElementFactory(typeof(Path));
-            arrowStart.SetValue(Shape.FillProperty, Brushes.SteelBlue);
-            arrowStart.SetValue(Path.DataProperty, Geometry.Parse("M5,14 L8,11 L8,17 Z"));
+            arrowStart.SetValue(Shape.FillProperty, Brushes.Black);
+            arrowStart.SetValue(Path.DataProperty, Geometry.Parse("M8,18 L8,13 L12,17 Z"));
             canvas.AppendChild(arrowStart);
 
             var arrowEnd = new FrameworkElementFactory(typeof(Path));
-            arrowEnd.SetValue(Shape.FillProperty, Brushes.SteelBlue);
-            arrowEnd.SetValue(Path.DataProperty, Geometry.Parse("M17,14 L14,11 L14,17 Z"));
+            arrowEnd.SetValue(Shape.FillProperty, Brushes.Black);
+            arrowEnd.SetValue(Path.DataProperty, Geometry.Parse("M20,10 L15,10 L19,14 Z"));
             canvas.AppendChild(arrowEnd);
 
             template.VisualTree = canvas;

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/BackendAutoStarter.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/BackendAutoStarter.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BrakeDiscInspector_GUI_ROI.Util;
+
+namespace BrakeDiscInspector_GUI_ROI.Services
+{
+    internal static class BackendAutoStarter
+    {
+        private static readonly SemaphoreSlim StartLock = new(1, 1);
+
+        public static async Task EnsureStartedAsync(AppConfig.BackendConfig config, CancellationToken ct = default)
+        {
+            if (config == null || !config.AutoStart)
+            {
+                return;
+            }
+
+            await StartLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (await IsHealthyAsync(config.BaseUrl, ct).ConfigureAwait(false))
+                {
+                    GuiLog.Info("[backend-autostart] backend already healthy; startup skipped.");
+                    return;
+                }
+
+                var mode = string.IsNullOrWhiteSpace(config.AutoStartMode) ? "WslVenv" : config.AutoStartMode.Trim();
+                if (!IsSupportedWslMode(mode))
+                {
+                    GuiLog.Warn($"[backend-autostart] unsupported mode '{config.AutoStartMode}'.");
+                    return;
+                }
+
+                var repoRoot = ResolveRepoRoot(config.AutoStartWorkingDirectory);
+                if (string.IsNullOrWhiteSpace(repoRoot))
+                {
+                    GuiLog.Warn("[backend-autostart] repository root not found; cannot start backend.");
+                    return;
+                }
+
+                StartWslBackend(config, repoRoot, mode);
+
+                var timeout = TimeSpan.FromSeconds(Math.Clamp(config.StartupTimeoutSeconds, 1, 300));
+                if (await WaitUntilHealthyAsync(config.BaseUrl, timeout, ct).ConfigureAwait(false))
+                {
+                    GuiLog.Info("[backend-autostart] backend became healthy.");
+                }
+                else
+                {
+                    GuiLog.Warn($"[backend-autostart] backend did not answer /health within {timeout.TotalSeconds:0}s.");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                GuiLog.Error("[backend-autostart] startup failed", ex);
+            }
+            finally
+            {
+                StartLock.Release();
+            }
+        }
+
+        private static void StartWslBackend(AppConfig.BackendConfig config, string repoRoot, string mode)
+        {
+            var distro = string.IsNullOrWhiteSpace(config.WslDistro) ? "Ubuntu" : config.WslDistro.Trim();
+            var envName = string.IsNullOrWhiteSpace(config.WslCondaEnvironment) ? "BrakeDisc" : config.WslCondaEnvironment.Trim();
+            var venvPath = string.IsNullOrWhiteSpace(config.WslVenvPath) ? "/home/millylinux/venv" : config.WslVenvPath.Trim();
+            var modelsDir = ResolveWslPath(config.AutoStartModelsDirectory);
+            var host = string.IsNullOrWhiteSpace(config.AutoStartHost) ? "0.0.0.0" : config.AutoStartHost.Trim();
+            var port = config.AutoStartPort > 0 ? config.AutoStartPort : TryGetPort(config.BaseUrl) ?? 8000;
+            var wslRepoRoot = ToWslPath(repoRoot);
+
+            var bashCommand =
+                "set -e; " +
+                "cd " + BashQuote(wslRepoRoot) + "; " +
+                "source ~/.bashrc >/dev/null 2>&1 || true; " +
+                BuildActivationCommand(mode, envName, venvPath) +
+                BuildModelsDirectoryCommand(modelsDir) +
+                "echo '[bdi] Backend starting from:' \"$(pwd)\"; " +
+                "echo '[bdi] Python:' \"$(command -v python || true)\"; " +
+                "if ! command -v python >/dev/null 2>&1; then echo '[bdi] python not found after environment activation.' >&2; exit 1; fi; " +
+                "python -m uvicorn backend.app:app --host " + BashQuote(host) + " --port " + port.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            var startInfo = new ProcessStartInfo("wsl.exe")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = false,
+                WindowStyle = ProcessWindowStyle.Normal
+            };
+            startInfo.ArgumentList.Add("-d");
+            startInfo.ArgumentList.Add(distro);
+            startInfo.ArgumentList.Add("--");
+            startInfo.ArgumentList.Add("bash");
+            startInfo.ArgumentList.Add("-lc");
+            startInfo.ArgumentList.Add(bashCommand);
+
+            GuiLog.Info($"[backend-autostart] launching WSL distro='{distro}' mode='{mode}' condaEnv='{envName}' venv='{venvPath}' models='{modelsDir ?? "<default>"}' repo='{repoRoot}' port={port}.");
+            Process.Start(startInfo);
+        }
+
+        private static bool IsSupportedWslMode(string mode)
+            => string.Equals(mode, "WslVenv", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(mode, "WslConda", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(mode, "WslAuto", StringComparison.OrdinalIgnoreCase);
+
+        private static string BuildActivationCommand(string mode, string envName, string venvPath)
+        {
+            if (string.Equals(mode, "WslVenv", StringComparison.OrdinalIgnoreCase))
+            {
+                return "if [ -f " + BashQuote(venvPath + "/bin/activate") + " ]; then " +
+                       ". " + BashQuote(venvPath + "/bin/activate") + "; " +
+                       "echo '[bdi] Python venv:' " + BashQuote(venvPath) + "; " +
+                       "else echo '[bdi] Python venv not found: " + BashEscapeForSingleQuotedEcho(venvPath) + "' >&2; exit 1; fi; ";
+            }
+
+            var condaSetup =
+                "if command -v conda >/dev/null 2>&1; then eval \"$(conda shell.bash hook)\"; " +
+                "elif [ -f \"$HOME/miniconda3/etc/profile.d/conda.sh\" ]; then . \"$HOME/miniconda3/etc/profile.d/conda.sh\"; " +
+                "elif [ -f \"$HOME/anaconda3/etc/profile.d/conda.sh\" ]; then . \"$HOME/anaconda3/etc/profile.d/conda.sh\"; fi; ";
+
+            if (string.Equals(mode, "WslAuto", StringComparison.OrdinalIgnoreCase))
+            {
+                return "if [ -f " + BashQuote(venvPath + "/bin/activate") + " ]; then " +
+                       ". " + BashQuote(venvPath + "/bin/activate") + "; " +
+                       "echo '[bdi] Python venv:' " + BashQuote(venvPath) + "; " +
+                       "else " + condaSetup +
+                       "if command -v conda >/dev/null 2>&1; then conda activate " + BashQuote(envName) + "; echo '[bdi] Conda env:' \"$CONDA_DEFAULT_ENV\"; " +
+                       "else echo '[bdi] neither venv nor conda is available.' >&2; exit 1; fi; fi; ";
+            }
+
+            return condaSetup +
+                   "if command -v conda >/dev/null 2>&1; then conda activate " + BashQuote(envName) + "; echo '[bdi] Conda env:' \"$CONDA_DEFAULT_ENV\"; " +
+                   "elif [ -f " + BashQuote(venvPath + "/bin/activate") + " ]; then echo '[bdi] conda not found; falling back to venv:' " + BashQuote(venvPath) + "; . " + BashQuote(venvPath + "/bin/activate") + "; " +
+                   "else echo '[bdi] conda not found and fallback venv missing: " + BashEscapeForSingleQuotedEcho(venvPath) + "' >&2; exit 1; fi; ";
+        }
+
+        private static string BuildModelsDirectoryCommand(string? modelsDir)
+        {
+            if (string.IsNullOrWhiteSpace(modelsDir))
+            {
+                return string.Empty;
+            }
+
+            return "export BDI_MODELS_DIR=" + BashQuote(modelsDir) + "; " +
+                   "echo '[bdi] BDI_MODELS_DIR:' \"$BDI_MODELS_DIR\"; ";
+        }
+
+        private static async Task<bool> WaitUntilHealthyAsync(string baseUrl, TimeSpan timeout, CancellationToken ct)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (await IsHealthyAsync(baseUrl, ct).ConfigureAwait(false))
+                {
+                    return true;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1), ct).ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
+        private static async Task<bool> IsHealthyAsync(string baseUrl, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+                var url = baseUrl.TrimEnd('/') + "/health";
+                using var response = await client.GetAsync(url, ct).ConfigureAwait(false);
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string? ResolveRepoRoot(string? configuredWorkingDirectory)
+        {
+            if (!string.IsNullOrWhiteSpace(configuredWorkingDirectory))
+            {
+                var expanded = Environment.ExpandEnvironmentVariables(configuredWorkingDirectory.Trim());
+                if (expanded.StartsWith("/", StringComparison.Ordinal))
+                {
+                    return expanded;
+                }
+
+                if (Directory.Exists(expanded))
+                {
+                    return Path.GetFullPath(expanded);
+                }
+            }
+
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+            while (current != null)
+            {
+                if (File.Exists(Path.Combine(current.FullName, "backend", "app.py")))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+
+            return null;
+        }
+
+        private static string ToWslPath(string path)
+        {
+            if (path.StartsWith("/", StringComparison.Ordinal))
+            {
+                return path;
+            }
+
+            var fullPath = Path.GetFullPath(path);
+            var root = Path.GetPathRoot(fullPath);
+            if (!string.IsNullOrWhiteSpace(root) && root.Length >= 2 && root[1] == ':')
+            {
+                var drive = char.ToLowerInvariant(root[0]);
+                var rest = fullPath[root.Length..].Replace('\\', '/');
+                return "/mnt/" + drive + "/" + rest;
+            }
+
+            return fullPath.Replace('\\', '/');
+        }
+
+        private static string? ResolveWslPath(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            return ToWslPath(Environment.ExpandEnvironmentVariables(path.Trim()));
+        }
+
+        private static string BashQuote(string value)
+            => "'" + (value ?? string.Empty).Replace("'", "'\"'\"'") + "'";
+
+        private static string BashEscapeForSingleQuotedEcho(string value)
+            => (value ?? string.Empty).Replace("'", "'\"'\"'");
+
+        private static int? TryGetPort(string baseUrl)
+        {
+            if (Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) && uri.Port > 0)
+            {
+                return uri.Port;
+            }
+
+            return null;
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettings.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettings.cs
@@ -7,6 +7,7 @@ namespace BrakeDiscInspector_GUI_ROI.Services
         public string? Theme { get; set; }
         public Dictionary<string, string>? FontFamilies { get; set; }
         public Dictionary<string, double>? FontSizes { get; set; }
+        public bool CustomColorsEnabled { get; set; }
         public Dictionary<string, string>? Brushes { get; set; }
         public string? Accent { get; set; }
     }

--- a/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Services/GuiSetupSettingsService.cs
@@ -12,8 +12,10 @@ namespace BrakeDiscInspector_GUI_ROI.Services
 {
     public static class GuiSetupSettingsService
     {
+        private const string AppBackgroundBrushKey = "BrushAppBackground";
         private const string AccentBrushKey = "UI.Brush.Accent";
         private const string AccentColorKey = "UI.Color.Accent";
+        private const string DefaultAccentColor = "#FF39FF14";
 
         private static readonly string[] FontFamilyKeys =
         {
@@ -41,6 +43,36 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             "UI.Brush.ButtonBackgroundHover",
             "UI.Brush.GroupHeaderForeground"
         };
+
+        private static readonly IReadOnlyDictionary<string, string> LightThemeBrushes =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [AppBackgroundBrushKey] = "#FFF3F3F3",
+                ["UI.Brush.Foreground"] = "#FF111827",
+                ["UI.Brush.Surface"] = "#FFFFFFFF",
+                ["UI.Brush.ControlBackground"] = "#FFFFFFFF",
+                ["UI.Brush.ControlBackgroundHover"] = "#FFF3F4F6",
+                ["UI.Brush.ControlBorder"] = "#FFB8C0CC",
+                ["UI.Brush.ButtonForeground"] = "#FF111827",
+                ["UI.Brush.ButtonBackground"] = "#FFE5E5E5",
+                ["UI.Brush.ButtonBackgroundHover"] = "#FFD5D5D5",
+                ["UI.Brush.GroupHeaderForeground"] = "#FF111827"
+            };
+
+        private static readonly IReadOnlyDictionary<string, string> DarkThemeBrushes =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [AppBackgroundBrushKey] = "#FF1E1F22",
+                ["UI.Brush.Foreground"] = "#FFF4F4F5",
+                ["UI.Brush.Surface"] = "#FF25272C",
+                ["UI.Brush.ControlBackground"] = "#FF2B2D31",
+                ["UI.Brush.ControlBackgroundHover"] = "#FF383B42",
+                ["UI.Brush.ControlBorder"] = "#FF545861",
+                ["UI.Brush.ButtonForeground"] = "#FFF4F4F5",
+                ["UI.Brush.ButtonBackground"] = "#FF2B2D31",
+                ["UI.Brush.ButtonBackgroundHover"] = "#FF383B42",
+                ["UI.Brush.GroupHeaderForeground"] = "#FFF4F4F5"
+            };
 
         // Stored at %LOCALAPPDATA%\BrakeDiscInspector\gui_setup.json for easy diagnostics.
         public static string ConfigPath => Path.Combine(
@@ -120,11 +152,15 @@ namespace BrakeDiscInspector_GUI_ROI.Services
         }
 
         public static GuiSetupSettings CaptureCurrent(Window? window)
+            => CaptureCurrent(window, includeCustomColors: false);
+
+        public static GuiSetupSettings CaptureCurrent(Window? window, bool includeCustomColors)
         {
-            Log("[CAPTURE] start");
+            Log($"[CAPTURE] start includeCustomColors={includeCustomColors}");
             var settings = new GuiSetupSettings
             {
-                Theme = Settings.Default.ThemePreference
+                Theme = Settings.Default.ThemePreference,
+                CustomColorsEnabled = includeCustomColors
             };
 
             var fontFamilies = new Dictionary<string, string>();
@@ -177,63 +213,98 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                 settings.FontSizes = fontSizes;
             }
 
-            var brushes = new Dictionary<string, string>();
-            foreach (var key in BrushKeys)
+            if (includeCustomColors)
             {
-                if (TryGetEffectiveResource(window, key, out var value, out var source))
+                var brushes = new Dictionary<string, string>();
+                foreach (var key in BrushKeys)
                 {
-                    if (value is SolidColorBrush brush)
+                    if (TryGetEffectiveResource(window, key, out var value, out var source))
                     {
-                        brushes[key] = brush.Color.ToString();
-                        LogCapture(key, source, brush.Color.ToString());
-                    }
-                    else if (value is Color color)
-                    {
-                        brushes[key] = color.ToString();
-                        LogCapture(key, source, color.ToString());
+                        if (value is SolidColorBrush brush)
+                        {
+                            brushes[key] = brush.Color.ToString();
+                            LogCapture(key, source, brush.Color.ToString());
+                        }
+                        else if (value is Color color)
+                        {
+                            brushes[key] = color.ToString();
+                            LogCapture(key, source, color.ToString());
+                        }
+                        else
+                        {
+                            LogCapture(key, source, value);
+                        }
                     }
                     else
                     {
                         LogCapture(key, source, value);
                     }
                 }
+
+                if (brushes.Count > 0)
+                {
+                    settings.Brushes = brushes;
+                }
+
+                if (TryGetEffectiveResource(window, AccentColorKey, out var accentValue, out var accentSource)
+                    && accentValue is Color accentColor)
+                {
+                    settings.Accent = accentColor.ToString();
+                    LogCapture(AccentColorKey, accentSource, accentColor.ToString());
+                }
+                else if (TryGetEffectiveResource(window, AccentBrushKey, out var accentBrush, out var accentBrushSource)
+                         && accentBrush is SolidColorBrush accent)
+                {
+                    settings.Accent = accent.Color.ToString();
+                    LogCapture(AccentBrushKey, accentBrushSource, accent.Color.ToString());
+                }
+                else if (settings.Brushes != null && settings.Brushes.TryGetValue(AccentBrushKey, out var accentHex))
+                {
+                    settings.Accent = accentHex;
+                    LogCapture(AccentBrushKey, "Snapshot", accentHex);
+                }
                 else
                 {
-                    LogCapture(key, source, value);
+                    LogCapture(AccentBrushKey, "fallback", null);
                 }
-            }
-
-            if (brushes.Count > 0)
-            {
-                settings.Brushes = brushes;
-            }
-
-            if (TryGetEffectiveResource(window, AccentColorKey, out var accentValue, out var accentSource)
-                && accentValue is Color accentColor)
-            {
-                settings.Accent = accentColor.ToString();
-                LogCapture(AccentColorKey, accentSource, accentColor.ToString());
-            }
-            else if (TryGetEffectiveResource(window, AccentBrushKey, out var accentBrush, out var accentBrushSource)
-                     && accentBrush is SolidColorBrush accent)
-            {
-                settings.Accent = accent.Color.ToString();
-                LogCapture(AccentBrushKey, accentBrushSource, accent.Color.ToString());
-            }
-            else if (settings.Brushes != null && settings.Brushes.TryGetValue(AccentBrushKey, out var accentHex))
-            {
-                settings.Accent = accentHex;
-                LogCapture(AccentBrushKey, "Snapshot", accentHex);
-            }
-            else
-            {
-                LogCapture(AccentBrushKey, "fallback", null);
             }
 
             return settings;
         }
 
-        public static void Apply(GuiSetupSettings settings)
+        public static void ApplyThemeBrushes(string? preference, Window? window = null)
+        {
+            if (Application.Current == null && window == null)
+            {
+                return;
+            }
+
+            var themeName = ResolveThemeName(preference);
+            var palette = themeName.Equals("Dark", StringComparison.OrdinalIgnoreCase)
+                ? DarkThemeBrushes
+                : LightThemeBrushes;
+
+            var updatedKeys = new List<string>();
+            foreach (var pair in palette)
+            {
+                if (TryParseColor(pair.Value, out var color))
+                {
+                    SetBrushResource(pair.Key, color, window);
+                    updatedKeys.Add(pair.Key);
+                }
+            }
+
+            if (TryParseColor(DefaultAccentColor, out var accentColor))
+            {
+                SetAccentResources(accentColor, window);
+                updatedKeys.Add(AccentColorKey);
+                updatedKeys.Add(AccentBrushKey);
+            }
+
+            Log($"[APPLY_THEME] theme={themeName} keys=[{string.Join(", ", updatedKeys)}]");
+        }
+
+        public static void Apply(GuiSetupSettings settings, Window? window = null)
         {
             if (settings == null || Application.Current == null)
             {
@@ -247,7 +318,7 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                 {
                     if (!string.IsNullOrWhiteSpace(pair.Value))
                     {
-                        SetResourceValue(pair.Key, new FontFamily(pair.Value));
+                        SetResourceValue(pair.Key, new FontFamily(pair.Value), window);
                         updatedKeys.Add(pair.Key);
                     }
                 }
@@ -257,12 +328,12 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             {
                 foreach (var pair in settings.FontSizes)
                 {
-                    SetResourceValue(pair.Key, pair.Value);
+                    SetResourceValue(pair.Key, pair.Value, window);
                     updatedKeys.Add(pair.Key);
                 }
             }
 
-            if (settings.Brushes != null)
+            if (settings.CustomColorsEnabled && settings.Brushes != null)
             {
                 foreach (var pair in settings.Brushes)
                 {
@@ -270,22 +341,24 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                     {
                         if (string.Equals(pair.Key, AccentBrushKey, StringComparison.OrdinalIgnoreCase))
                         {
-                            SetAccentResources(color);
+                            SetAccentResources(color, window);
                             updatedKeys.Add(AccentColorKey);
                             updatedKeys.Add(pair.Key);
                         }
                         else
                         {
-                            SetBrushResource(pair.Key, color);
+                            SetBrushResource(pair.Key, color, window);
                             updatedKeys.Add(pair.Key);
                         }
                     }
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.Accent) && TryParseColor(settings.Accent, out var accentColor))
+            if (settings.CustomColorsEnabled
+                && !string.IsNullOrWhiteSpace(settings.Accent)
+                && TryParseColor(settings.Accent, out var accentColor))
             {
-                SetAccentResources(accentColor);
+                SetAccentResources(accentColor, window);
                 updatedKeys.Add(AccentColorKey);
                 updatedKeys.Add(AccentBrushKey);
             }
@@ -335,7 +408,7 @@ namespace BrakeDiscInspector_GUI_ROI.Services
             return false;
         }
 
-        private static void SetBrushResource(string key, Color color)
+        private static void SetBrushResource(string key, Color color, Window? window = null)
         {
             var brush = new SolidColorBrush(color);
             if (brush.CanFreeze)
@@ -343,25 +416,36 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                 brush.Freeze();
             }
 
-            SetResourceValue(key, brush);
+            SetResourceValue(key, brush, window);
         }
 
-        private static void SetAccentResources(Color color)
+        private static void SetAccentResources(Color color, Window? window = null)
         {
-            SetResourceValue(AccentColorKey, color);
-            SetBrushResource(AccentBrushKey, color);
+            SetResourceValue(AccentColorKey, color, window);
+            SetBrushResource(AccentBrushKey, color, window);
         }
 
-        private static void SetResourceValue(string key, object value)
+        private static void SetResourceValue(string key, object value, Window? window = null)
         {
-            if (Application.Current.Resources.Contains(key))
+            if (Application.Current != null)
             {
                 Application.Current.Resources[key] = value;
             }
-            else
+
+            if (window != null && window.Resources.Contains(key))
             {
-                Application.Current.Resources[key] = value;
+                window.Resources[key] = value;
             }
+        }
+
+        private static string ResolveThemeName(string? preference)
+        {
+            if (string.Equals(preference, "Dark", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Dark";
+            }
+
+            return "Light";
         }
 
         private static bool TryParseColor(string value, out Color color)
@@ -435,6 +519,8 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                 parts.Add($"theme={settings.Theme}");
             }
 
+            parts.Add($"customColors={settings.CustomColorsEnabled}");
+
             if (TryGetFontSize(settings, "UI.FontSize.WindowTitle", out var titleSize))
             {
                 parts.Add($"title={titleSize.ToString("0.#", CultureInfo.InvariantCulture)}");
@@ -450,17 +536,17 @@ namespace BrakeDiscInspector_GUI_ROI.Services
                 parts.Add($"button={buttonText.ToString("0.#", CultureInfo.InvariantCulture)}");
             }
 
-            if (TryGetBrush(settings, "UI.Brush.Foreground", out var foreground))
+            if (settings.CustomColorsEnabled && TryGetBrush(settings, "UI.Brush.Foreground", out var foreground))
             {
                 parts.Add($"fg={foreground}");
             }
 
-            if (TryGetBrush(settings, "UI.Brush.ButtonBackground", out var buttonBg))
+            if (settings.CustomColorsEnabled && TryGetBrush(settings, "UI.Brush.ButtonBackground", out var buttonBg))
             {
                 parts.Add($"btnBg={buttonBg}");
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.Accent))
+            if (settings.CustomColorsEnabled && !string.IsNullOrWhiteSpace(settings.Accent))
             {
                 parts.Add($"accent={settings.Accent}");
             }

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/Controls.xaml
@@ -4,19 +4,98 @@
     <Thickness x:Key="SpacingThickness">8</Thickness>
     <CornerRadius x:Key="CardCornerRadius">10</CornerRadius>
 
+    <ControlTemplate x:Key="ThemedUiButtonTemplate" TargetType="{x:Type ui:Button}">
+        <Border x:Name="ButtonRoot"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="6"
+                SnapsToDevicePixels="True">
+            <ContentPresenter Margin="{TemplateBinding Padding}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              RecognizesAccessKey="True"
+                              TextElement.Foreground="{TemplateBinding Foreground}" />
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
+                <Setter TargetName="ButtonRoot" Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.Accent}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="ButtonRoot" Property="Opacity" Value="0.45" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ThemedButtonTemplate" TargetType="{x:Type Button}">
+        <Border x:Name="ButtonRoot"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="6"
+                SnapsToDevicePixels="True">
+            <ContentPresenter Margin="{TemplateBinding Padding}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              RecognizesAccessKey="True"
+                              TextElement.Foreground="{TemplateBinding Foreground}" />
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
+                <Setter TargetName="ButtonRoot" Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter TargetName="ButtonRoot" Property="Background" Value="{DynamicResource UI.Brush.Accent}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter TargetName="ButtonRoot" Property="Opacity" Value="0.45" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style TargetType="{x:Type Button}">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template" Value="{StaticResource ThemedButtonTemplate}" />
+    </Style>
+
+    <Style TargetType="{x:Type ui:Button}">
+        <Setter Property="Appearance" Value="Secondary" />
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
+    </Style>
+
     <Style x:Key="IconTextButtonStyle" TargetType="{x:Type ui:Button}">
         <Setter Property="Height" Value="40" />
         <Setter Property="Padding" Value="12,6" />
         <Setter Property="Margin" Value="0,0,8,8" />
         <Setter Property="Appearance" Value="Secondary" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
         <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
         <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Body}" />
         <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.ButtonText}" />
         <Setter Property="Effect" Value="{x:Null}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
         <Setter Property="ToolTipService.ShowDuration" Value="30000" />
         <Setter Property="ContentTemplate">
             <Setter.Value>
@@ -48,10 +127,13 @@
         <Setter Property="Margin" Value="8,0,0,0" />
         <Setter Property="Appearance" Value="Secondary" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
         <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
         <Setter Property="Effect" Value="{x:Null}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
         <Setter Property="ToolTipService.ShowDuration" Value="30000" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
@@ -77,13 +159,16 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.ButtonForeground}" />
         <Setter Property="Effect" Value="{x:Null}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template" Value="{StaticResource ThemedUiButtonTemplate}" />
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="Margin" Value="0,0,0,8" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
                 <Setter Property="Effect">
                     <Setter.Value>
                         <DropShadowEffect ShadowDepth="0" BlurRadius="12" Opacity="0.25"
@@ -94,11 +179,119 @@
         </Style.Triggers>
     </Style>
 
+    <Style TargetType="TextBox">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CaretBrush" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource UI.Brush.Accent}" />
+        <Setter Property="SelectionOpacity" Value="0.35" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
+    <Style TargetType="ComboBox">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
+    <Style TargetType="ComboBoxItem">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="Padding" Value="6,4" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ListBox">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+    </Style>
+
+    <Style TargetType="ListView">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+    </Style>
+
+    <Style TargetType="ListBoxItem">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="Padding" Value="4,2" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="ListViewItem" BasedOn="{StaticResource {x:Type ListBoxItem}}" />
+
+    <Style TargetType="TabControl">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.Surface}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+    </Style>
+
+    <Style TargetType="TabItem">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="Padding" Value="10,5" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.ButtonBackgroundHover}" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Background" Value="{DynamicResource UI.Brush.Surface}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="DataGrid">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="GridLinesVisibility" Value="Horizontal" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+        <Setter Property="RowBackground" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="AlternatingRowBackground" Value="{DynamicResource UI.Brush.ControlBackgroundHover}" />
+    </Style>
+
+    <Style TargetType="DataGridCell">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+    </Style>
+
+    <Style TargetType="DataGridColumnHeader">
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.Surface}" />
+        <Setter Property="Foreground" Value="{DynamicResource UI.Brush.Foreground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
+    </Style>
+
     <Style x:Key="CardGroupBoxStyle" TargetType="GroupBox">
         <Setter Property="Margin" Value="0,0,0,12" />
         <Setter Property="Padding" Value="12" />
-        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
-        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.Surface}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource UI.Brush.ControlBorder}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontFamily" Value="{DynamicResource UI.FontFamily.Header}" />
         <Setter Property="FontSize" Value="{DynamicResource UI.FontSize.GroupHeader}" />
@@ -128,7 +321,7 @@
     </Style>
 
     <Style TargetType="GridSplitter" x:Key="PanelGridSplitterStyle">
-        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}" />
+        <Setter Property="Background" Value="{DynamicResource UI.Brush.ControlBorder}" />
         <Setter Property="Width" Value="6" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
     </Style>

--- a/gui/BrakeDiscInspector_GUI_ROI/Styles/GuiTokens.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Styles/GuiTokens.xaml
@@ -13,6 +13,10 @@
     <sys:Double x:Key="UI.FontSize.CheckBox">13</sys:Double>
 
     <SolidColorBrush x:Key="UI.Brush.Foreground" Color="Black" />
+    <SolidColorBrush x:Key="UI.Brush.Surface" Color="White" />
+    <SolidColorBrush x:Key="UI.Brush.ControlBackground" Color="White" />
+    <SolidColorBrush x:Key="UI.Brush.ControlBackgroundHover" Color="#FFF3F4F6" />
+    <SolidColorBrush x:Key="UI.Brush.ControlBorder" Color="#FFB8C0CC" />
     <SolidColorBrush x:Key="UI.Brush.ButtonForeground" Color="Black" />
     <SolidColorBrush x:Key="UI.Brush.ButtonBackground" Color="#FFE5E5E5" />
     <SolidColorBrush x:Key="UI.Brush.ButtonBackgroundHover" Color="#FFD5D5D5" />

--- a/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Views/BusyProgressWindow.xaml
@@ -12,7 +12,7 @@
         Topmost="True">
 
     <Border CornerRadius="12"
-            Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
+            Background="{DynamicResource UI.Brush.Surface}"
             Padding="22"
             SnapsToDevicePixels="True">
         <Border.Effect>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowControl.xaml
@@ -16,7 +16,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10" Orientation="Vertical">
             <StackPanel.Resources>
-                <Style TargetType="GroupBox">
+                <Style TargetType="GroupBox" BasedOn="{StaticResource CardGroupBoxStyle}">
                     <Setter Property="Margin" Value="0,0,0,12"/>
                 </Style>
             </StackPanel.Resources>

--- a/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Workflow/WorkflowViewModel.cs
@@ -23,7 +23,6 @@ using BrakeDiscInspector_GUI_ROI.Helpers;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using BrakeDiscInspector_GUI_ROI;
-using BrakeDiscInspector_GUI_ROI.Helpers;
 using BrakeDiscInspector_GUI_ROI.Util;
 using BrakeDiscInspector_GUI_ROI.Imaging;
 using BrakeDiscInspector_GUI_ROI.Models;
@@ -264,6 +263,8 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
         private readonly RoiModel?[] _batchBaselineRois = new RoiModel?[4];
         private Mat? _cachedM1Pattern;
         private Mat? _cachedM2Pattern;
+        private LocalMatcher.TemplateVariantSet? _cachedM1PatternVariants;
+        private LocalMatcher.TemplateVariantSet? _cachedM2PatternVariants;
         private string? _cachedM1PatternPath;
         private string? _cachedM2PatternPath;
         private DateTime? _cachedM1PatternLastWriteUtc;
@@ -593,7 +594,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             TrainSelectedRoiCommand = CreateCommand(async _ => await TrainSelectedRoiWithValidationAsync().ConfigureAwait(false), _ => !IsBusy && SelectedInspectionRoi != null);
             CalibrateSelectedRoiCommand = CreateCommand(async _ => await CalibrateSelectedRoiWithValidationAsync().ConfigureAwait(false), _ => !IsBusy && SelectedInspectionRoi != null);
             EvaluateSelectedRoiCommand = CreateCommand(_ => EvaluateSelectedRoiAsync(), _ => !IsBusy && SelectedInspectionRoi != null && SelectedInspectionRoi.Enabled);
-            var inferEnabledCommand = CreateCommand(_ => InferEnabledRoisAsync(), _ => !IsBusy && HasAnyEnabledInspectionRoi());
+            var inferEnabledCommand = CreateCommand(_ => InferEnabledRoisAsync(CancellationToken.None), _ => !IsBusy && HasAnyEnabledInspectionRoi());
             EvaluateAllRoisCommand = inferEnabledCommand;
             InferEnabledRoisCommand = inferEnabledCommand;
 
@@ -1526,6 +1527,31 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             InvokeOnUi(RedrawOverlays);
             EvaluateAllRoisCommand.RaiseCanExecuteChanged();
             UpdateGlobalBadge();
+        }
+
+        public async Task RefreshInspectionDatasetsAsync(string reason = "")
+        {
+            var rois = _inspectionRois?.ToList() ?? new List<InspectionRoiConfig>();
+            if (rois.Count == 0)
+            {
+                _log($"[dataset] refresh all skipped: no inspection ROIs reason='{reason}'");
+                return;
+            }
+
+            _roiDatasetCache.Clear();
+            _log($"[dataset] refresh all start reason='{reason}' layout='{CurrentLayoutName}' count={rois.Count}");
+
+            foreach (var roi in rois)
+            {
+                await RefreshRoiDatasetStateAsync(roi).ConfigureAwait(false);
+            }
+
+            if (SelectedInspectionRoi != null)
+            {
+                await RefreshDatasetAsync().ConfigureAwait(false);
+            }
+
+            _log($"[dataset] refresh all done reason='{reason}' layout='{CurrentLayoutName}'");
         }
 
         public Task InitializeAsync(CancellationToken ct = default)
@@ -5051,7 +5077,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             await EvaluateRoiAsync(roiCfg, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private async Task InferEnabledRoisAsync()
+        private async Task InferEnabledRoisAsync(CancellationToken ct)
         {
             if (_inspectionRois == null)
             {
@@ -5060,15 +5086,22 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
             foreach (var roi in _inspectionRois.Where(r => r.Enabled))
             {
-                await EvaluateRoiAsync(roi, CancellationToken.None).ConfigureAwait(false);
+                ct.ThrowIfCancellationRequested();
+                await EvaluateRoiAsync(roi, ct).ConfigureAwait(false);
             }
 
             UpdateGlobalBadge();
         }
 
+        public async Task<bool?> EvaluateEnabledRoisForAutomationAsync(CancellationToken ct = default)
+        {
+            await InferEnabledRoisAsync(ct).ConfigureAwait(false);
+            return CalcGlobalDiskOk();
+        }
+
         private async Task EvaluateAllRoisAsync()
         {
-            await InferEnabledRoisAsync().ConfigureAwait(false);
+            await InferEnabledRoisAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task EvaluateRoiAsync(InspectionRoiConfig? roi, CancellationToken ct)
@@ -6241,7 +6274,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             await TryUpdateBatchAnchorsForImageAsync(mat, imagePath, ct).ConfigureAwait(false);
         }
 
-        private Task<bool> TryUpdateBatchAnchorsForImageAsync(Mat imageGray, string imagePath, CancellationToken ct)
+        private async Task<bool> TryUpdateBatchAnchorsForImageAsync(Mat imageGray, string imagePath, CancellationToken ct)
         {
             _batchAnchorsOk = false;
             _batchAnchorM1Ready = false;
@@ -6262,23 +6295,24 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             if (string.IsNullOrWhiteSpace(imagePath))
             {
                 GuiLog.Warn("[batch] match: missing image path");
-                return Task.FromResult(false);
+                return false;
             }
 
-            if (_layoutOriginal == null)
+            var layoutOriginal = _layoutOriginal;
+            if (layoutOriginal == null)
             {
                 GuiLog.Warn("[batch] match: no layout loaded; anchors cannot be computed");
-                return Task.FromResult(false);
+                return false;
             }
 
-            if (_layoutOriginal.Master1Pattern == null || _layoutOriginal.Master2Pattern == null
-                || _layoutOriginal.Master1Search == null || _layoutOriginal.Master2Search == null)
+            if (layoutOriginal.Master1Pattern == null || layoutOriginal.Master2Pattern == null
+                || layoutOriginal.Master1Search == null || layoutOriginal.Master2Search == null)
             {
                 GuiLog.Warn("[batch] match: master ROIs are missing (pattern/search)");
-                return Task.FromResult(false);
+                return false;
             }
 
-            var analyze = _layoutOriginal.Analyze ?? new AnalyzeOptions();
+            var analyze = layoutOriginal.Analyze ?? new AnalyzeOptions();
             var featureM1 = GetBatchFeatureM1();
             var featureM2 = GetBatchFeatureM2();
             var thrM1 = GetBatchThrM1();
@@ -6294,11 +6328,11 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             if (imageGray == null || imageGray.Empty())
             {
                 GuiLog.Warn($"[batch] match: image '{fileName}' could not be loaded for anchors");
-                return Task.FromResult(false);
+                return false;
             }
 
-            var pattern1 = GetOrLoadPatternCached(_layoutOriginal.Master1PatternImagePath, "M1");
-            var pattern2 = GetOrLoadPatternCached(_layoutOriginal.Master2PatternImagePath, "M2");
+            var pattern1 = GetOrLoadPatternCached(layoutOriginal.Master1PatternImagePath, "M1");
+            var pattern2 = GetOrLoadPatternCached(layoutOriginal.Master2PatternImagePath, "M2");
 
             if (pattern1 == null || pattern2 == null)
             {
@@ -6307,7 +6341,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 {
                     GuiLog.Warn("[batch] match: missing reference patterns for M1/M2");
                 }
-                return Task.FromResult(false);
+                return false;
             }
 
             LogPatternConfig(
@@ -6324,10 +6358,13 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 scaleLock,
                 disableRot);
 
-            var m1Result = LocalMatcher.MatchInSearchROIWithDetailsGray(
+            var m1Variants = GetOrBuildPatternVariants(pattern1, analyze.RotRange, analyze.ScaleMin, analyze.ScaleMax, "M1");
+            var m2Variants = GetOrBuildPatternVariants(pattern2, analyze.RotRange, analyze.ScaleMin, analyze.ScaleMax, "M2");
+
+            var m1Task = Task.Run(() => LocalMatcher.MatchInSearchROIWithDetailsGray(
                 imageGray,
-                _layoutOriginal.Master1Pattern,
-                _layoutOriginal.Master1Search,
+                layoutOriginal.Master1Pattern,
+                layoutOriginal.Master1Search,
                 featureM1,
                 thrM1,
                 analyze.RotRange,
@@ -6335,12 +6372,13 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 analyze.ScaleMax,
                 pattern1,
                 PatternLog,
-                "M1");
+                "M1",
+                m1Variants), ct);
 
-            var m2Result = LocalMatcher.MatchInSearchROIWithDetailsGray(
+            var m2Task = Task.Run(() => LocalMatcher.MatchInSearchROIWithDetailsGray(
                 imageGray,
-                _layoutOriginal.Master2Pattern,
-                _layoutOriginal.Master2Search,
+                layoutOriginal.Master2Pattern,
+                layoutOriginal.Master2Search,
                 featureM2,
                 thrM2,
                 analyze.RotRange,
@@ -6348,7 +6386,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 analyze.ScaleMax,
                 pattern2,
                 PatternLog,
-                "M2");
+                "M2",
+                m2Variants), ct);
+
+            await Task.WhenAll(m1Task, m2Task).ConfigureAwait(false);
+            var m1Result = m1Task.Result;
+            var m2Result = m2Task.Result;
 
             var acceptedFinal = m1Result.Score >= thrM1 && m2Result.Score >= thrM2;
             LogPatternSummary("M1", featureM1, thrM1, m1Result, acceptedFinal);
@@ -6381,14 +6424,14 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 GuiLog.Warn(FormattableString.Invariant(
                     $"[batch] match: anchors not found for file='{fileName}' (M1={_m1Detection.IsOk} M2={_m2Detection.IsOk})"));
                 _log?.Invoke("[batch] Anclajes no detectados (Master1 o Master2). Se omite reposicionamiento de ROIs.");
-                return Task.FromResult(false);
+                return false;
             }
 
             TraceBatch(FormattableString.Invariant(
                 $"[batch] match: M1=({_m1Detection.Center.Value.X:0.0},{_m1Detection.Center.Value.Y:0.0}) score={_m1Detection.Score:0.00}  M2=({_m2Detection.Center.Value.X:0.0},{_m2Detection.Center.Value.Y:0.0}) score={_m2Detection.Score:0.00}"));
 
-            var m1Base = _layoutOriginal.Master1Pattern.GetCenter();
-            var m2Base = _layoutOriginal.Master2Pattern.GetCenter();
+            var m1Base = layoutOriginal.Master1Pattern.GetCenter();
+            var m2Base = layoutOriginal.Master2Pattern.GetCenter();
 
             RegisterBatchAnchors(
                 new Point(m1Base.cx, m1Base.cy),
@@ -6415,7 +6458,7 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             _batchAnchorsOk = AnchorsMeetThreshold();
             GuiLog.Info(FormattableString.Invariant(
                 $"[batch] match: M1 score={_m1Detection.Score:0.0} M2 score={_m2Detection.Score:0.0} anchorsOk={_batchAnchorsOk}"));
-            return Task.FromResult(_batchAnchorsOk);
+            return _batchAnchorsOk;
         }
 
         private void InvalidateMasterPatternCache()
@@ -6424,8 +6467,12 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
             {
                 _cachedM1Pattern?.Dispose();
                 _cachedM2Pattern?.Dispose();
+                _cachedM1PatternVariants?.Dispose();
+                _cachedM2PatternVariants?.Dispose();
                 _cachedM1Pattern = null;
                 _cachedM2Pattern = null;
+                _cachedM1PatternVariants = null;
+                _cachedM2PatternVariants = null;
                 _cachedM1PatternPath = null;
                 _cachedM2PatternPath = null;
                 _cachedM1PatternLastWriteUtc = null;
@@ -6444,7 +6491,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 if (role == RoiRole.Master1Pattern || role == RoiRole.Master1Search)
                 {
                     _cachedM1Pattern?.Dispose();
+                    _cachedM1PatternVariants?.Dispose();
                     _cachedM1Pattern = null;
+                    _cachedM1PatternVariants = null;
                     _cachedM1PatternPath = null;
                     _cachedM1PatternLastWriteUtc = null;
                     _cachedM1PatternSize = null;
@@ -6456,7 +6505,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                 if (role == RoiRole.Master2Pattern || role == RoiRole.Master2Search)
                 {
                     _cachedM2Pattern?.Dispose();
+                    _cachedM2PatternVariants?.Dispose();
                     _cachedM2Pattern = null;
+                    _cachedM2PatternVariants = null;
                     _cachedM2PatternPath = null;
                     _cachedM2PatternLastWriteUtc = null;
                     _cachedM2PatternSize = null;
@@ -6528,13 +6579,17 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     cachedMat.Dispose();
                     if (isM1)
                     {
+                        _cachedM1PatternVariants?.Dispose();
                         _cachedM1Pattern = null;
+                        _cachedM1PatternVariants = null;
                         _cachedM1PatternLastWriteUtc = null;
                         _cachedM1PatternSize = null;
                     }
                     else
                     {
+                        _cachedM2PatternVariants?.Dispose();
                         _cachedM2Pattern = null;
+                        _cachedM2PatternVariants = null;
                         _cachedM2PatternLastWriteUtc = null;
                         _cachedM2PatternSize = null;
                     }
@@ -6558,7 +6613,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
 
                     if (isM1)
                     {
+                        _cachedM1PatternVariants?.Dispose();
                         _cachedM1Pattern = mat;
+                        _cachedM1PatternVariants = null;
                         _cachedM1PatternPath = effectivePath;
                         _cachedM1PatternLastWriteUtc = lastWriteUtc;
                         _cachedM1PatternSize = size;
@@ -6566,7 +6623,9 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     }
                     else
                     {
+                        _cachedM2PatternVariants?.Dispose();
                         _cachedM2Pattern = mat;
+                        _cachedM2PatternVariants = null;
                         _cachedM2PatternPath = effectivePath;
                         _cachedM2PatternLastWriteUtc = lastWriteUtc;
                         _cachedM2PatternSize = size;
@@ -6580,6 +6639,39 @@ namespace BrakeDiscInspector_GUI_ROI.Workflow
                     WarnMissingPatternOnce(tag, $"failed to load pattern: {ex.Message}");
                     return null;
                 }
+            }
+        }
+
+        private LocalMatcher.TemplateVariantSet? GetOrBuildPatternVariants(Mat? pattern, int rotRange, double scaleMin, double scaleMax, string tag)
+        {
+            if (pattern == null || pattern.Empty())
+            {
+                return null;
+            }
+
+            var isM1 = string.Equals(tag, "M1", StringComparison.OrdinalIgnoreCase);
+            lock (_masterPatternCacheLock)
+            {
+                var cached = isM1 ? _cachedM1PatternVariants : _cachedM2PatternVariants;
+                if (cached != null && cached.Matches(pattern, rotRange, scaleMin, scaleMax))
+                {
+                    _log($"[master-cache] variants hit tag={tag} count={cached.Count} rotRange={rotRange} scale=({scaleMin:0.###},{scaleMax:0.###})");
+                    return cached;
+                }
+
+                cached?.Dispose();
+                var built = LocalMatcher.BuildTemplateVariantSet(pattern, rotRange, scaleMin, scaleMax);
+                if (isM1)
+                {
+                    _cachedM1PatternVariants = built;
+                }
+                else
+                {
+                    _cachedM2PatternVariants = built;
+                }
+
+                _log($"[master-cache] variants build tag={tag} count={built.Count} rotRange={rotRange} scale=({scaleMin:0.###},{scaleMax:0.###})");
+                return built;
             }
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
+++ b/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
@@ -1,6 +1,16 @@
 {
   "Backend": {
-    "BaseUrl": "http://127.0.0.1:8000"
+    "BaseUrl": "http://127.0.0.1:8000",
+    "AutoStart": true,
+    "AutoStartMode": "WslVenv",
+    "WslDistro": "Ubuntu",
+    "WslCondaEnvironment": "BrakeDisc",
+    "WslVenvPath": "/home/millylinux/venv",
+    "AutoStartWorkingDirectory": "",
+    "AutoStartModelsDirectory": "/mnt/c/Users/corre/source/repos/Backend_BDI_V2/backend/models",
+    "AutoStartHost": "0.0.0.0",
+    "AutoStartPort": 8000,
+    "StartupTimeoutSeconds": 45
   },
   "Dataset": {
     "Root": ""
@@ -13,5 +23,25 @@
   },
   "UI": {
     "HeatmapOverlayOpacity": 0.6
+  },
+  "Comms": {
+    "Enabled": true,
+    "AutoConnectOnStartup": false,
+    "AutoRunInspectionOnTrigger": false,
+    "RequirePartPresent": true,
+    "Plc": {
+      "Mode": "Simulation",
+      "IpAddress": "192.168.0.10",
+      "Rack": 0,
+      "Slot": 1,
+      "DbNumber": 1,
+      "PollIntervalMs": 100
+    },
+    "Camera": {
+      "Provider": "Disabled",
+      "Source": "",
+      "OutputDirectory": "",
+      "TimeoutMs": 5000
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds the accumulated GUI workflow updates: backend auto-start, image thumbnail strip, heatmap/HUD visibility improvements, theme/setup color fixes, ROI rotation affordance, edit-mode feedback, and inspection ROI dataset locking.
- Adds/updates PLC and camera communication scaffolding for Siemens S7-1200, simulation PLC, Folder camera provider, and FLIR/Cognex placeholders.
- Updates CI with a Windows GUI test job and refreshes README, docs index, frontend, architecture, ROI/heatmap, comms, troubleshooting, deployment, logging, onboarding, changelog, and contributing docs.

## Validation
- `dotnet build gui\BrakeDiscInspector_GUI_ROI\BrakeDiscInspector_GUI_ROI.csproj -v:minimal`
- `dotnet test gui\BrakeDiscInspector_GUI_ROI.Tests\BrakeDiscInspector_GUI_ROI.Tests.csproj -v:minimal`
- `git diff --check`

## Notes
- `gh` CLI is not installed in this local environment, so the branch was pushed with `git` and this draft PR was created through the GitHub connector.
- Build still reports existing warnings around obsolete `BackendAPI` usage and unused legacy fields; there are 0 build errors and all GUI tests pass.