### PR TITLE
[codex] Integrate Mesa Giratoria PLC map

### DIFF
--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -33,7 +33,9 @@
       "IpAddress": "192.168.0.10",
       "Rack": 0,
       "Slot": 1,
-      "DbNumber": 1,
+      "DbNumber": 150,
+      "PlcToPcDbNumber": 151,
+      "DiagnosticDbNumber": 8,
       "PollIntervalMs": 100
     },
     "Camera": {

--- a/docs/COMMS.md
+++ b/docs/COMMS.md
@@ -2,6 +2,12 @@
 
 The GUI owns the production-cell communication layer. It can run without hardware by using simulation modes, and it is prepared for a Siemens S7-1200 PLC plus one industrial camera provider.
 
+The PLC contract follows the `Mesa_Giratoria` project used as reference:
+
+- `DB150` / `PC_PLC`: commands and state written by the GUI to the PLC.
+- `DB151` / `PLC_PC`: state, handshake, and camera result bits read by the GUI from the PLC.
+- `DB8` / `DB_Diag_AutoCam1_360`: diagnostic DB reserved for AutoCam1 360 troubleshooting.
+
 ## PLC
 
 Supported modes:
@@ -17,27 +23,60 @@ Default PLC settings live in `gui/BrakeDiscInspector_GUI_ROI/appsettings.json` a
     "IpAddress": "192.168.0.10",
     "Rack": 0,
     "Slot": 1,
-    "DbNumber": 1,
+    "DbNumber": 150,
+    "PlcToPcDbNumber": 151,
+    "DiagnosticDbNumber": 8,
     "PollIntervalMs": 100
   }
 }
 ```
 
-PLC DB bit map:
+`DbNumber` is kept for backward compatibility and means the PC-to-PLC DB. In the Mesa Giratoria layout that is `DB150`.
 
-| Signal | Direction | DB byte.bit |
+PLC-to-GUI status map (`DB151`):
+
+| Signal | DB byte.bit | Notes |
 |---|---|---|
-| Start inspection | PLC to GUI | DBX0.0 |
-| Stop inspection | PLC to GUI | DBX0.1 |
-| Part present | PLC to GUI | DBX0.2 |
-| Reset error | PLC to GUI | DBX0.3 |
-| System ready | GUI to PLC | DBX2.0 |
-| Busy | GUI to PLC | DBX2.1 |
-| Result OK | GUI to PLC | DBX2.2 |
-| Result NG | GUI to PLC | DBX2.3 |
-| Error | GUI to PLC | DBX2.4 |
+| PLC ready / part present | DBX0.0 | Used by `RequirePartPresent`. |
+| PLC alarm | DBX0.1 | PLC alarm state. |
+| Rotating | DBX0.2 | Rotary axis in motion. |
+| Gripper open | DBX0.3 | Gripper open feedback. |
+| Gripper closed | DBX0.4 | Gripper closed feedback. |
+| Reset from PLC | DBX0.5 | Clears GUI alarm output. |
+| Abort from PLC | DBX0.6 | Cancels the current acquisition cycle. |
+| Legacy capture 1 | DBX0.7 | Also accepted as a start edge for compatibility. |
+| Start inspection / TriggerAck Cam1 | DBX1.0 | Main rising edge used to acquire an image. |
+| PLC inspection complete Cam1 | DBX1.1 | Mesa Giratoria camera completion feedback. |
+| PLC OK Cam1 | DBX1.2 | PLC-side camera result. |
+| PLC NG Cam1 | DBX1.3 | PLC-side camera result. |
+| Data saved | DBX1.4 | Mesa Giratoria saved-data flag. |
+| Manual / auto | DBX1.5 | PLC mode feedback. |
+| AutoCam1 active | DBX1.6 | AutoCam1 360 sequence active. |
+| AutoCam1 error | DBX1.7 | AutoCam1 360 sequence error. |
 
-The GUI detects a rising edge on `Start inspection`. If `RequirePartPresent` is enabled, `Part present` must also be true.
+GUI-to-PLC command map (`DB150`):
+
+| Signal | DB byte.bit | Notes |
+|---|---|---|
+| App ready (`EstadoAPP`) | DBX0.0 | Set when the GUI connects. |
+| App alarm | DBX0.1 | Set when the GUI cycle fails. |
+| App busy / `Estado` | DBX0.2 | Set while acquisition or inspection is running. |
+| Open gripper | DBX0.3 | Manual gripper command. |
+| Close gripper | DBX0.4 | Manual gripper command. |
+| New position | DBX0.5 | Manual position command. |
+| Reset command | DBX0.6 | Reset command to PLC. |
+| Abort command | DBX0.7 | Abort command to PLC. |
+| Trigger 1 | DBX1.0 | Mesa Giratoria trigger bit. |
+| BDI inspection complete (`Trigger2`) | DBX1.1 | Written when BDI finishes evaluating the image. |
+| BDI result OK (`Trigger3`) | DBX1.2 | Written when BDI result is OK. |
+| Rotate command | DBX1.3 | Mesa Giratoria rotate command. |
+| Manual / auto command | DBX1.4 | Mesa Giratoria mode command. |
+| AutoCam1 360 start (`RESERVA2`) | DBX1.5 | Pulsed for 150 ms by the AutoCam1 button. |
+| BDI result NG (`RESERVA3`) | DBX1.6 | Written when BDI result is NG. |
+
+The GUI detects a rising edge on `Start inspection / TriggerAck Cam1`, with `Legacy capture 1` accepted as a compatibility start edge. If `RequirePartPresent` is enabled, `PLC ready / part present` must also be true.
+
+The S7 client writes only the first two boolean bytes of `DB150` for the command map. It does not write the Mesa Giratoria `GiroPinza` DInt at byte 4 or `Velocidad` byte at 8, so motion setpoints remain owned by the PLC/HMI workflow until they are explicitly wired in BDI.
 
 ## Camera
 
@@ -61,11 +100,11 @@ Supported providers:
 
 When `AutoRunInspectionOnTrigger` is true, the cycle is:
 
-1. PLC rising edge: `Start inspection`.
+1. PLC rising edge: `Start inspection / TriggerAck Cam1` or legacy `Captura1`.
 2. GUI writes `Busy=true`, clears result bits.
 3. Camera acquires an image.
 4. GUI loads the image, analyzes masters, and evaluates enabled inspection ROIs.
-5. GUI writes `Busy=false` plus `Result OK` or `Result NG`.
+5. GUI writes `Busy=false`, `BDI inspection complete=true`, plus `BDI result OK` or `BDI result NG`.
 6. On failure, GUI writes `Error=true`.
 
 Real FLIR/Cognex acquisition requires the vendor SDK choice and installed native/.NET assemblies before those providers can replace their placeholders.

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/MesaGiratoriaPlcMapTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/MesaGiratoriaPlcMapTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using BrakeDiscInspector_GUI_ROI.Comms;
+
+public sealed class MesaGiratoriaPlcMapTests
+{
+    [Fact]
+    public void PlcConfig_UsesMesaGiratoriaDefaultDbNumbers()
+    {
+        var config = new PlcConfig("192.168.0.10", 0, 1);
+
+        Assert.Equal(150, config.PcToPlcDbNumber);
+        Assert.Equal(151, config.PlcToPcDbNumber);
+        Assert.Equal(8, config.DiagnosticDbNumber);
+    }
+
+    [Fact]
+    public void Decode_MapsPlcToPcMesaGiratoriaBits()
+    {
+        var plcToPc = new byte[PlcSignals.PlcToPcReadLength];
+        plcToPc[0] = 0b0010_0001;
+        plcToPc[1] = 0b1100_0111;
+
+        var decoded = PlcSignals.Decode(plcToPc);
+
+        Assert.True(decoded[PlcSignalId.PartPresent]);
+        Assert.True(decoded[PlcSignalId.ResetError]);
+        Assert.True(decoded[PlcSignalId.StartInspection]);
+        Assert.True(decoded[PlcSignalId.InspectionCompleteCam1]);
+        Assert.True(decoded[PlcSignalId.PlcReportedOkCam1]);
+        Assert.True(decoded[PlcSignalId.AutoCam1Active]);
+        Assert.True(decoded[PlcSignalId.AutoCam1Error]);
+    }
+
+    [Fact]
+    public void EncodeOutputs_WritesOnlyPcToPlcMesaGiratoriaBoolBytes()
+    {
+        var pcToPlc = new byte[PlcSignals.PcToPlcBoolWriteLength];
+
+        PlcSignals.EncodeOutputs(pcToPlc, new Dictionary<PlcSignalId, bool>
+        {
+            [PlcSignalId.SystemReady] = true,
+            [PlcSignalId.Busy] = true,
+            [PlcSignalId.InspectionComplete] = true,
+            [PlcSignalId.ResultOk] = false,
+            [PlcSignalId.AutoCam1Start] = true,
+            [PlcSignalId.ResultNg] = true
+        });
+
+        Assert.Equal(0b0000_0101, pcToPlc[0]);
+        Assert.Equal(0b0110_0010, pcToPlc[1]);
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
@@ -62,7 +62,9 @@ namespace BrakeDiscInspector_GUI_ROI
             public string IpAddress { get; set; } = "192.168.0.10";
             public short Rack { get; set; } = 0;
             public short Slot { get; set; } = 1;
-            public int DbNumber { get; set; } = 1;
+            public int DbNumber { get; set; } = 150;
+            public int PlcToPcDbNumber { get; set; } = 151;
+            public int DiagnosticDbNumber { get; set; } = 8;
             public int PollIntervalMs { get; set; } = 100;
         }
 
@@ -230,6 +232,16 @@ namespace BrakeDiscInspector_GUI_ROI
                         target.Comms.Plc.DbNumber = source.Comms.Plc.DbNumber;
                     }
 
+                    if (source.Comms.Plc.PlcToPcDbNumber > 0)
+                    {
+                        target.Comms.Plc.PlcToPcDbNumber = source.Comms.Plc.PlcToPcDbNumber;
+                    }
+
+                    if (source.Comms.Plc.DiagnosticDbNumber > 0)
+                    {
+                        target.Comms.Plc.DiagnosticDbNumber = source.Comms.Plc.DiagnosticDbNumber;
+                    }
+
                     if (source.Comms.Plc.PollIntervalMs > 0)
                     {
                         target.Comms.Plc.PollIntervalMs = source.Comms.Plc.PollIntervalMs;
@@ -289,6 +301,8 @@ namespace BrakeDiscInspector_GUI_ROI
             OverrideInt("BDI_PLC_RACK", value => config.Comms.Plc.Rack = (short)value);
             OverrideInt("BDI_PLC_SLOT", value => config.Comms.Plc.Slot = (short)value);
             OverrideInt("BDI_PLC_DB", value => config.Comms.Plc.DbNumber = Math.Max(1, value));
+            OverrideInt("BDI_PLC_TO_PC_DB", value => config.Comms.Plc.PlcToPcDbNumber = Math.Max(1, value));
+            OverrideInt("BDI_PLC_DIAG_DB", value => config.Comms.Plc.DiagnosticDbNumber = Math.Max(1, value));
             OverrideInt("BDI_PLC_POLL_MS", value => config.Comms.Plc.PollIntervalMs = Math.Max(50, value));
             OverrideString("BDI_CAMERA_PROVIDER", value => config.Comms.Camera.Provider = value);
             OverrideString("BDI_CAMERA_SOURCE", value => config.Comms.Camera.Source = value);

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
@@ -73,6 +73,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         private short _rack;
         private short _slot;
         private int _dbNumber;
+        private int _plcToPcDbNumber;
+        private int _diagnosticDbNumber;
         private string _plcMode;
         private string _connectionStatus = "Disconnected";
         private string _cameraProvider;
@@ -113,6 +115,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             _rack = config.Rack;
             _slot = config.Slot;
             _dbNumber = config.DbNumber;
+            _plcToPcDbNumber = config.PlcToPcDbNumber;
+            _diagnosticDbNumber = config.DiagnosticDbNumber;
             _plcMode = _clientMode;
             _cameraProvider = cameraConfig?.Provider ?? BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled;
             _cameraSource = cameraConfig?.Source ?? string.Empty;
@@ -139,6 +143,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             DisconnectCommand = new AsyncCommand(_ => DisconnectAsync());
             ToggleOutputCommand = new AsyncCommand(param => ToggleOutputAsync(param));
             ToggleInputCommand = new AsyncCommand(param => ToggleInputAsync(param));
+            StartAutoCam1Command = new AsyncCommand(_ => PulseAutoCam1StartAsync());
             ConnectCameraCommand = new AsyncCommand(_ => ConnectCameraAsync());
             DisconnectCameraCommand = new AsyncCommand(_ => DisconnectCameraAsync());
             AcquireImageCommand = new AsyncCommand(_ => AcquireImageCycleAsync("manual"));
@@ -215,6 +220,34 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 if (_dbNumber != normalized)
                 {
                     _dbNumber = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int PlcToPcDbNumber
+        {
+            get => _plcToPcDbNumber;
+            set
+            {
+                var normalized = Math.Max(1, value);
+                if (_plcToPcDbNumber != normalized)
+                {
+                    _plcToPcDbNumber = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int DiagnosticDbNumber
+        {
+            get => _diagnosticDbNumber;
+            set
+            {
+                var normalized = Math.Max(1, value);
+                if (_diagnosticDbNumber != normalized)
+                {
+                    _diagnosticDbNumber = normalized;
                     OnPropertyChanged();
                 }
             }
@@ -345,6 +378,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
         public AsyncCommand ToggleInputCommand { get; }
 
+        public AsyncCommand StartAutoCam1Command { get; }
+
         public AsyncCommand ConnectCameraCommand { get; }
 
         public AsyncCommand DisconnectCameraCommand { get; }
@@ -449,6 +484,28 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             return Task.CompletedTask;
         }
 
+        private async Task PulseAutoCam1StartAsync()
+        {
+            if (!_client.IsConnected)
+            {
+                CycleStatus = "AutoCam1 start ignored: PLC disconnected";
+                return;
+            }
+
+            CycleStatus = "AutoCam1 360 start pulse";
+            await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+            {
+                [PlcSignalId.AutoCam1Start] = true
+            }).ConfigureAwait(false);
+
+            await Task.Delay(150).ConfigureAwait(false);
+
+            await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+            {
+                [PlcSignalId.AutoCam1Start] = false
+            }).ConfigureAwait(false);
+        }
+
         public async Task ConnectCameraAsync()
         {
             EnsureCameraMatchesConfig();
@@ -524,6 +581,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             {
                 [PlcSignalId.Busy] = true,
                 [PlcSignalId.Error] = false,
+                [PlcSignalId.InspectionComplete] = false,
                 [PlcSignalId.ResultOk] = false,
                 [PlcSignalId.ResultNg] = false
             };
@@ -536,6 +594,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             var payload = new Dictionary<PlcSignalId, bool>
             {
                 [PlcSignalId.Busy] = false,
+                [PlcSignalId.InspectionComplete] = true,
                 [PlcSignalId.ResultOk] = ok,
                 [PlcSignalId.ResultNg] = !ok
             };
@@ -645,6 +704,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         {
             var startNow = values.TryGetValue(PlcSignalId.StartInspection, out var start) && start;
             var startWas = _lastSignals.TryGetValue(PlcSignalId.StartInspection, out var previousStart) && previousStart;
+            var legacyStartNow = values.TryGetValue(PlcSignalId.LegacyCapture1, out var legacyStart) && legacyStart;
+            var legacyStartWas = _lastSignals.TryGetValue(PlcSignalId.LegacyCapture1, out var previousLegacyStart) && previousLegacyStart;
             var stopNow = values.TryGetValue(PlcSignalId.StopInspection, out var stop) && stop;
             var stopWas = _lastSignals.TryGetValue(PlcSignalId.StopInspection, out var previousStop) && previousStop;
             var partPresent = values.TryGetValue(PlcSignalId.PartPresent, out var present) && present;
@@ -665,7 +726,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 CancelCycle("plc-stop");
             }
 
-            if (!startNow || startWas)
+            if ((!startNow || startWas) && (!legacyStartNow || legacyStartWas))
             {
                 return;
             }
@@ -801,12 +862,14 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         private void EnsureClientMatchesConfig()
         {
             var desiredMode = NormalizePlcMode(PlcMode);
-            var desired = new PlcConfig(PlcIpAddress, Rack, Slot, DbNumber);
+            var desired = new PlcConfig(PlcIpAddress, Rack, Slot, DbNumber, PlcToPcDbNumber, DiagnosticDbNumber);
 
             if (_client.Config.IpAddress == desired.IpAddress &&
                 _client.Config.Rack == desired.Rack &&
                 _client.Config.Slot == desired.Slot &&
                 _client.Config.DbNumber == desired.DbNumber &&
+                _client.Config.PlcToPcDbNumber == desired.PlcToPcDbNumber &&
+                _client.Config.DiagnosticDbNumber == desired.DiagnosticDbNumber &&
                 string.Equals(_clientMode, desiredMode, StringComparison.OrdinalIgnoreCase))
             {
                 return;

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/IPlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/IPlcClient.cs
@@ -7,12 +7,20 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 {
     public sealed class PlcConfig
     {
-        public PlcConfig(string ipAddress, short rack, short slot, int dbNumber = 1)
+        public PlcConfig(
+            string ipAddress,
+            short rack,
+            short slot,
+            int dbNumber = PlcSignals.DefaultPcToPlcDbNumber,
+            int plcToPcDbNumber = PlcSignals.DefaultPlcToPcDbNumber,
+            int diagnosticDbNumber = PlcSignals.DefaultDiagnosticDbNumber)
         {
             IpAddress = ipAddress;
             Rack = rack;
             Slot = slot;
-            DbNumber = dbNumber > 0 ? dbNumber : 1;
+            DbNumber = NormalizeDbNumber(dbNumber, PlcSignals.DefaultPcToPlcDbNumber);
+            PlcToPcDbNumber = NormalizeDbNumber(plcToPcDbNumber, PlcSignals.DefaultPlcToPcDbNumber);
+            DiagnosticDbNumber = NormalizeDbNumber(diagnosticDbNumber, PlcSignals.DefaultDiagnosticDbNumber);
         }
 
         public string IpAddress { get; }
@@ -21,7 +29,16 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
         public short Slot { get; }
 
+        public int PcToPlcDbNumber => DbNumber;
+
         public int DbNumber { get; }
+
+        public int PlcToPcDbNumber { get; }
+
+        public int DiagnosticDbNumber { get; }
+
+        private static int NormalizeDbNumber(int value, int fallback)
+            => value > 0 ? value : fallback;
     }
 
     public interface IPlcClient : IDisposable

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/PlcDefinitions.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/PlcDefinitions.cs
@@ -1,7 +1,14 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BrakeDiscInspector_GUI_ROI.Comms
 {
+    public enum PlcDbRole
+    {
+        PcToPlc,
+        PlcToPc
+    }
+
     public enum PlcSignalDirection
     {
         Input,
@@ -18,16 +25,45 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         Busy,
         ResultOk,
         ResultNg,
-        Error
+        Error,
+        PlcAlarm,
+        Rotating,
+        GripperOpen,
+        GripperClosed,
+        LegacyCapture1,
+        InspectionCompleteCam1,
+        PlcReportedOkCam1,
+        PlcReportedNgCam1,
+        DataSaved,
+        ManualAuto,
+        AutoCam1Active,
+        AutoCam1Error,
+        OpenGripper,
+        CloseGripper,
+        NewPosition,
+        ResetCommand,
+        AbortCommand,
+        Trigger1,
+        InspectionComplete,
+        RotateCommand,
+        ManualAutoCommand,
+        AutoCam1Start
     }
 
     public sealed class PlcSignalDefinition
     {
-        public PlcSignalDefinition(PlcSignalId id, string displayName, PlcSignalDirection direction, int byteOffset, int bitOffset)
+        public PlcSignalDefinition(
+            PlcSignalId id,
+            string displayName,
+            PlcSignalDirection direction,
+            PlcDbRole dbRole,
+            int byteOffset,
+            int bitOffset)
         {
             Id = id;
             DisplayName = displayName;
             Direction = direction;
+            DbRole = dbRole;
             ByteOffset = byteOffset;
             BitOffset = bitOffset;
         }
@@ -38,6 +74,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
         public PlcSignalDirection Direction { get; }
 
+        public PlcDbRole DbRole { get; }
+
         public int ByteOffset { get; }
 
         public int BitOffset { get; }
@@ -45,20 +83,121 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
     public static class PlcSignals
     {
-        public const int DefaultDbNumber = 1;
+        public const int DefaultPcToPlcDbNumber = 150;
+        public const int DefaultPlcToPcDbNumber = 151;
+        public const int DefaultDiagnosticDbNumber = 8;
+        public const int PlcToPcReadLength = 9;
+        public const int PcToPlcBoolWriteLength = 2;
+
+        public const int DefaultDbNumber = DefaultPcToPlcDbNumber;
 
         public static readonly IReadOnlyList<PlcSignalDefinition> Definitions = new[]
         {
-            new PlcSignalDefinition(PlcSignalId.StartInspection, "Start inspection", PlcSignalDirection.Input, 0, 0),
-            new PlcSignalDefinition(PlcSignalId.StopInspection, "Stop inspection", PlcSignalDirection.Input, 0, 1),
-            new PlcSignalDefinition(PlcSignalId.PartPresent, "Part present", PlcSignalDirection.Input, 0, 2),
-            new PlcSignalDefinition(PlcSignalId.ResetError, "Reset error", PlcSignalDirection.Input, 0, 3),
+            new PlcSignalDefinition(PlcSignalId.PartPresent, "PLC ready / part present", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 0),
+            new PlcSignalDefinition(PlcSignalId.PlcAlarm, "PLC alarm", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 1),
+            new PlcSignalDefinition(PlcSignalId.Rotating, "Rotating", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 2),
+            new PlcSignalDefinition(PlcSignalId.GripperOpen, "Gripper open", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 3),
+            new PlcSignalDefinition(PlcSignalId.GripperClosed, "Gripper closed", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 4),
+            new PlcSignalDefinition(PlcSignalId.ResetError, "Reset from PLC", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 5),
+            new PlcSignalDefinition(PlcSignalId.StopInspection, "Abort from PLC", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 6),
+            new PlcSignalDefinition(PlcSignalId.LegacyCapture1, "Legacy capture 1", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 0, 7),
 
-            new PlcSignalDefinition(PlcSignalId.SystemReady, "System ready", PlcSignalDirection.Output, 2, 0),
-            new PlcSignalDefinition(PlcSignalId.Busy, "Busy", PlcSignalDirection.Output, 2, 1),
-            new PlcSignalDefinition(PlcSignalId.ResultOk, "Result OK", PlcSignalDirection.Output, 2, 2),
-            new PlcSignalDefinition(PlcSignalId.ResultNg, "Result NG", PlcSignalDirection.Output, 2, 3),
-            new PlcSignalDefinition(PlcSignalId.Error, "Error", PlcSignalDirection.Output, 2, 4)
+            new PlcSignalDefinition(PlcSignalId.StartInspection, "Start inspection / TriggerAck Cam1", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 0),
+            new PlcSignalDefinition(PlcSignalId.InspectionCompleteCam1, "PLC inspection complete Cam1", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 1),
+            new PlcSignalDefinition(PlcSignalId.PlcReportedOkCam1, "PLC OK Cam1", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 2),
+            new PlcSignalDefinition(PlcSignalId.PlcReportedNgCam1, "PLC NG Cam1", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 3),
+            new PlcSignalDefinition(PlcSignalId.DataSaved, "Data saved", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 4),
+            new PlcSignalDefinition(PlcSignalId.ManualAuto, "Manual / auto", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 5),
+            new PlcSignalDefinition(PlcSignalId.AutoCam1Active, "AutoCam1 active", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 6),
+            new PlcSignalDefinition(PlcSignalId.AutoCam1Error, "AutoCam1 error", PlcSignalDirection.Input, PlcDbRole.PlcToPc, 1, 7),
+
+            new PlcSignalDefinition(PlcSignalId.SystemReady, "App ready (EstadoAPP)", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 0),
+            new PlcSignalDefinition(PlcSignalId.Error, "App alarm", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 1),
+            new PlcSignalDefinition(PlcSignalId.Busy, "App busy / Estado", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 2),
+            new PlcSignalDefinition(PlcSignalId.OpenGripper, "Open gripper", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 3),
+            new PlcSignalDefinition(PlcSignalId.CloseGripper, "Close gripper", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 4),
+            new PlcSignalDefinition(PlcSignalId.NewPosition, "New position", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 5),
+            new PlcSignalDefinition(PlcSignalId.ResetCommand, "Reset command", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 6),
+            new PlcSignalDefinition(PlcSignalId.AbortCommand, "Abort command", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 0, 7),
+
+            new PlcSignalDefinition(PlcSignalId.Trigger1, "Trigger 1", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 0),
+            new PlcSignalDefinition(PlcSignalId.InspectionComplete, "BDI inspection complete (Trigger2)", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 1),
+            new PlcSignalDefinition(PlcSignalId.ResultOk, "BDI result OK (Trigger3)", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 2),
+            new PlcSignalDefinition(PlcSignalId.RotateCommand, "Rotate command", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 3),
+            new PlcSignalDefinition(PlcSignalId.ManualAutoCommand, "Manual / auto command", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 4),
+            new PlcSignalDefinition(PlcSignalId.AutoCam1Start, "AutoCam1 360 start", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 5),
+            new PlcSignalDefinition(PlcSignalId.ResultNg, "BDI result NG (Reserva3)", PlcSignalDirection.Output, PlcDbRole.PcToPlc, 1, 6)
         };
+
+        public static IDictionary<PlcSignalId, bool> Decode(
+            IReadOnlyList<byte> plcToPcBytes,
+            IReadOnlyList<byte>? pcToPlcBytes = null)
+        {
+            var result = new Dictionary<PlcSignalId, bool>();
+
+            foreach (var definition in Definitions)
+            {
+                IReadOnlyList<byte>? source = definition.DbRole == PlcDbRole.PlcToPc
+                    ? plcToPcBytes
+                    : definition.DbRole == PlcDbRole.PcToPlc
+                        ? pcToPlcBytes
+                        : null;
+
+                if (source == null)
+                {
+                    continue;
+                }
+
+                result[definition.Id] = GetBit(source, definition.ByteOffset, definition.BitOffset);
+            }
+
+            return result;
+        }
+
+        public static void EncodeOutputs(IList<byte> pcToPlcBytes, IDictionary<PlcSignalId, bool> outputs)
+        {
+            if (outputs == null || outputs.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var kvp in outputs)
+            {
+                var definition = Definitions.FirstOrDefault(d => d.Id == kvp.Key && d.Direction == PlcSignalDirection.Output);
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                SetBit(pcToPlcBytes, definition.ByteOffset, definition.BitOffset, kvp.Value);
+            }
+        }
+
+        public static bool GetBit(IReadOnlyList<byte> buffer, int byteIndex, int bitIndex)
+        {
+            if (byteIndex < 0 || bitIndex < 0 || bitIndex > 7 || byteIndex >= buffer.Count)
+            {
+                return false;
+            }
+
+            return (buffer[byteIndex] & (1 << bitIndex)) != 0;
+        }
+
+        public static void SetBit(IList<byte> buffer, int byteIndex, int bitIndex, bool value)
+        {
+            if (byteIndex < 0 || bitIndex < 0 || bitIndex > 7 || byteIndex >= buffer.Count)
+            {
+                return;
+            }
+
+            if (value)
+            {
+                buffer[byteIndex] = (byte)(buffer[byteIndex] | (1 << bitIndex));
+            }
+            else
+            {
+                buffer[byteIndex] = (byte)(buffer[byteIndex] & ~(1 << bitIndex));
+            }
+        }
     }
 }

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BrakeDiscInspector_GUI_ROI.Util;
@@ -42,7 +41,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                     try
                     {
                         _plc.Open();
-                        GuiLog.Info($"[plc] Connected to {Config.IpAddress} rack={Config.Rack} slot={Config.Slot} db={Config.DbNumber}");
+                        GuiLog.Info($"[plc] Connected to {Config.IpAddress} rack={Config.Rack} slot={Config.Slot} pc_to_plc_db={Config.PcToPlcDbNumber} plc_to_pc_db={Config.PlcToPcDbNumber} diag_db={Config.DiagnosticDbNumber}");
                     }
                     catch (Exception ex)
                     {
@@ -84,22 +83,17 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 ct.ThrowIfCancellationRequested();
                 EnsureConnected();
 
-                byte[] buffer;
+                byte[] plcToPcBytes;
+                byte[] pcToPlcBytes;
                 lock (_sync)
                 {
-                    buffer = _plc.ReadBytes(DataType.DataBlock, Config.DbNumber, 0, 4) ?? Array.Empty<byte>();
+                    plcToPcBytes = _plc.ReadBytes(DataType.DataBlock, Config.PlcToPcDbNumber, 0, PlcSignals.PlcToPcReadLength) ?? Array.Empty<byte>();
+                    pcToPlcBytes = _plc.ReadBytes(DataType.DataBlock, Config.PcToPlcDbNumber, 0, PlcSignals.PcToPlcBoolWriteLength) ?? Array.Empty<byte>();
                 }
 
-                var data = buffer.Length >= 4 ? buffer : buffer.Concat(new byte[4 - buffer.Length]).ToArray();
-                var result = new Dictionary<PlcSignalId, bool>();
-
-                foreach (var signal in PlcSignals.Definitions)
-                {
-                    var bit = GetBit(data, signal.ByteOffset, signal.BitOffset);
-                    result[signal.Id] = bit;
-                }
-
-                return (IDictionary<PlcSignalId, bool>)result;
+                return PlcSignals.Decode(
+                    EnsureLength(plcToPcBytes, PlcSignals.PlcToPcReadLength),
+                    EnsureLength(pcToPlcBytes, PlcSignals.PcToPlcBoolWriteLength));
             }, ct);
         }
 
@@ -118,28 +112,19 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 byte[] buffer;
                 lock (_sync)
                 {
-                    buffer = _plc.ReadBytes(DataType.DataBlock, Config.DbNumber, 0, 4) ?? new byte[4];
+                    buffer = _plc.ReadBytes(DataType.DataBlock, Config.PcToPlcDbNumber, 0, PlcSignals.PcToPlcBoolWriteLength) ?? new byte[PlcSignals.PcToPlcBoolWriteLength];
                 }
 
-                if (buffer.Length < 4)
+                if (buffer.Length < PlcSignals.PcToPlcBoolWriteLength)
                 {
-                    Array.Resize(ref buffer, 4);
+                    Array.Resize(ref buffer, PlcSignals.PcToPlcBoolWriteLength);
                 }
 
-                foreach (var kvp in outputs)
-                {
-                    var definition = PlcSignals.Definitions.FirstOrDefault(d => d.Id == kvp.Key && d.Direction == PlcSignalDirection.Output);
-                    if (definition == null)
-                    {
-                        continue;
-                    }
-
-                    SetBit(buffer, definition.ByteOffset, definition.BitOffset, kvp.Value);
-                }
+                PlcSignals.EncodeOutputs(buffer, outputs);
 
                 lock (_sync)
                 {
-                    _plc.WriteBytes(DataType.DataBlock, Config.DbNumber, 0, buffer);
+                    _plc.WriteBytes(DataType.DataBlock, Config.PcToPlcDbNumber, 0, buffer);
                 }
             }, ct);
         }
@@ -170,36 +155,15 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
         }
 
-        private static bool GetBit(IReadOnlyList<byte> buffer, int byteIndex, int bitIndex)
+        private static byte[] EnsureLength(byte[] buffer, int length)
         {
-            if (byteIndex < 0 || bitIndex < 0 || bitIndex > 7 || byteIndex >= buffer.Count)
+            if (buffer.Length >= length)
             {
-                return false;
+                return buffer;
             }
 
-            return (buffer[byteIndex] & (1 << bitIndex)) != 0;
-        }
-
-        private static void SetBit(IList<byte> buffer, int byteIndex, int bitIndex, bool value)
-        {
-            if (byteIndex < 0 || bitIndex < 0 || bitIndex > 7)
-            {
-                return;
-            }
-
-            if (byteIndex >= buffer.Count)
-            {
-                return;
-            }
-
-            if (value)
-            {
-                buffer[byteIndex] = (byte)(buffer[byteIndex] | (1 << bitIndex));
-            }
-            else
-            {
-                buffer[byteIndex] = (byte)(buffer[byteIndex] & ~(1 << bitIndex));
-            }
+            Array.Resize(ref buffer, length);
+            return buffer;
         }
 
         private void EnsureConnected()

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/SimulatedPlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/SimulatedPlcClient.cs
@@ -48,7 +48,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 _signals[PlcSignalId.SystemReady] = true;
             }
 
-            GuiLog.Info($"[plc-sim] Connected db={Config.DbNumber}");
+            GuiLog.Info($"[plc-sim] Connected pc_to_plc_db={Config.PcToPlcDbNumber} plc_to_pc_db={Config.PlcToPcDbNumber} diag_db={Config.DiagnosticDbNumber}");
             return Task.CompletedTask;
         }
 

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
@@ -26,7 +26,9 @@ namespace BrakeDiscInspector_GUI_ROI
                     plcSettings.IpAddress,
                     plcSettings.Rack,
                     plcSettings.Slot,
-                    plcSettings.DbNumber);
+                    plcSettings.DbNumber,
+                    plcSettings.PlcToPcDbNumber,
+                    plcSettings.DiagnosticDbNumber);
                 var cameraConfig = new CameraConfig(
                     cameraSettings.Provider,
                     cameraSettings.Source,

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1943,9 +1943,17 @@
                         <TextBox Width="40"
                                  Text="{Binding Slot, UpdateSourceTrigger=PropertyChanged}"/>
 
-                        <TextBlock Text="DB:" VerticalAlignment="Center" Margin="8,0,4,0"/>
-                        <TextBox Width="44"
+                        <TextBlock Text="PC-&gt;PLC DB:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                        <TextBox Width="48"
                                  Text="{Binding DbNumber, UpdateSourceTrigger=PropertyChanged}"/>
+
+                        <TextBlock Text="PLC-&gt;PC DB:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                        <TextBox Width="48"
+                                 Text="{Binding PlcToPcDbNumber, UpdateSourceTrigger=PropertyChanged}"/>
+
+                        <TextBlock Text="Diag DB:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                        <TextBox Width="48"
+                                 Text="{Binding DiagnosticDbNumber, UpdateSourceTrigger=PropertyChanged}"/>
 
                         <ui:Button Margin="12,0,0,0"
                                    Padding="10,3"
@@ -1968,6 +1976,15 @@
                         <TextBlock Margin="12,0,0,0"
                                    VerticalAlignment="Center"
                                    Text="{Binding ConnectionStatus}"/>
+
+                        <ui:Button Margin="12,0,0,0"
+                                   Padding="10,3"
+                                   Command="{Binding StartAutoCam1Command}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Record24}" Margin="0,0,8,0" FontSize="16"/>
+                                <TextBlock Text="AutoCam1 360" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
                     </WrapPanel>
 
                     <Grid Grid.Row="1">
@@ -2111,7 +2128,8 @@
                                                      Fill="{Binding IsOn, Converter={StaticResource BoolToBrush}}"/>
                                             <TextBlock Text="{Binding DisplayName}"
                                                        VerticalAlignment="Center"
-                                                       Width="140"/>
+                                                       Width="220"
+                                                       TextWrapping="Wrap"/>
                                             <ui:Button Margin="8,0,0,0"
                                                        Padding="6,2"
                                                        Command="{Binding DataContext.ToggleInputCommand, RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}}"
@@ -2137,7 +2155,8 @@
                                                      Fill="{Binding IsOn, Converter={StaticResource BoolToBrush}}"/>
                                             <TextBlock Text="{Binding DisplayName}"
                                                        VerticalAlignment="Center"
-                                                       Width="140"/>
+                                                       Width="220"
+                                                       TextWrapping="Wrap"/>
                                             <ui:Button Margin="8,0,0,0"
                                                        Padding="6,2"
                                                        Command="{Binding DataContext.ToggleOutputCommand, RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}}"

--- a/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
+++ b/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
@@ -34,7 +34,9 @@
       "IpAddress": "192.168.0.10",
       "Rack": 0,
       "Slot": 1,
-      "DbNumber": 1,
+      "DbNumber": 150,
+      "PlcToPcDbNumber": 151,
+      "DiagnosticDbNumber": 8,
       "PollIntervalMs": 100
     },
     "Camera": {


### PR DESCRIPTION
## Summary
- Adopts the Mesa_Giratoria PLC DB contract in the GUI comms layer: DB150 for PC_PLC commands, DB151 for PLC_PC status, and DB8 reserved for AutoCam1 diagnostics.
- Expands the PLC signal map, keeps simulation support, and updates the S7 client to read DB151 while reflecting/writing the DB150 boolean command bytes safely.
- Adds an AutoCam1 360 start pulse command, updates config/docs, and adds unit tests for the DB bit mapping.

## Notes
- This PR is stacked on `codex/update-gui-workflow-and-docs` so the diff stays focused on the communications change.
- FLIR Blackfly and Cognex providers still fail fast until the selected vendor SDK/protocol adapter is installed and wired.

## Validation
- `dotnet build gui\BrakeDiscInspector_GUI_ROI\BrakeDiscInspector_GUI_ROI.csproj -v:minimal`
- `dotnet test gui\BrakeDiscInspector_GUI_ROI.Tests\BrakeDiscInspector_GUI_ROI.Tests.csproj -v:minimal`