### PR TITLE
[codex] Add comms persistence and manual PLC camera trigger

### DIFF
--- a/config/appsettings.json
+++ b/config/appsettings.json
@@ -30,7 +30,7 @@
     "RequirePartPresent": true,
     "Plc": {
       "Mode": "Simulation",
-      "IpAddress": "192.168.0.10",
+      "IpAddress": "192.168.0.1",
       "Rack": 0,
       "Slot": 1,
       "DbNumber": 150,

--- a/docs/COMMS.md
+++ b/docs/COMMS.md
@@ -20,7 +20,7 @@ Default PLC settings live in `gui/BrakeDiscInspector_GUI_ROI/appsettings.json` a
 "Comms": {
   "Plc": {
     "Mode": "Simulation",
-    "IpAddress": "192.168.0.10",
+    "IpAddress": "192.168.0.1",
     "Rack": 0,
     "Slot": 1,
     "DbNumber": 150,
@@ -32,6 +32,14 @@ Default PLC settings live in `gui/BrakeDiscInspector_GUI_ROI/appsettings.json` a
 ```
 
 `DbNumber` is kept for backward compatibility and means the PC-to-PLC DB. In the Mesa Giratoria layout that is `DB150`.
+
+The communications panel can edit these PLC fields directly. Use `Save comms` to persist the complete communications settings to:
+
+```text
+%LOCALAPPDATA%\BrakeDiscInspector\appsettings.user.json
+```
+
+That user config is loaded after the packaged `appsettings.json`, so saved IP/DB/camera changes survive Visual Studio rebuilds.
 
 PLC-to-GUI status map (`DB151`):
 

--- a/docs/COMMS.md
+++ b/docs/COMMS.md
@@ -8,6 +8,14 @@ The PLC contract follows the `Mesa_Giratoria` project used as reference:
 - `DB151` / `PLC_PC`: state, handshake, and camera result bits read by the GUI from the PLC.
 - `DB8` / `DB_Diag_AutoCam1_360`: diagnostic DB reserved for AutoCam1 360 troubleshooting.
 
+The FLIR Blackfly S `BFS-PGE-120S4M-CS` is a mono GigE Vision / GenICam camera. It is not treated as a native PROFINET device by the GUI. The intended production topology is:
+
+```text
+BrakeDiscInspector <-> Siemens PLC: S7 over Ethernet / PROFINET network
+BrakeDiscInspector <-> FLIR camera: Spinnaker / GigE Vision
+PLC -> camera trigger: PLC output or PROFINET remote I/O wired to the camera trigger input
+```
+
 ## PLC
 
 Supported modes:
@@ -85,6 +93,8 @@ GUI-to-PLC command map (`DB150`):
 The GUI detects a rising edge on `Start inspection / TriggerAck Cam1`, with `Legacy capture 1` accepted as a compatibility start edge. If `RequirePartPresent` is enabled, `PLC ready / part present` must also be true.
 
 The S7 client writes only the first two boolean bytes of `DB150` for the command map. It does not write the Mesa Giratoria `GiroPinza` DInt at byte 4 or `Velocidad` byte at 8, so motion setpoints remain owned by the PLC/HMI workflow until they are explicitly wired in BDI.
+
+The `PLC trigger` button in the communications panel manually pulses `DB150.DBX1.0` (`Trigger 1`) for 150 ms. The PLC must translate that bit into the camera trigger action.
 
 ## Camera
 

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/AppConfigLoaderTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/AppConfigLoaderTests.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using BrakeDiscInspector_GUI_ROI;
+
+public sealed class AppConfigLoaderTests
+{
+    [Fact]
+    public void Save_WritesCommsSettings()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"bdi-appsettings-{Guid.NewGuid():N}.json");
+        try
+        {
+            var config = new AppConfig();
+            config.Comms.Plc.Mode = "S7";
+            config.Comms.Plc.IpAddress = "192.168.0.1";
+            config.Comms.Plc.DbNumber = 150;
+            config.Comms.Plc.PlcToPcDbNumber = 151;
+            config.Comms.Plc.DiagnosticDbNumber = 8;
+            config.Comms.Plc.PollIntervalMs = 100;
+            config.Comms.AutoConnectOnStartup = true;
+            config.Comms.RequirePartPresent = false;
+            config.Comms.Camera.Provider = "Folder";
+            config.Comms.Camera.Source = @"C:\images";
+
+            AppConfigLoader.Save(config, path);
+
+            using var stream = File.OpenRead(path);
+            var saved = JsonSerializer.Deserialize<AppConfig>(stream);
+
+            Assert.NotNull(saved);
+            Assert.Equal("S7", saved!.Comms.Plc.Mode);
+            Assert.Equal("192.168.0.1", saved.Comms.Plc.IpAddress);
+            Assert.Equal(150, saved.Comms.Plc.DbNumber);
+            Assert.Equal(151, saved.Comms.Plc.PlcToPcDbNumber);
+            Assert.Equal(8, saved.Comms.Plc.DiagnosticDbNumber);
+            Assert.Equal(100, saved.Comms.Plc.PollIntervalMs);
+            Assert.True(saved.Comms.AutoConnectOnStartup);
+            Assert.False(saved.Comms.RequirePartPresent);
+            Assert.Equal("Folder", saved.Comms.Camera.Provider);
+            Assert.Equal(@"C:\images", saved.Comms.Camera.Source);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI.Tests/CommsViewModelTests.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI.Tests/CommsViewModelTests.cs
@@ -1,0 +1,102 @@
+using BrakeDiscInspector_GUI_ROI.Comms;
+
+public sealed class CommsViewModelTests
+{
+    [Fact]
+    public async Task TriggerCameraViaPlcCommand_PulsesTrigger1Output()
+    {
+        var plcConfig = new PlcConfig("192.168.0.1", 0, 1);
+        var cameraConfig = new CameraConfig(CameraProviders.Disabled, string.Empty, string.Empty);
+        var plcClient = new RecordingPlcClient(plcConfig, isConnected: true);
+
+        using var vm = new CommsViewModel(
+            plcConfig,
+            "S7",
+            (_, _) => plcClient,
+            cameraConfig,
+            _ => new NoopCameraClient(cameraConfig),
+            saveSettingsAsync: null,
+            inspectImageAsync: null,
+            pollIntervalMs: 100,
+            requirePartPresent: true,
+            autoConnectOnStartup: false,
+            autoRunInspection: false);
+
+        vm.TriggerCameraViaPlcCommand.Execute(null);
+
+        await WaitForAsync(() => plcClient.WriteHistory.Count >= 2);
+
+        Assert.True(plcClient.WriteHistory[0][PlcSignalId.Trigger1]);
+        Assert.False(plcClient.WriteHistory[1][PlcSignalId.Trigger1]);
+        Assert.Equal("PLC camera trigger pulse", vm.CycleStatus);
+    }
+
+    private static async Task WaitForAsync(Func<bool> predicate)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        while (!predicate())
+        {
+            cts.Token.ThrowIfCancellationRequested();
+            await Task.Delay(25, cts.Token);
+        }
+    }
+
+    private sealed class RecordingPlcClient : IPlcClient
+    {
+        private readonly bool _isConnected;
+
+        public RecordingPlcClient(PlcConfig config, bool isConnected)
+        {
+            Config = config;
+            _isConnected = isConnected;
+        }
+
+        public PlcConfig Config { get; }
+
+        public bool IsConnected => _isConnected;
+
+        public IReadOnlyList<PlcSignalDefinition> SignalDefinitions => PlcSignals.Definitions;
+
+        public List<Dictionary<PlcSignalId, bool>> WriteHistory { get; } = new();
+
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DisconnectAsync() => Task.CompletedTask;
+
+        public Task<IDictionary<PlcSignalId, bool>> ReadAsync(CancellationToken ct = default)
+            => Task.FromResult((IDictionary<PlcSignalId, bool>)new Dictionary<PlcSignalId, bool>());
+
+        public Task WriteOutputsAsync(IDictionary<PlcSignalId, bool> outputs, CancellationToken ct = default)
+        {
+            WriteHistory.Add(new Dictionary<PlcSignalId, bool>(outputs));
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class NoopCameraClient : ICameraClient
+    {
+        public NoopCameraClient(CameraConfig config)
+        {
+            Config = config;
+        }
+
+        public CameraConfig Config { get; }
+
+        public bool IsConnected => false;
+
+        public Task ConnectAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DisconnectAsync() => Task.CompletedTask;
+
+        public Task<CameraFrame> AcquireAsync(CancellationToken ct = default)
+            => throw new InvalidOperationException("Camera acquisition is not used by this test.");
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/AppConfig.cs
@@ -59,7 +59,7 @@ namespace BrakeDiscInspector_GUI_ROI
         public sealed class PlcSettings
         {
             public string Mode { get; set; } = "Simulation";
-            public string IpAddress { get; set; } = "192.168.0.10";
+            public string IpAddress { get; set; } = "192.168.0.1";
             public short Rack { get; set; } = 0;
             public short Slot { get; set; } = 1;
             public int DbNumber { get; set; } = 150;
@@ -79,10 +79,16 @@ namespace BrakeDiscInspector_GUI_ROI
 
     public static class AppConfigLoader
     {
+        public static string UserConfigPath => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "BrakeDiscInspector",
+            "appsettings.user.json");
+
         private static readonly string[] ConfigPaths =
         {
             Path.Combine(AppContext.BaseDirectory, "config", "appsettings.json"),
-            Path.Combine(AppContext.BaseDirectory, "appsettings.json")
+            Path.Combine(AppContext.BaseDirectory, "appsettings.json"),
+            UserConfigPath
         };
 
         public static AppConfig Load()
@@ -116,6 +122,37 @@ namespace BrakeDiscInspector_GUI_ROI
 
             ApplyEnvironmentOverrides(config);
             return config;
+        }
+
+        public static void SaveUserConfig(AppConfig config)
+        {
+            Save(config, UserConfigPath);
+        }
+
+        public static void Save(AppConfig config, string path)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Config path is required.", nameof(path));
+            }
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            File.WriteAllText(path, json);
         }
 
         private static void Merge(AppConfig target, AppConfig source)

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
@@ -182,6 +182,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             SaveSettingsCommand = new AsyncCommand(_ => SaveSettingsCommandAsync());
             ToggleOutputCommand = new AsyncCommand(param => ToggleOutputAsync(param));
             ToggleInputCommand = new AsyncCommand(param => ToggleInputAsync(param));
+            TriggerCameraViaPlcCommand = new AsyncCommand(_ => PulsePlcCameraTriggerAsync());
             StartAutoCam1Command = new AsyncCommand(_ => PulseAutoCam1StartAsync());
             ConnectCameraCommand = new AsyncCommand(_ => ConnectCameraAsync());
             DisconnectCameraCommand = new AsyncCommand(_ => DisconnectCameraAsync());
@@ -472,6 +473,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
         public AsyncCommand ToggleInputCommand { get; }
 
+        public AsyncCommand TriggerCameraViaPlcCommand { get; }
+
         public AsyncCommand StartAutoCam1Command { get; }
 
         public AsyncCommand ConnectCameraCommand { get; }
@@ -605,6 +608,28 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
 
             return Task.CompletedTask;
+        }
+
+        private async Task PulsePlcCameraTriggerAsync()
+        {
+            if (!_client.IsConnected)
+            {
+                CycleStatus = "PLC camera trigger ignored: PLC disconnected";
+                return;
+            }
+
+            CycleStatus = "PLC camera trigger pulse";
+            await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+            {
+                [PlcSignalId.Trigger1] = true
+            }).ConfigureAwait(false);
+
+            await Task.Delay(150).ConfigureAwait(false);
+
+            await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
+            {
+                [PlcSignalId.Trigger1] = false
+            }).ConfigureAwait(false);
         }
 
         private async Task PulseAutoCam1StartAsync()

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
@@ -53,10 +53,42 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         }
     }
 
+    public sealed class CommsSettingsSnapshot
+    {
+        public string PlcMode { get; set; } = "Simulation";
+
+        public string PlcIpAddress { get; set; } = "192.168.0.1";
+
+        public short Rack { get; set; }
+
+        public short Slot { get; set; } = 1;
+
+        public int PcToPlcDbNumber { get; set; } = PlcSignals.DefaultPcToPlcDbNumber;
+
+        public int PlcToPcDbNumber { get; set; } = PlcSignals.DefaultPlcToPcDbNumber;
+
+        public int DiagnosticDbNumber { get; set; } = PlcSignals.DefaultDiagnosticDbNumber;
+
+        public int PollIntervalMs { get; set; } = 100;
+
+        public bool AutoConnectOnStartup { get; set; }
+
+        public bool AutoRunInspection { get; set; }
+
+        public bool RequirePartPresent { get; set; } = true;
+
+        public string CameraProvider { get; set; } = CameraProviders.Disabled;
+
+        public string CameraSource { get; set; } = string.Empty;
+
+        public string CameraOutputDirectory { get; set; } = string.Empty;
+    }
+
     public sealed class CommsViewModel : INotifyPropertyChanged, IDisposable
     {
         private readonly Func<PlcConfig, string, IPlcClient> _clientFactory;
         private readonly Func<CameraConfig, ICameraClient> _cameraFactory;
+        private readonly Func<CommsSettingsSnapshot, CancellationToken, Task>? _saveSettingsAsync;
         private readonly Func<string, CancellationToken, Task<bool?>>? _inspectImageAsync;
         private IPlcClient _client;
         private ICameraClient _camera;
@@ -64,8 +96,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         private readonly SynchronizationContext? _uiContext;
         private CancellationTokenSource? _pollingCts;
         private Task? _pollingTask;
-        private readonly int _pollIntervalMs;
-        private readonly bool _requirePartPresent;
+        private int _pollIntervalMs;
+        private bool _requirePartPresent;
         private readonly object _cycleSync = new();
         private readonly Dictionary<PlcSignalId, bool> _lastSignals = new();
         private CancellationTokenSource? _cycleCts;
@@ -83,6 +115,8 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
         private string _cameraStatus = "Camera disconnected";
         private string _lastAcquiredImagePath = string.Empty;
         private string _cycleStatus = "Idle";
+        private string _settingsStatus = "Comms settings not saved";
+        private bool _autoConnectOnStartup;
         private bool _autoRunInspection;
         private bool _cycleInProgress;
 
@@ -92,9 +126,11 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             Func<PlcConfig, string, IPlcClient> clientFactory,
             CameraConfig cameraConfig,
             Func<CameraConfig, ICameraClient> cameraFactory,
+            Func<CommsSettingsSnapshot, CancellationToken, Task>? saveSettingsAsync,
             Func<string, CancellationToken, Task<bool?>>? inspectImageAsync,
             int pollIntervalMs,
             bool requirePartPresent,
+            bool autoConnectOnStartup,
             bool autoRunInspection)
         {
             if (config == null)
@@ -108,6 +144,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             _clientMode = NormalizePlcMode(plcMode);
             _client = _clientFactory(config, _clientMode);
             _camera = _cameraFactory(cameraConfig ?? new CameraConfig(BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled, string.Empty, string.Empty));
+            _saveSettingsAsync = saveSettingsAsync;
             _uiContext = SynchronizationContext.Current;
             _pollIntervalMs = Math.Max(50, pollIntervalMs);
             _requirePartPresent = requirePartPresent;
@@ -121,6 +158,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             _cameraProvider = cameraConfig?.Provider ?? BrakeDiscInspector_GUI_ROI.Comms.CameraProviders.Disabled;
             _cameraSource = cameraConfig?.Source ?? string.Empty;
             _cameraOutputDirectory = cameraConfig?.OutputDirectory ?? string.Empty;
+            _autoConnectOnStartup = autoConnectOnStartup;
             _autoRunInspection = autoRunInspection;
 
             Inputs = new ObservableCollection<PlcIoPointViewModel>();
@@ -141,6 +179,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
 
             ConnectCommand = new AsyncCommand(_ => ConnectAsync());
             DisconnectCommand = new AsyncCommand(_ => DisconnectAsync());
+            SaveSettingsCommand = new AsyncCommand(_ => SaveSettingsCommandAsync());
             ToggleOutputCommand = new AsyncCommand(param => ToggleOutputAsync(param));
             ToggleInputCommand = new AsyncCommand(param => ToggleInputAsync(param));
             StartAutoCam1Command = new AsyncCommand(_ => PulseAutoCam1StartAsync());
@@ -248,6 +287,46 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 if (_diagnosticDbNumber != normalized)
                 {
                     _diagnosticDbNumber = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public int PollIntervalMs
+        {
+            get => _pollIntervalMs;
+            set
+            {
+                var normalized = Math.Max(50, value);
+                if (_pollIntervalMs != normalized)
+                {
+                    _pollIntervalMs = normalized;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool AutoConnectOnStartup
+        {
+            get => _autoConnectOnStartup;
+            set
+            {
+                if (_autoConnectOnStartup != value)
+                {
+                    _autoConnectOnStartup = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool RequirePartPresent
+        {
+            get => _requirePartPresent;
+            set
+            {
+                if (_requirePartPresent != value)
+                {
+                    _requirePartPresent = value;
                     OnPropertyChanged();
                 }
             }
@@ -370,9 +449,24 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
         }
 
+        public string SettingsStatus
+        {
+            get => _settingsStatus;
+            private set
+            {
+                if (_settingsStatus != value)
+                {
+                    _settingsStatus = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public AsyncCommand ConnectCommand { get; }
 
         public AsyncCommand DisconnectCommand { get; }
+
+        public AsyncCommand SaveSettingsCommand { get; }
 
         public AsyncCommand ToggleOutputCommand { get; }
 
@@ -436,6 +530,28 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             }
 
             ConnectionStatus = "Disconnected";
+        }
+
+        private async Task SaveSettingsCommandAsync()
+        {
+            if (_saveSettingsAsync == null)
+            {
+                SettingsStatus = "Save unavailable";
+                return;
+            }
+
+            try
+            {
+                var snapshot = CreateSettingsSnapshot();
+                await _saveSettingsAsync(snapshot, CancellationToken.None).ConfigureAwait(false);
+                SettingsStatus = $"Saved to {AppConfigLoader.UserConfigPath}";
+                GuiLog.Info($"[comms] Settings saved to '{AppConfigLoader.UserConfigPath}'");
+            }
+            catch (Exception ex)
+            {
+                SettingsStatus = $"Save failed: {ex.Message}";
+                GuiLog.Error("[comms] Save settings failed", ex);
+            }
         }
 
         private Task ToggleOutputAsync(object? parameter)
@@ -640,7 +756,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                         var values = await _client.ReadAsync(token).ConfigureAwait(false);
                         UpdateSignals(values);
                         await HandleInputTransitionsAsync(values, token).ConfigureAwait(false);
-                        await Task.Delay(_pollIntervalMs, token).ConfigureAwait(false);
+                        await Task.Delay(PollIntervalMs, token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -731,7 +847,7 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                 return;
             }
 
-            if (_requirePartPresent && !partPresent)
+            if (RequirePartPresent && !partPresent)
             {
                 CycleStatus = "Start ignored: part not present";
                 GuiLog.Warn("[plc] StartInspection ignored because PartPresent is false");
@@ -880,6 +996,27 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             _clientMode = desiredMode;
             _client = _clientFactory(desired, desiredMode);
             _lastSignals.Clear();
+        }
+
+        private CommsSettingsSnapshot CreateSettingsSnapshot()
+        {
+            return new CommsSettingsSnapshot
+            {
+                PlcMode = PlcMode,
+                PlcIpAddress = PlcIpAddress,
+                Rack = Rack,
+                Slot = Slot,
+                PcToPlcDbNumber = DbNumber,
+                PlcToPcDbNumber = PlcToPcDbNumber,
+                DiagnosticDbNumber = DiagnosticDbNumber,
+                PollIntervalMs = PollIntervalMs,
+                AutoConnectOnStartup = AutoConnectOnStartup,
+                AutoRunInspection = AutoRunInspection,
+                RequirePartPresent = RequirePartPresent,
+                CameraProvider = CameraProvider,
+                CameraSource = CameraSource,
+                CameraOutputDirectory = CameraOutputDirectory
+            };
         }
 
         private void EnsureCameraMatchesConfig()

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/CommsViewModel.cs
@@ -499,6 +499,13 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
             try
             {
                 await _client.ConnectAsync().ConfigureAwait(false);
+                if (!_client.IsConnected)
+                {
+                    ConnectionStatus = $"Disconnected: cannot reach PLC {PlcIpAddress}:102";
+                    GuiLog.Warn($"[plc] Connection unavailable ip={PlcIpAddress} rack={Rack} slot={Slot} port=102");
+                    return;
+                }
+
                 ConnectionStatus = "Connected";
                 await WriteOutputsSafeAsync(new Dictionary<PlcSignalId, bool>
                 {

--- a/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/Comms/S7PlcClient.cs
@@ -46,7 +46,14 @@ namespace BrakeDiscInspector_GUI_ROI.Comms
                     catch (Exception ex)
                     {
                         GuiLog.Error($"[plc] Connect failed to {Config.IpAddress}", ex);
-                        throw;
+                        try
+                        {
+                            _plc.Close();
+                        }
+                        catch
+                        {
+                            // Keep the connection failure non-fatal for the GUI.
+                        }
                     }
                 }
             }, ct);

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.Comms.cs
@@ -41,9 +41,11 @@ namespace BrakeDiscInspector_GUI_ROI
                     CreatePlcClient,
                     cameraConfig,
                     CameraClientFactory.Create,
+                    SaveCommsSettingsAsync,
                     RunCommsInspectionAsync,
                     plcSettings.PollIntervalMs,
                     _appConfig.Comms?.RequirePartPresent ?? true,
+                    _appConfig.Comms?.AutoConnectOnStartup ?? false,
                     _appConfig.Comms?.AutoRunInspectionOnTrigger ?? false);
 
                 CommsRoot.DataContext = _commsVm;
@@ -58,6 +60,35 @@ namespace BrakeDiscInspector_GUI_ROI
             {
                 Util.GuiLog.Error("[comms] InitComms failed", ex);
             }
+        }
+
+        private Task SaveCommsSettingsAsync(CommsSettingsSnapshot settings, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var comms = _appConfig.Comms ??= new AppConfig.CommsConfig();
+            var plc = comms.Plc ??= new AppConfig.PlcSettings();
+            var camera = comms.Camera ??= new AppConfig.CameraSettings();
+
+            comms.AutoConnectOnStartup = settings.AutoConnectOnStartup;
+            comms.AutoRunInspectionOnTrigger = settings.AutoRunInspection;
+            comms.RequirePartPresent = settings.RequirePartPresent;
+
+            plc.Mode = settings.PlcMode;
+            plc.IpAddress = settings.PlcIpAddress;
+            plc.Rack = settings.Rack;
+            plc.Slot = settings.Slot;
+            plc.DbNumber = settings.PcToPlcDbNumber;
+            plc.PlcToPcDbNumber = settings.PlcToPcDbNumber;
+            plc.DiagnosticDbNumber = settings.DiagnosticDbNumber;
+            plc.PollIntervalMs = settings.PollIntervalMs;
+
+            camera.Provider = settings.CameraProvider;
+            camera.Source = settings.CameraSource;
+            camera.OutputDirectory = settings.CameraOutputDirectory;
+
+            AppConfigLoader.SaveUserConfig(_appConfig);
+            return Task.CompletedTask;
         }
 
         private static IPlcClient CreatePlcClient(PlcConfig config, string mode)

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -2002,6 +2002,15 @@
 
                         <ui:Button Margin="12,0,0,0"
                                    Padding="10,3"
+                                   Command="{Binding TriggerCameraViaPlcCommand}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Camera24}" Margin="0,0,8,0" FontSize="16"/>
+                                <TextBlock Text="PLC trigger" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
+
+                        <ui:Button Margin="4,0,0,0"
+                                   Padding="10,3"
                                    Command="{Binding StartAutoCam1Command}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Record24}" Margin="0,0,8,0" FontSize="16"/>

--- a/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
+++ b/gui/BrakeDiscInspector_GUI_ROI/MainWindow.xaml
@@ -1955,6 +1955,20 @@
                         <TextBox Width="48"
                                  Text="{Binding DiagnosticDbNumber, UpdateSourceTrigger=PropertyChanged}"/>
 
+                        <TextBlock Text="Poll ms:" VerticalAlignment="Center" Margin="8,0,4,0"/>
+                        <TextBox Width="56"
+                                 Text="{Binding PollIntervalMs, UpdateSourceTrigger=PropertyChanged}"/>
+
+                        <CheckBox Content="Auto connect"
+                                  Margin="12,0,0,0"
+                                  VerticalAlignment="Center"
+                                  IsChecked="{Binding AutoConnectOnStartup, Mode=TwoWay}"/>
+
+                        <CheckBox Content="Require part"
+                                  Margin="12,0,0,0"
+                                  VerticalAlignment="Center"
+                                  IsChecked="{Binding RequirePartPresent, Mode=TwoWay}"/>
+
                         <ui:Button Margin="12,0,0,0"
                                    Padding="10,3"
                                    Command="{Binding ConnectCommand}">
@@ -1979,12 +1993,28 @@
 
                         <ui:Button Margin="12,0,0,0"
                                    Padding="10,3"
+                                   Command="{Binding SaveSettingsCommand}">
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Save24}" Margin="0,0,8,0" FontSize="16"/>
+                                <TextBlock Text="Save comms" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </ui:Button>
+
+                        <ui:Button Margin="12,0,0,0"
+                                   Padding="10,3"
                                    Command="{Binding StartAutoCam1Command}">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                 <ui:SymbolIcon Symbol="{x:Static ui:SymbolRegular.Record24}" Margin="0,0,8,0" FontSize="16"/>
                                 <TextBlock Text="AutoCam1 360" VerticalAlignment="Center"/>
                             </StackPanel>
                         </ui:Button>
+
+                        <TextBlock Margin="12,0,0,0"
+                                   VerticalAlignment="Center"
+                                   Width="320"
+                                   Text="{Binding SettingsStatus}"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip="{Binding SettingsStatus}"/>
                     </WrapPanel>
 
                     <Grid Grid.Row="1">

--- a/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
+++ b/gui/BrakeDiscInspector_GUI_ROI/appsettings.json
@@ -31,7 +31,7 @@
     "RequirePartPresent": true,
     "Plc": {
       "Mode": "Simulation",
-      "IpAddress": "192.168.0.10",
+      "IpAddress": "192.168.0.1",
       "Rack": 0,
       "Slot": 1,
       "DbNumber": 150,


### PR DESCRIPTION
## Summary
- Persist PLC/camera communications settings in the user config, including editable PLC IP and DB numbers.
- Keep the GUI responsive when the configured S7 PLC is unreachable instead of surfacing an unhandled connection exception.
- Document the FLIR Blackfly S BFS-PGE-120S4M-CS topology as GigE Vision/Spinnaker on the camera side with PLC/S7 used for the PROFINET-side trigger flow.
- Add a manual `PLC trigger` command in Comms that pulses DB150.DBX1.0 (`Trigger 1`) for 150 ms so the PLC can perform the camera shot.

## Validation
- `dotnet build gui\BrakeDiscInspector_GUI_ROI\BrakeDiscInspector_GUI_ROI.csproj -v:minimal`
- `dotnet test gui\BrakeDiscInspector_GUI_ROI.Tests\BrakeDiscInspector_GUI_ROI.Tests.csproj -v:minimal`